### PR TITLE
Implement Temporal Operators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ tox = {version = "^3.14.0", optional = true}
 sphinx_rtd_theme = {version = "^0.5.2", optional = true}
 astor = {version = "^0.8.1", optional = true}
 inflect = {version = "^5.5.2", optional = true}
+rv-ltl = "0.1.0a1"
 
 [tool.poetry.extras]
 guideways = ["pyproj"]

--- a/src/scenic/core/dynamics.py
+++ b/src/scenic/core/dynamics.py
@@ -195,8 +195,6 @@ class DynamicScenario(Invocable):
         self._monitors = []
         self._behaviors = []
         self._temporalRequirements = []
-        self._alwaysRequirements = [] # TODO(shun): Check if this can also be deleted
-        self._eventuallyRequirements = []
         self._terminationConditions = []
         self._terminateSimulationConditions = []
         self._recordedExprs = []
@@ -259,8 +257,6 @@ class DynamicScenario(Invocable):
         self._ego = scene.egoObject
         self._objects = list(scene.objects)
         self._agents = [obj for obj in scene.objects if obj.behavior is not None]
-        self._alwaysRequirements = scene.alwaysRequirements
-        self._eventuallyRequirements = scene.eventuallyRequirements
         self._temporalRequirements = scene.temporalRequirements
         self._terminationConditions = scene.terminationConditions
         self._terminateSimulationConditions = scene.terminateSimulationConditions
@@ -497,12 +493,10 @@ class DynamicScenario(Invocable):
 
     def _compileRequirements(self):
         namespace = self._dummyNamespace if self._dummyNamespace else self.__dict__
-        requirementSyntax = self._requirementSyntax
         propositionSyntax = self._propositionSyntax
-        assert requirementSyntax is not None
-        for reqID, requirement in self._pendingRequirements.items():
-            syntax = requirementSyntax[reqID] if requirementSyntax else None
-            compiledReq = requirement.compile(namespace, self, syntax, propositionSyntax)
+        assert propositionSyntax is not None
+        for _, requirement in self._pendingRequirements.items():
+            compiledReq = requirement.compile(namespace, self, propositionSyntax)
 
             self._registerCompiledRequirement(compiledReq)
             self._requirementDeps.update(compiledReq.dependencies)
@@ -510,10 +504,6 @@ class DynamicScenario(Invocable):
     def _registerCompiledRequirement(self, req):
         if req.ty is RequirementType.require:
             place = self._requirements
-        elif req.ty is RequirementType.requireAlways:
-            place = self._alwaysRequirements
-        elif req.ty is RequirementType.requireEventually:
-            place = self._eventuallyRequirements
         elif req.ty is RequirementType.terminateWhen:
             place = self._terminationConditions
         elif req.ty is RequirementType.terminateSimulationWhen:

--- a/src/scenic/core/dynamics.py
+++ b/src/scenic/core/dynamics.py
@@ -487,7 +487,6 @@ class DynamicScenario(Invocable):
 
     def _addDynamicRequirement(self, ty, req, line, name):
         """Add a requirement defined during a dynamic simulation."""
-        assert ty is RequirementType.require
         dreq = DynamicRequirement(ty, req, line, name)
         self._temporalRequirements.append(dreq)
 

--- a/src/scenic/core/dynamics.py
+++ b/src/scenic/core/dynamics.py
@@ -175,8 +175,7 @@ class DynamicScenario(Invocable):
     def __init_subclass__(cls, *args, **kwargs):
         veneer.registerDynamicScenarioClass(cls)
 
-    _requirementSyntax = None   # overridden by subclasses
-    _propositionSyntax = None
+    _propositionSyntax = None # overridden by subclasses
     _simulatorFactory = None
     _globalParameters = None
     _locals = ()
@@ -472,6 +471,7 @@ class DynamicScenario(Invocable):
         self._globalParameters.update(other._globalParameters)
         self._externalParameters.extend(other._externalParameters)
         self._requirements.extend(other._requirements)
+        self._temporalRequirements.extend(other._temporalRequirements)
         self._behaviors.extend(other._behaviors)
 
     def _registerObject(self, obj):

--- a/src/scenic/core/dynamics.py
+++ b/src/scenic/core/dynamics.py
@@ -454,7 +454,7 @@ class DynamicScenario(Invocable):
 
     def _checkSimulationTerminationConditions(self):
         for req in self._terminateSimulationConditions:
-            # TODO(shun): I don't think this is right
+
             if req.isTrue().is_truthy:
                 return req
         return None

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -53,10 +53,9 @@ class PropositionNode:
 		if isinstance(node, Always):
 			node = node.req
 
-		eligible = True
-		for n in node.flatten():
-			# turns false if any one of the node is temporal
-			eligible = eligible and (not n.is_temporal)
+		# eligible if none of the nodes was temporal
+		eligible = all(not n.is_temporal for n in node.flatten())
+
 		return node.syntax_id if eligible else None
 	
 	@property
@@ -90,10 +89,7 @@ class PropositionNode:
 	@property
 	def has_temporal_operator(self):
 		node = self
