### PR TITLE
Fixed a couple utility functions

### DIFF
--- a/src/scenic/domains/driving/behaviors.scenic
+++ b/src/scenic/domains/driving/behaviors.scenic
@@ -218,7 +218,7 @@ behavior FollowTrajectoryBehavior(target_speed = 10, trajectory = None):
             end_intersection = trajectory[-1].centerline[-1]
     else:
         end_intersection = trajectory[-1].centerline[-1]
-    
+
     while True:
         if self in _model.network.intersectionRegion:
             do TurnBehavior(trajectory_centerline)

--- a/src/scenic/domains/driving/model.scenic
+++ b/src/scenic/domains/driving/model.scenic
@@ -358,11 +358,11 @@ def withinDistanceToObjsInLane(vehicle, thresholdDistance):
     for obj in objects:
         if not (vehicle can see obj):
             continue
-        if not (network.laneAt(vehicle) == network.laneAt(obj) or network.intersectionAt(vehicle)==network.intersectionAt(obj)):
-            continue
         if (distance from vehicle.position to obj.position) < 0.1:
             # this means obj==vehicle
-            pass
-        elif (distance from vehicle.position to obj.position) < thresholdDistance:
-            return True
+            continue
+        if (network.intersectionAt(vehicle) is not None and network.intersectionAt(vehicle)==network.intersectionAt(obj)) or \
+            network.intersectionAt(vehicle) is None and network.laneAt(vehicle) == network.laneAt(obj):
+            if (distance from vehicle.position to obj.position) < thresholdDistance:
+                return True
     return False

--- a/src/scenic/domains/driving/model.scenic
+++ b/src/scenic/domains/driving/model.scenic
@@ -361,8 +361,11 @@ def withinDistanceToObjsInLane(vehicle, thresholdDistance):
         if (distance from vehicle.position to obj.position) < 0.1:
             # this means obj==vehicle
             continue
-        if (network.intersectionAt(vehicle) is not None and network.intersectionAt(vehicle)==network.intersectionAt(obj)) or \
-            network.intersectionAt(vehicle) is None and network.laneAt(vehicle) == network.laneAt(obj):
-            if (distance from vehicle.position to obj.position) < thresholdDistance:
-                return True
+        inter = network.intersectionAt(vehicle)
+        if inter and inter != network.intersectionAt(obj):    # different intersections
+            continue
+        if not inter and network.laneAt(vehicle) != network.laneAt(obj):    # different lanes
+            continue
+        if (distance from vehicle to obj) < thresholdDistance:
+            return True
     return False

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -168,7 +168,7 @@ class Maneuver(_ElementReferencer):
         conflicts = []
         for maneuver in self.intersection.maneuvers:
             if (maneuver.startLane is not start
-                and maneuver.connectingLane.intersects(guideway.centerline)):
+                and maneuver.connectingLane.centerline.intersects(guideway.centerline)):
                 conflicts.append(maneuver)
         return tuple(conflicts)
 

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -478,6 +478,11 @@ class Lane(_ContainsCenterline, LinearElement):
         """Get the LaneSection passing through a given point."""
         return self.network.findPointIn(point, self.sections, reject)
 
+    def intersects(self, other):
+        if isinstance(other, Lane):
+            return self.centerline.intersects(other.centerline)
+        return super().intersects(other)
+
     # TODO remove hack; freeze all these classes
     __hash__ = object.__hash__
 

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -168,7 +168,7 @@ class Maneuver(_ElementReferencer):
         conflicts = []
         for maneuver in self.intersection.maneuvers:
             if (maneuver.startLane is not start
-                and maneuver.connectingLane.intersects(guideway)):
+                and maneuver.connectingLane.intersects(guideway.centerline)):
                 conflicts.append(maneuver)
         return tuple(conflicts)
 
@@ -477,11 +477,6 @@ class Lane(_ContainsCenterline, LinearElement):
     def sectionAt(self, point: Vectorlike, reject=False) -> Union[LaneSection, None]:
         """Get the LaneSection passing through a given point."""
         return self.network.findPointIn(point, self.sections, reject)
-
-    def intersects(self, other):
-        if isinstance(other, Lane):
-            return self.centerline.intersects(other.centerline)
-        return super().intersects(other)
 
     # TODO remove hack; freeze all these classes
     __hash__ = object.__hash__


### PR DESCRIPTION
This PR means to fix two utility functions:
- **withinDistanceToObjsInLane:** Outside intersections, `network.intersectionAt(vehicle)` always returns None, which was causing some objects to be taken into account even if they weren't inside the specified lane
- **Maneuver.conflictingManeuver:** This function used the `PoligonalRegions.intersects()` function, creating some false positives between parallel lanes. Therefore, a new `Lane.intersects()` function has been created to overwrite it, which specifically uses their centerLines, not the whole road.