### PR TITLE
Remove dependency on PolygonLib and GPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,4 @@ The models are:
 
 ## License
 
-Scenic is distributed under the 3-Clause BSD License. However, it currently uses the [GPC library](http://www.cs.man.ac.uk/~toby/alan/software/) (through the [Polygon3](https://pypi.org/project/Polygon3/) package), which is free only for non-commercial use.
-GPC is used only in the `triangulatePolygon` function in `scenic.core.geometry`, and you can alternatively plug in any algorithm of your choice for triangulation of polygons with holes.
-We plan to replace GPC with a BSD-compatible library in the near future.
+Scenic is distributed under the 3-Clause BSD License.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='scenic',
           'opencv-python',
           'pillow',
           'shapely', # had to separately install via conda install shapely
-          'Polygon3',
+          'pypoly2tri',
       ],
       extras_require={
         'pyproj': ['pyproj'], # issue on Windows with Anaconda

--- a/src/scenic/core/geometry.py
+++ b/src/scenic/core/geometry.py
@@ -8,7 +8,7 @@ import itertools
 import numpy as np
 import shapely.geometry
 import shapely.ops
-import Polygon as PolygonLib	# TODO remove dependency (see triangulatePolygon)
+import pypoly2tri
 
 from scenic.core.distributions import (needsSampling, distributionFunction,
                                        monotonicDistributionFunction)
@@ -172,20 +172,20 @@ def cleanChain(chain, tolerance, angleTolerance=0.008):
 	return newChain
 
 def triangulatePolygon(polygon):
-	# TODO replace with another library!
-	# N.B. can't use shapely.ops.triangulate since it doesn't respect edges
-	poly = PolygonLib.Polygon(polygon.exterior.coords)
-	for interior in polygon.interiors:
-		poly.addContour(interior.coords, True)
-	tristrips = poly.triStrip()
-	triangles = []
-	for strip in tristrips:
-		a, b = strip[:2]
-		for c in strip[2:]:
-			tri = shapely.geometry.Polygon((a, b, c))
-			triangles.append(tri)
-			a = b
-			b = c
+	polyline = []
+	for c in polygon.exterior.coords[:-1]:
+		polyline.append(pypoly2tri.shapes.Point(c[0],c[1]))
+	cdt = pypoly2tri.cdt.CDT(polyline)
+	polyline = []
+	for i in polygon.interiors:
+		for c in i.coords[:-1]:
+			polyline.append(pypoly2tri.shapes.Point(c[0],c[1]))
+		cdt.AddHole(polyline)
+	triangles = list()
+	cdt.Triangulate()
+
+	for t in cdt.GetTriangles():
+		triangles.append(shapely.geometry.Polygon([(t.GetPoint(0).toTuple()), (t.GetPoint(1).toTuple()), (t.GetPoint(2).toTuple())]))
 	return triangles
 
 def plotPolygon(polygon, plt, style='r-'):

--- a/src/scenic/core/geometry.py
+++ b/src/scenic/core/geometry.py
@@ -176,16 +176,20 @@ def triangulatePolygon(polygon):
 	for c in polygon.exterior.coords[:-1]:
 		polyline.append(pypoly2tri.shapes.Point(c[0],c[1]))
 	cdt = pypoly2tri.cdt.CDT(polyline)
-	polyline = []
 	for i in polygon.interiors:
+		polyline = []
 		for c in i.coords[:-1]:
 			polyline.append(pypoly2tri.shapes.Point(c[0],c[1]))
 		cdt.AddHole(polyline)
-	triangles = list()
 	cdt.Triangulate()
 
+	triangles = list()
 	for t in cdt.GetTriangles():
-		triangles.append(shapely.geometry.Polygon([(t.GetPoint(0).toTuple()), (t.GetPoint(1).toTuple()), (t.GetPoint(2).toTuple())]))
+		triangles.append(shapely.geometry.Polygon([
+			t.GetPoint(0).toTuple(),
+			t.GetPoint(1).toTuple(),
+			t.GetPoint(2).toTuple()
+		]))
 	return triangles
 
 def plotPolygon(polygon, plt, style='r-'):

--- a/tests/core/test_geometry.py
+++ b/tests/core/test_geometry.py
@@ -14,8 +14,8 @@ def checkTriangulation(poly, prec=1e-6):
     assert all(t.difference(poly).area == pytest.approx(0, abs=prec) for t in tris)
     # check triangles are (nearly) disjoint
     for i, t1 in enumerate(tris[:-1]):
-        t2 = tris[i+1]
-        assert (t1 & t2).area == pytest.approx(0, abs=prec)
+        for t2 in tris[i+1:]:
+            assert (t1 & t2).area == pytest.approx(0, abs=prec)
     # check union of triangles is (nearly) identical to poly
     union = shapely.ops.unary_union(tris)
     assert poly.difference(union).area == pytest.approx(0, abs=prec)
@@ -39,5 +39,16 @@ def test_triangulation_hole_2():
     p = shapely.geometry.Polygon(
         [(-1,0), (0,3), (1,0), (0,-3)],
         holes=[[(0,2),(0.2,-2),(-0.2,-2)]]
+    )
+    checkTriangulation(p)
+
+def test_triangulation_holes():
+    """An example with multiple holes."""
+    p = shapely.geometry.Polygon(
+        [(0,0), (0,3), (5,3), (5,0)],
+        holes=[
+            [(1,1), (1,2), (2,2), (2,1)],
+            [(3,1), (3,2), (4,2), (4,1)],
+        ]
     )
     checkTriangulation(p)


### PR DESCRIPTION
* the triangulation algoritm used by shapely is different
  from GPC, but if we remove the triangles which cover the
  holes, then both tests pass and it might work without
  any extra library needed.

Signed-off-by: Martin Jansa <martin.jansa@lge.com>