### PR TITLE
Fix bug upon CARLA's SimulationCreationError

### DIFF
--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -118,6 +118,7 @@ class CarlaSimulation(DrivingSimulation):
 		# Create Carla actor
 		carlaActor = self.world.try_spawn_actor(blueprint, transform)
 		if carlaActor is None:
+			self.destroy()
 			raise SimulationCreationError(f'Unable to spawn object {obj}')
 
 		if isinstance(carlaActor, carla.Vehicle):


### PR DESCRIPTION
Upon a SimulationCreationError, Scenic reset but didn't destroy the already created actors, which caused the simulation to possibly have remnants of previously tried ones. **This PR requries the Simulation.destroy() function, with is introduced in PR #11**