-		has_temporal_op = False
-		for n in node.flatten():
-			# turns false if any one of the node is temporal
-			has_temporal_op = has_temporal_op or n.is_temporal
+		has_temporal_op = any(n.is_temporal for n in node.flatten())
 		return has_temporal_op
 
 class Atomic(PropositionNode):

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -150,7 +150,7 @@ class Not(UnaryProposition):
 
 class And(PropositionNode):
 	def __init__(self, reqs, syntax_id):
-		ltl_node = rv_ltl.And(reqs)
+		ltl_node = rv_ltl.And(*[req.ltl_node for req in reqs])
 		super().__init__(syntax_id, ltl_node)
 		self.reqs = reqs
 	def __str__(self):
@@ -163,7 +163,7 @@ class And(PropositionNode):
 
 class Or(PropositionNode):
 	def __init__(self, reqs, syntax_id):
-		ltl_node = rv_ltl.Or(reqs)
+		ltl_node = rv_ltl.Or(*[req.ltl_node for req in reqs])
 		super().__init__(syntax_id, ltl_node)
 		self.reqs = reqs
 	def __str__(self):

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -185,3 +185,15 @@ class Until(PropositionNode):
 	@property
 	def children(self):
 		return [self.lhs, self.rhs]
+
+class Implies(PropositionNode):
+	def __init__(self, lhs, rhs, syntax_id) -> None:
+		self.lhs = lhs
+		self.rhs = rhs
+		ltl_node = rv_ltl.Implies(lhs.ltl_node, rhs.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+	def __str__(self):
+		return f"({self.lhs} implies {self.rhs})"
+	@property
+	def children(self):
+		return [self.lhs, self.rhs]

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -98,7 +98,7 @@ class Atomic(PropositionNode):
 		super().__init__(syntax_id, ap)
 		self.closure = closure
 	def __str__(self):
-		return f"(AP)"
+		return f"(AP syntax_id={self.syntax_id})" if self.syntax_id is not None else "(AP)"
 	def evaluate(self):
 		return self.closure()
 

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -2,9 +2,10 @@
 
 from functools import reduce
 import operator
-import rv_ltl
-from scenic.core.errors import InvalidScenarioError
 
+import rv_ltl
+
+from scenic.core.errors import InvalidScenarioError
 from scenic.core.lazy_eval import needsLazyEvaluation
 
 class PropositionMonitor:

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -177,6 +177,7 @@ class Until(PropositionNode):
 		self.rhs = rhs
 		ltl_node = rv_ltl.Until(lhs.ltl_node, rhs.ltl_node)
 		super().__init__(syntax_id, ltl_node)
+		self.is_temporal = True
 	def __str__(self):
 		return f"({self.lhs} until {self.rhs})"
 	@property

--- a/src/scenic/core/propositions.py
+++ b/src/scenic/core/propositions.py
@@ -1,0 +1,187 @@
+"""Objects representing propositions that can be used to specify conditions"""
+
+from functools import reduce
+import operator
+import rv_ltl
+from scenic.core.errors import InvalidScenarioError
+
+from scenic.core.lazy_eval import needsLazyEvaluation
+
+class PropositionMonitor:
+	def __init__(self, proposition: "PropositionNode") -> None:
+		self._proposition = proposition
+		self._monitor = proposition.ltl_node.create_monitor()
+		
+	def update(self):
+		atomic_propositions = self._proposition.atomics()
+		state = {}
+		for ap in atomic_propositions:
+			b = ap.closure()
+			if needsLazyEvaluation(b):
+				raise InvalidScenarioError(f'value undefined outside of object definition')
+			state[str(ap.syntax_id)] = b
+		self._monitor.update(state)
+		return self._monitor.evaluate()
+
+
+class PropositionNode:
+	"""Base class for temporal and non-temporal propositions"""
+	def __init__(self, syntax_id, ltl_node) -> None:
+		self.syntax_id = syntax_id
+		self.ltl_node = ltl_node
+
+		self.is_temporal = False
+		"""tells if the proposition is temporal"""
+
+	def check_constrains_sampling(self):
+		"""checks if the proposition can be used for pruning
+
+		A requirement can be used for pruning if it is evaluated on the scene generation phase before simulation, and
+		violation in that phase immediately results in discarding the scene and regenerating a new one.
+
+		For simplicity, we currently check two special cases:
+		1. requirements with no temporal requirement
+		2. requirements with only one `always` operator on top-level
+
+		Returns:
+			None|int: returns syntax id that can be used for pruning, None if proposition cannot be used for pruning
+		"""
+		node = self
+
+		# if `always` is on top-level, check what's inside
+		if isinstance(node, Always):
+			node = node.req
+
+		eligible = True
+		for n in node.flatten():
+			# turns false if any one of the node is temporal
+			eligible = eligible and (not n.is_temporal)
+		return node.syntax_id if eligible else None
+	
+	@property
+	def children(self) -> list["PropositionNode"]:
+		"""returns all children of proposition tree
+
+		Returns:
+			list: proposition nodes that are directly under this node
+		"""
+		return []
+
+	def flatten(self) -> list["PropositionNode"]:
+		"""flattens the tree and return the list of nodes
+
+		Returns:
+			list: list of all children nodes
+		"""
+		return [self] + reduce(
+			operator.concat, [node.flatten() for node in self.children], []
+		)
+	
+	def atomics(self) -> list["Atomic"]:
+		return list(filter(lambda n: isinstance(n, Atomic), self.flatten()))
+
+	def create_monitor(self) -> rv_ltl.Monitor:
+		return PropositionMonitor(self)
+
+	def evaluate(self):
+		raise RuntimeError("This proposition contains temporal operators and can only be evaluated using monitor")
+
+	@property
+	def has_temporal_operator(self):
+		node = self
+		has_temporal_op = False
+		for n in node.flatten():
+			# turns false if any one of the node is temporal
+			has_temporal_op = has_temporal_op or n.is_temporal
+		return has_temporal_op
+
+class Atomic(PropositionNode):
+	def __init__(self, closure, syntax_id = None):
+		ap = rv_ltl.Atomic(identifier=str(syntax_id))
+		super().__init__(syntax_id, ap)
+		self.closure = closure
+	def __str__(self):
+		return f"(AP)"
+	def evaluate(self):
+		return self.closure()
+
+class UnaryProposition(PropositionNode):
+	"""Base class for temporal unary operators"""
+	@property
+	def children(self):
+		return [self.req]
+
+class Always(UnaryProposition):
+	def __init__(self, req: PropositionNode, syntax_id = None):
+		ltl_node = rv_ltl.Always(req.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+		self.req = req
+		self.is_temporal = True
+	def __str__(self):
+		return f"(Always {str(self.req)})"
+
+class Eventually(UnaryProposition):
+	def __init__(self, req: PropositionNode, syntax_id = None):
+		ltl_node = rv_ltl.Eventually(req.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+		self.req = req
+		self.is_temporal = True
+	def __str__(self):
+		return f"(Eventually {str(self.req)})"
+
+class Next(UnaryProposition):
+	def __init__(self, req: PropositionNode, syntax_id = None):
+		ltl_node = rv_ltl.Next(req.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+		self.req = req
+		self.is_temporal = True
+	def __str__(self):
+		return f"(Next {str(self.req)})"
+
+class Not(UnaryProposition):
+	def __init__(self, req: PropositionNode, syntax_id = None):
+		ltl_node = rv_ltl.Not(req.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+		self.req = req
+	def __str__(self):
+		return f"(Not {str(self.req)})"
+	def evaluate(self):
+		return not self.req.evaluate()
+
+class And(PropositionNode):
+	def __init__(self, reqs, syntax_id):
+		ltl_node = rv_ltl.And(reqs)
+		super().__init__(syntax_id, ltl_node)
+		self.reqs = reqs
+	def __str__(self):
+		return " and ".join([f"{str(req)}" for req in self.reqs])
+	@property
+	def children(self):
+		return self.reqs
+	def evaluate(self):
+		return reduce(operator.and_, [node.evaluate() for node in self.reqs], True)
+
+class Or(PropositionNode):
+	def __init__(self, reqs, syntax_id):
+		ltl_node = rv_ltl.Or(reqs)
+		super().__init__(syntax_id, ltl_node)
+		self.reqs = reqs
+	def __str__(self):
+		return " or ".join([f"{str(req)}" for req in self.reqs])
+	@property
+	def children(self):
+		return self.reqs
+	def evaluate(self):
+		return reduce(operator.or_, [node.evaluate() for node in self.reqs], False)
+
+class Until(PropositionNode):
+	def __init__(self, lhs, rhs, syntax_id) -> None:
+		self.lhs = lhs
+		self.rhs = rhs
+		ltl_node = rv_ltl.Until(lhs.ltl_node, rhs.ltl_node)
+		super().__init__(syntax_id, ltl_node)
+	def __str__(self):
+		return f"({self.lhs} until {self.rhs})"
+	@property
+	def children(self):
+		return [self.lhs, self.rhs]

--- a/src/scenic/core/requirements.py
+++ b/src/scenic/core/requirements.py
@@ -17,8 +17,6 @@ import scenic.syntax.relations as relations
 class RequirementType(enum.Enum):
     # requirements which must hold during initial sampling
     require = 'require'
-    requireAlways = 'require always'
-    requireEventually = 'require eventually'
 
     # requirements used only during simulation
     terminateWhen = 'terminate when'
@@ -31,7 +29,7 @@ class RequirementType(enum.Enum):
 
     @property
     def constrainsSampling(self):
-        return self in (self.require, self.requireAlways)
+        return self in (self.require,)
 
 class PendingRequirement:
     def __init__(self, ty, condition, line, prob, name, ego):
@@ -54,14 +52,13 @@ class PendingRequirement:
 
         self.egoObject = ego
 
-    def compile(self, namespace, scenario, syntax=None, propositionSyntax=[]):
+    def compile(self, namespace, scenario, propositionSyntax=[]):
         """Create a closure testing the requirement in the correct runtime state.
 
         While we're at it, determine whether the requirement implies any relations
         we can use for pruning, and gather all of its dependencies.
         """
         bindings, ego, line = self.bindings, self.egoObject, self.line
-        condition = self.condition
 
         # Check whether requirement implies any relations used for pruning
         propositionIdForPruning = self.condition.check_constrains_sampling()

--- a/src/scenic/core/requirements.py
+++ b/src/scenic/core/requirements.py
@@ -39,8 +39,7 @@ class PendingRequirement:
         self.prob = prob
         self.name = name
 
-        # conditions are propositions
-        # TODO(shun): add comments here
+        # condition is an instance of Proposition. Flatten to get a list of atomic propositions.
         nodes = condition.flatten()
         binding_list = []
         for node in nodes:

--- a/src/scenic/core/requirements.py
+++ b/src/scenic/core/requirements.py
@@ -152,7 +152,6 @@ class BoundRequirement:
         self.closure = compiledReq.closure
         self.line = compiledReq.line
         self.name = compiledReq.name
-        assert compiledReq.prob == 1
         self.sample = sample
         self.compiledReq = compiledReq
         self.proposition = proposition

--- a/src/scenic/core/requirements.py
+++ b/src/scenic/core/requirements.py
@@ -39,6 +39,10 @@ class PendingRequirement:
         self.prob = prob
         self.name = name
 
+        # the translator wrapped the requirement in a lambda to prevent evaluation,
+        # so we need to save the current values of all referenced names; we save
+        # the ego object too since it can be referred to implicitly
+
         # condition is an instance of Proposition. Flatten to get a list of atomic propositions.
         nodes = condition.flatten()
         binding_list = []

--- a/src/scenic/core/scenarios.py
+++ b/src/scenic/core/scenarios.py
@@ -32,8 +32,7 @@ class Scene:
 		workspace (:obj:`~scenic.core.workspaces.Workspace`): Workspace for the scenario.
 	"""
 	def __init__(self, workspace, objects, egoObject, params,
-				 alwaysReqs=(), eventuallyReqs=(), temporalReqs=(),
-				 terminationConds=(), termSimulationConds=(),
+				 temporalReqs=(), terminationConds=(), termSimulationConds=(),
 				 recordedExprs=(), recordedInitialExprs=(), recordedFinalExprs=(),
 				 monitors=(), behaviorNamespaces={}, dynamicScenario=None):
 		self.workspace = workspace
@@ -41,9 +40,6 @@ class Scene:
 		self.egoObject = egoObject
 		self.params = params
 		self.temporalRequirements = tuple(temporalReqs)
-		# TODO(shun): Delete always and eventually reqs in favor of temporal reqs if possible
-		self.alwaysRequirements = tuple(alwaysReqs)
-		self.eventuallyRequirements = tuple(eventuallyReqs)
 		self.terminationConditions = tuple(terminationConds)
 		self.terminateSimulationConditions = tuple(termSimulationConds)
 		self.recordedExprs = tuple(recordedExprs)
@@ -98,11 +94,9 @@ class Scenario:
 
 		staticReqs, alwaysReqs, terminationConds = [], [], []
 		self.requirements = tuple(dynamicScenario._requirements)	# TODO clean up
-		self.alwaysRequirements = tuple(dynamicScenario._alwaysRequirements)
-		self.eventuallyRequirements = tuple(dynamicScenario._eventuallyRequirements)
 		self.terminationConditions = tuple(dynamicScenario._terminationConditions)
 		self.terminateSimulationConditions = tuple(dynamicScenario._terminateSimulationConditions)
-		self.initialRequirements = self.requirements + self.alwaysRequirements
+		self.initialRequirements = self.requirements
 		assert all(req.constrainsSampling for req in self.initialRequirements)
 		self.recordedExprs = tuple(dynamicScenario._recordedExprs)
 		self.recordedInitialExprs = tuple(dynamicScenario._recordedInitialExprs)
@@ -280,8 +274,6 @@ class Scenario:
 		for modName, namespace in self.behaviorNamespaces.items():
 			sampledNamespace = { name: sample[value] for name, value in namespace.items() }
 			sampledNamespaces[modName] = (namespace, sampledNamespace, namespace.copy())
-		alwaysReqs = (BoundRequirement(req, sample) for req in self.alwaysRequirements)
-		eventuallyReqs = (BoundRequirement(req, sample) for req in self.eventuallyRequirements)
 		temporalReqs = (BoundRequirement(req, sample, req.proposition) for req in self.requirements)
 		terminationConds = (BoundRequirement(req, sample, req.proposition)
 							for req in self.terminationConditions)
@@ -293,7 +285,7 @@ class Scenario:
 		recordedFinalExprs = (BoundRequirement(req, sample, req.proposition)
 		                      for req in self.recordedFinalExprs)
 		scene = Scene(self.workspace, sampledObjects, ego, sampledParams,
-					  alwaysReqs, eventuallyReqs, temporalReqs, terminationConds, termSimulationConds,
+					  temporalReqs, terminationConds, termSimulationConds,
 					  recordedExprs, recordedInitialExprs,recordedFinalExprs,
 					  self.monitors, sampledNamespaces, self.dynamicScenario)
 		return scene, iterations

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -290,7 +290,7 @@ def compileStream(stream, namespace, params={}, model=None, filename='<stream>')
 			# Execute it
 			executeCodeIn(code, namespace)
 		# Extract scenario state from veneer and store it
-		storeScenarioStateIn(namespace, requirements, propositionSyntax) # TODO(shun): requirements should no longer be needed
+		storeScenarioStateIn(namespace, propositionSyntax)
 	finally:
 		veneer.deactivate()
 	if verbosity >= 2:
@@ -2441,7 +2441,7 @@ def executeCodeIn(code, namespace):
 
 ### TRANSLATION PHASE SEVEN: scenario construction
 
-def storeScenarioStateIn(namespace, requirementSyntax, propositionSyntax):
+def storeScenarioStateIn(namespace, propositionSyntax):
 	"""Post-process an executed Scenic module, extracting state from the veneer."""
 
 	# Save requirement syntax and other module-level information
@@ -2449,7 +2449,6 @@ def storeScenarioStateIn(namespace, requirementSyntax, propositionSyntax):
 	factory = veneer.simulatorFactory
 	bns = gatherBehaviorNamespacesFrom(moduleScenario._behaviors)
 	def handle(scenario):
-		scenario._requirementSyntax = requirementSyntax
 		scenario._propositionSyntax = propositionSyntax
 		if isinstance(scenario, type):
 			scenario._simulatorFactory = staticmethod(factory)

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -462,7 +462,7 @@ requirementStatements = recordStatements + (
 )
 
 # statements that supports temporal operators
-statementWithTemporalSupport = (requireStatement)
+statementWithTemporalSupport = (requireStatement,)
 
 statementRaiseMarker = '_Scenic_statement_'
 

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -1041,7 +1041,7 @@ class TokenTranslator:
 				# all function calls on the stack
 				contexts = set(ctx for ctx, _ in functionStack)
 				for opTokens, op in infixTokens.items():
-					# if not context is specified, the operator can be used
+					# if no context is specified, the operator can be used
 					if not op.contexts:
 						allowedInfixOps[opTokens] = op.tokens
 						continue

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -2075,14 +2075,11 @@ class ASTSurgeon(NodeTransformer):
 		newArgs = []
 
 		# wrap temporal requirement in lambda
-		# FIXME(shun): Should I also check if the node is in a requirement here?
 		if isinstance(func, Name) and func.id in TEMPORAL_PROPOSITION_FACTORY:
-			assert self.inRequire # temporal operators must be inside requirements
 			if not self.canUseTemporalOps:
-				# TODO(shun): Add a test to check this
 				self.parseError(node, f"Operator {func.id} is not allowed in this statement")
 			checkedArgs = node.args
-			# self.validateSimpleCall(node, (1, None), args=checkedArgs) # FIXME: Do I need this?
+			self.validateSimpleCall(node, (1, None), args=checkedArgs)
 			rawRequirement = checkedArgs[0]
 
 			syntaxId = self._register_requirement_syntax(node)

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -1630,7 +1630,7 @@ class ASTSurgeon(NodeTransformer):
 			# convert `and` and `or` inside requirements into function calls
 			# Note: BoolOp is either `and` or `or` so it always needs transformation inside a requirement
 			lineNum = Constant(node.lineno)
-			copy_location(lineNum, node) # TODO(shun): what should be the second argument?
+			copy_location(lineNum, node)
 
 			for infixOp in temporalInfixOperators:
 				groups = list(

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -1045,7 +1045,7 @@ class TokenTranslator:
 					if not op.contexts:
 						allowedInfixOps[opTokens] = op.tokens
 						continue
-					# if operator is start level only and it is start level, cannot be used
+					# if operator is start level only and it is not start level, cannot be used
 					if op.startLevelOnly and parenLevel != startLevel:
 						continue
 					# a set of contexts under which this operator is allowed

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -605,7 +605,7 @@ class TemporalInfixOp(typing.NamedTuple):
 			2,
 			((Name, "or"), (Name, f"_Scenic_infixop_{self.syntax}"), (Name, "or")),
 			None,
-			(requireStatement,),
+			frozenset({requireStatement,}),
 			False # temporal infix operators can be nested
 		)
 
@@ -620,7 +620,7 @@ class InfixOp(typing.NamedTuple):
 	arity: int
 	tokens: typing.Tuple[typing.Tuple[int, str]]
 	node: ast.AST
-	contexts: typing.Optional[typing.Tuple[str]] = ()
+	contexts: typing.Optional[typing.FrozenSet[str]] = ()
 	# True if the operator can only be used at top level
 	startLevelOnly: bool = True
 
@@ -636,10 +636,10 @@ infixOperators = (
 
 	# just syntactic conveniences, not really operators
 	InfixOp('from', None, 2, ((COMMA, ','),), None),
-	InfixOp('for', None, 2, ((COMMA, ','),), None, ('Follow', 'Following')),
+	InfixOp('for', None, 2, ((COMMA, ','),), None, frozenset({'Follow', 'Following'})),
 	InfixOp('to', None, 2, ((COMMA, ','),), None),
-	InfixOp('as', None, 2, ((COMMA, ','),), None, requirementStatements),
-	InfixOp('of', None, 2, ((COMMA, ','),), None, ('DistancePast',)),
+	InfixOp('as', None, 2, ((COMMA, ','),), None, frozenset(requirementStatements)),
+	InfixOp('of', None, 2, ((COMMA, ','),), None, frozenset({'DistancePast',})),
 	InfixOp('by', None, 2, (packageToken,), None)
 ) + tuple(op.toInfixOp() for op in temporalInfixOperators)
 
@@ -1049,8 +1049,7 @@ class TokenTranslator:
 					if op.startLevelOnly and parenLevel != startLevel:
 						continue
 					# a set of contexts under which this operator is allowed
-					allowedContexts = set(op.contexts)
-					if allowedContexts.intersection(contexts):
+					if op.contexts.intersection(contexts):
 						# this operator can be used in the current context
 						allowedInfixOps[opTokens] = op.tokens
 			else:

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -1028,11 +1028,6 @@ class TokenTranslator:
 					inConstructorContext = True
 					allowedPrefixOps = self.specifiersForConstructor(context)
 				else:
-					contexts = set(ctx for ctx, _ in functionStack)
-					for opTokens, op in infixTokens.items():
-						allowedContexts = set(op.contexts)
-						if not op.contexts or allowedContexts.intersection(contexts):
-							allowedInfixOps[opTokens] = op.tokens
 					for name, mod in modifierNames.items():
 						if not mod.contexts or context in mod.contexts:
 							allowedModifiers[name] = mod.name
@@ -1040,7 +1035,8 @@ class TokenTranslator:
 						allowedTerminators = modifierNames[context].terminators
 					elif context in terminatorsForStatements:
 						allowedTerminators = terminatorsForStatements[context]
-			elif context:
+			# construct allowedInfixOps
+			if context:
 				# all function calls on the stack
 				contexts = set(ctx for ctx, _ in functionStack)
 				for opTokens, op in infixTokens.items():
@@ -1048,8 +1044,8 @@ class TokenTranslator:
 					if not op.contexts:
 						allowedInfixOps[opTokens] = op.tokens
 						continue
-					# if operator is top level only, cannot be used
-					if op.startLevelOnly:
+					# if operator is start level only and it is start level, cannot be used
+					if op.startLevelOnly and parenLevel != startLevel:
 						continue
 					# a set of contexts under which this operator is allowed
 					allowedContexts = set(op.contexts)
@@ -1058,7 +1054,6 @@ class TokenTranslator:
 						allowedInfixOps[opTokens] = op.tokens
 			else:
 				allowedInfixOps = generalInfixOps
-			print(tstring, allowedInfixOps)
 			# Parse next token
 			if ttype == LPAR or ttype == LSQB:		# keep track of nesting level
 				parenLevel += 1

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -2079,9 +2079,8 @@ class ASTSurgeon(NodeTransformer):
 		if isinstance(func, Name) and func.id in PROPOSITION_FACTORY:
 			if not self.canUseTemporalOps:
 				self.parseError(node, f"Operator {func.id} is not allowed in this statement")
-			checkedArgs = node.args
-			self.validateSimpleCall(node, (1, None), args=checkedArgs)
-			rawRequirement = checkedArgs[0]
+			self.validateSimpleCall(node, (1, None))
+			rawRequirement = node.args[0]
 
 			syntaxId = self._register_requirement_syntax(node)
 			syntaxIdConst = Constant(syntaxId)

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -400,6 +400,8 @@ def require(reqID, req, line, name, prob=1):
 				if not result:
 					raise RejectSimulationException(name)
 	else:	# requirement being defined at compile time
+		if req.is_temporal and prob != 1:
+			raise RuntimeParseError('requirements with temporal operators must have probability of 1')
 		currentScenario._addRequirement(requirements.RequirementType.require,
                                         reqID, req, line, name, prob)
 

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -48,8 +48,8 @@ __all__ = (
 	'PropertyDefault', 'Behavior', 'Monitor', 'makeTerminationAction',
 	'BlockConclusion', 'runTryInterrupt', 'wrapStarredValue', 'callWithStarArgs',
 	'Modifier', 'DynamicScenario',
-	# Temporal Operator Factories
-	'TemporalAtomicProposition', 'TemporalAnd', 'TemporalOr', 'TemporalNot',
+	# Proposition Factories
+	'AtomicProposition', 'PropositionAnd', 'PropositionOr', 'PropositionNot',
 )
 
 # various Python types and functions used in the language but defined elsewhere
@@ -1040,13 +1040,13 @@ def str(*args, **kwargs):
 
 ### Temporal Operators Factories
 
-def TemporalAtomicProposition(closure, *, line, syntaxId):
+def AtomicProposition(closure, *, line, syntaxId):
 	return propositions.Atomic(closure, syntaxId)
-def TemporalAnd(reqs, *, line, syntaxId):
+def PropositionAnd(reqs, *, line, syntaxId):
 	return propositions.And(reqs, syntaxId)
-def TemporalOr(reqs, *, line, syntaxId):
+def PropositionOr(reqs, *, line, syntaxId):
 	return propositions.Or(reqs, syntaxId)
-def TemporalNot(req, *, line, syntaxId):
+def PropositionNot(req, *, line, syntaxId):
 	return propositions.Not(req, syntaxId)
 def Always(req, *, line, syntaxId):
 	return propositions.Always(req, syntaxId)

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -438,6 +438,8 @@ def makeRequirement(ty, reqID, req, line, name):
 		raise RuntimeParseError(f'tried to use "{ty.value}" inside a requirement')
 	elif currentBehavior is not None:
 		raise RuntimeParseError(f'"{ty.value}" inside a behavior on line {line}')
+	elif currentSimulation is not None:
+		currentScenario._addDynamicRequirement(ty, req, line, name)
 	else:	# requirement being defined at compile time
 		currentScenario._addRequirement(ty, reqID, req, line, name, 1)
 

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -23,7 +23,7 @@ __all__ = (
 	'DistanceFrom', 'DistancePast', 'AngleTo', 'AngleFrom', 'Follow',
 	'Always', 'Eventually', 'Next',
 	# Infix operators
-	'FieldAt', 'RelativeTo', 'OffsetAlong', 'CanSee', 'Until',
+	'FieldAt', 'RelativeTo', 'OffsetAlong', 'CanSee', 'Until', 'Implies',
 	# Primitive types
 	'Vector', 'VectorField', 'PolygonalVectorField',
 	'Region', 'PointSetRegion', 'RectangularRegion', 'CircularRegion', 'SectorRegion',
@@ -1055,3 +1055,5 @@ def Next(req, *, line, syntaxId):
 	return propositions.Next(req, syntaxId)
 def Until(lhs, rhs, *, line, syntaxId):
 	return propositions.Until(lhs, rhs, syntaxId)
+def Implies(lhs, rhs, *, line, syntaxId):
+	return propositions.Implies(lhs, rhs, syntaxId)

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -9,7 +9,7 @@ global state such as the list of all created Scenic objects.
 __all__ = (
 	# Primitive statements and functions
 	'ego', 'require', 'resample', 'param', 'globalParameters', 'mutate', 'verbosePrint',
-	'localPath', 'model', 'simulator', 'simulation', 'require_always', 'require_eventually',
+	'localPath', 'model', 'simulator', 'simulation',
 	'terminate_when', 'terminate_simulation_when', 'terminate_after', 'in_initial_scenario',
 	'override',
 	'record', 'record_initial', 'record_final',
@@ -418,19 +418,6 @@ def record_final(reqID, value, line, name):
 	if not name:
 		name = f'record{line}'
 	makeRequirement(requirements.RequirementType.recordFinal, reqID, value, line, name)
-
-def require_always(reqID, req, line, name):
-	"""Function implementing the 'require always' statement."""
-	if not name:
-		name = f'requirement on line {line}'
-	makeRequirement(requirements.RequirementType.requireAlways, reqID, req, line, name)
-
-def require_eventually(reqID, req, line, name):
-	"""Function implementing the 'require eventually' statement."""
-	if not name:
-		name = f'requirement on line {line}'
-	makeRequirement(requirements.RequirementType.requireEventually, reqID, req, line, name)
-
 
 def terminate_when(reqID, req, line, name):
 	"""Function implementing the 'terminate when' statement."""

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -400,7 +400,6 @@ def require(reqID, req, line, name, prob=1):
 				if not result:
 					raise RejectSimulationException(name)
 	else:	# requirement being defined at compile time
-		# TODO(shun): if req has temporal operators and prob != 1 then raise an error
 		currentScenario._addRequirement(requirements.RequirementType.require,
                                         reqID, req, line, name, prob)
 

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -637,7 +637,7 @@ def test_require_implies_2():
                 self.blah += 1
                 take self.blah
         ego = Object with behavior Foo, with blah 0
-        require always ((ego.blah % 2 == 0) implies (next (ego.blah % 2 == 1)))
+        require always ego.blah % 2 == 0 implies (next ego.blah % 2 == 1)
     """)
     sampleEgoActions(scenario, maxSteps=5)
 

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -584,6 +584,17 @@ def test_require_next_2():
     """)
     sampleEgoActions(scenario, maxSteps=5)
 
+def test_require_until():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require ego.blah < 3 until ego.blah >= 3
+    """)
+    sampleEgoActions(scenario, maxSteps=5)
+
 ## Monitors
 
 def test_monitor():

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -562,6 +562,28 @@ def test_require_eventually_2():
     """)
     sampleEgoActions(scenario, maxSteps=3)
 
+def test_require_next_1():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require (next (ego.blah == 1))
+    """)
+    sampleEgoActions(scenario, maxSteps=5)
+
+def test_require_next_2():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require (next (next (ego.blah == 2)))
+    """)
+    sampleEgoActions(scenario, maxSteps=5)
+
 ## Monitors
 
 def test_monitor():

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from scenic.core.errors import RuntimeParseError, ScenicSyntaxError
-from scenic.core.simulators import TerminationType
+from scenic.core.simulators import RejectSimulationException, TerminationType
 
 from tests.utils import (compileScenic, sampleScene, sampleActions, sampleActionsFromScene,
                          sampleEgoActions, sampleEgoActionsFromScene, sampleResult,
@@ -536,7 +536,7 @@ def test_require_always():
         actions = sampleEgoActions(scenario, maxSteps=2, maxIterations=50)
         assert tuple(actions) == (0, 0)
 
-def test_require_eventually():
+def test_require_eventually_1():
     scenario = compileScenic("""
         behavior Foo():
             while True:
@@ -561,6 +561,18 @@ def test_require_eventually_2():
         require eventually ego.blah == 2
     """)
     sampleEgoActions(scenario, maxSteps=3)
+
+def test_require_eventually_3():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                take self.blah
+                self.blah += 1
+        ego = Object with behavior Foo, with blah 0
+        require eventually ego.blah == -1
+    """)
+    with pytest.raises(RejectSimulationException):
+        sampleEgoActions(scenario, maxSteps=3)
 
 def test_require_next_1():
     scenario = compileScenic("""
@@ -592,6 +604,29 @@ def test_require_until():
                 take self.blah
         ego = Object with behavior Foo, with blah 0
         require ego.blah < 3 until ego.blah >= 3
+    """)
+    sampleEgoActions(scenario, maxSteps=5)
+
+def test_require_until_2():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require False until ego.blah > 3
+    """)
+    with pytest.raises(RejectSimulationException):
+        sampleEgoActions(scenario, maxSteps=5)
+
+def test_require_implies_1():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require ego.blah == 3 implies ego.blah % 2 == 1
     """)
     sampleEgoActions(scenario, maxSteps=5)
 

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -603,7 +603,7 @@ def test_require_until():
                 self.blah += 1
                 take self.blah
         ego = Object with behavior Foo, with blah 0
