### PR TITLE
Adding ability to configure Traffic Manager in SetAutopilotAction (for Carla)

### DIFF
--- a/src/scenic/simulators/carla/actions.py
+++ b/src/scenic/simulators/carla/actions.py
@@ -96,13 +96,26 @@ class SetTrafficLightAction(VehicleAction):
 			traffic_light.set_state(self.color)
 
 class SetAutopilotAction(VehicleAction):
-	def __init__(self, enabled):
+	def __init__(self, enabled, ignore_lights_percentage=0, vehicle_percentage_speed_difference=30):
+		"""Enable or Disable the Autopilot for the current agent. Also allows to set certain TrafficManager 
+		parameters to configure the Autopilot behavior.
+		The default values of the Traffic Manager parameters are set to their Carla defaults
+		
+		Arguments
+			:param enabled: True if you want to turn on autopilot
+			:param ignore_lights_percentage: Between 0 and 100. Amount of times traffic lights will be ignored.
+			:param vehicle_percentage_speed_difference: Percentage difference between intended speed and the current limit. Can be negative to exceed the limit.
+		"""
 		if not isinstance(enabled, bool):
 			raise RuntimeError('Enabled must be a boolean.')
 		self.enabled = enabled
+		self.ignore_lights_percentage = ignore_lights_percentage
+		self.vehicle_percentage_speed_difference = vehicle_percentage_speed_difference
 
 	def applyTo(self, obj, sim):
 		vehicle = obj.carlaActor
+		sim.tm.ignore_lights_percentage(vehicle, self.ignore_lights_percentage)
+		sim.tm.vehicle_percentage_speed_difference(vehicle, self.vehicle_percentage_speed_difference)
 		vehicle.set_autopilot(self.enabled, sim.tm.get_port())
 
 #################################################

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -8,9 +8,17 @@ try:
 except ModuleNotFoundError:
     pass    # ignore; error will be caught later if user attempts to run a simulation
 
-behavior AutopilotBehavior():
-    """Behavior causing a vehicle to use CARLA's built-in autopilot."""
-    take SetAutopilotAction(True)
+behavior AutopilotBehavior(ignore_lights_percentage=0, vehicle_percentage_speed_difference=30):
+    """
+    Behavior causing a vehicle to use CARLA's built-in autopilot. 
+    This also, optionally, allows setting some [TrafficManager](https://carla.readthedocs.io/en/latest/python_api/#carlatrafficmanager) parameters.
+
+    Args:
+        ignore_lights_percentage(float): Between 0 and 100. Amount of times traffic lights will be ignored.
+        vehicle_percentage_speed_difference(float): Percentage difference between intended speed and the current limit. Can be negative to exceed the limit.
+    
+    """
+    take SetAutopilotAction(True, ignore_lights_percentage, vehicle_percentage_speed_difference)
 
 behavior WalkForwardBehavior(speed=0.5):
 	take SetWalkingDirectionAction(self.heading), SetWalkingSpeedAction(speed)


### PR DESCRIPTION
Addressing #27 

Adding arguments to the SetAutopilotAction to allow for setting some TrafficManager parameters for agents in a Scenic scenario. This could be extended to add more actor specific traffic manager parameters in the future as well.

Example Scenic behavior with this in practice,

```
# assuming all necessary imports are done before this section

VEHICLE_PERC_SPEED_DIFF = -30
SPEED_VIOLATION_PROB = 60 # probability that a vehicle is a speed limit violator(always exceeds speed limit)
TL_VIOLATION_PROB = 70  # probability with which the vehicle may violate a traffic light - this prob is constant for all vehicles

# Background activity
background_vehicles = []
for _ in range(25):
    lane = Uniform(*network.lanes)
    spot = OrientedPoint on lane.centerline
    kwargs = {"ignore_lights_percentage":TL_VIOLATION_PROB}
    if (random()*100) < SPEED_VIOLATION_PROB:
        kwargs["vehicle_percentage_speed_difference"] = VEHICLE_PERC_SPEED_DIFF
    background_car = Car at spot,
        with behavior AutopilotBehavior(**kwargs)
    background_vehicles.append(background_car)

#assuming ego vehicle is initialized after this section
```