-        require ego.blah < 3 until ego.blah >= 3
+        require (ego.blah < 3 until ego.blah >= 3)
     """)
     sampleEgoActions(scenario, maxSteps=5)
 
@@ -627,6 +627,17 @@ def test_require_implies_1():
                 take self.blah
         ego = Object with behavior Foo, with blah 0
         require ego.blah == 3 implies ego.blah % 2 == 1
+    """)
+    sampleEgoActions(scenario, maxSteps=5)
+
+def test_require_implies_2():
+    scenario = compileScenic("""
+        behavior Foo():
+            while True:
+                self.blah += 1
+                take self.blah
+        ego = Object with behavior Foo, with blah 0
+        require always ((ego.blah % 2 == 0) implies (next (ego.blah % 2 == 1)))
     """)
     sampleEgoActions(scenario, maxSteps=5)
 

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -135,6 +135,11 @@ def test_extra_infix_package():
     with pytest.raises(ASTParseError):
         compileScenic('x = 4 offset along 12 by 17 by 19')
 
+def test_invalid_temporal_operator_use():
+    """Temporal operators can only be used inside requirements"""
+    with pytest.raises(ASTParseError):
+        compileScenic('req = always x')
+
 def test_extra_temporal_operands():
     """Temporal infix operators should only take two arguments"""
     with pytest.raises(ASTParseError):

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -135,6 +135,11 @@ def test_extra_infix_package():
     with pytest.raises(ASTParseError):
         compileScenic('x = 4 offset along 12 by 17 by 19')
 
+def test_extra_temporal_operands():
+    """Temporal infix operators should only take two arguments"""
+    with pytest.raises(ASTParseError):
+        compileScenic('require a or b until c or d until e')
+
 ## Ranges
 
 def test_malformed_range():

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -166,6 +166,21 @@ def test_subscenario_require_eventually():
     result = sampleResultOnce(scenario)
     assert result is None
 
+def test_subscenario_terminate_when():
+    """Test that 'terminate when' and 'require' are properly handled."""
+    scenario = compileScenic("""
+        scenario Main():
+            compose:
+                do Sub()
+                wait
+        scenario Sub():
+            ego = Object
+            require eventually simulation().currentTime == 2
+            terminate when simulation().currentTime == 1
+    """)
+    result = sampleResultOnce(scenario, maxSteps=2)
+    assert result is None
+
 def test_initial_scenario_basic():
     scenario = compileScenic("""
         scenario Main():

--- a/tests/syntax/test_requirements.py
+++ b/tests/syntax/test_requirements.py
@@ -87,7 +87,7 @@ def test_runtime_parse_error_in_requirement():
         sampleScene(scenario)
 
 def test_soft_requirement_with_temporal_operators():
-    "Temporal operators are not be allowed if prob != 1"
+    "Temporal operators are not allowed if prob != 1"
     with pytest.raises(RuntimeParseError):
         compileScenic("""
             ego = Object

--- a/tests/syntax/test_requirements.py
+++ b/tests/syntax/test_requirements.py
@@ -2,7 +2,7 @@
 import pytest
 
 import scenic
-from scenic.core.errors import ScenicSyntaxError, InvalidScenarioError
+from scenic.core.errors import ScenicSyntaxError, InvalidScenarioError, RuntimeParseError
 from tests.utils import compileScenic, sampleScene, sampleSceneFrom, sampleEgo
 
 ## Basic
@@ -85,6 +85,14 @@ def test_runtime_parse_error_in_requirement():
     """)
     with pytest.raises(ScenicSyntaxError):
         sampleScene(scenario)
+
+def test_soft_requirement_with_temporal_operators():
+    "Temporal operators are not be allowed if prob != 1"
+    with pytest.raises(RuntimeParseError):
+        compileScenic("""
+            ego = Object
+            require[0.2] eventually ego
+        """)
 
 ## Enforcement of built-in requirements
 


### PR DESCRIPTION
This PR adds the following five temporal operators to the Scenic language.

- eventually
- always
- next
- until
- implies

These operators can be used inside `require` statements as a prefix or infix operator.

