### PR TITLE
Carla pedestrian color fix

### DIFF
--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -182,10 +182,11 @@ class CarlaSimulation(DrivingSimulation):
 		rot = utils.scenicToCarlaRotation(obj.heading)
 		transform = carla.Transform(loc, rot)
 
-		# Color
-		c = obj.color
-		c_str = f'{int(c.r*255)},{int(c.g*255)},{int(c.b*255)}'
-		blueprint.set_attribute('color', c_str)
+		# Color, cannot be set for Pedestrians
+		if blueprint.has_attribute('color') and obj.color is not None:
+			c = obj.color
+			c_str = f'{int(c.r*255)},{int(c.g*255)},{int(c.b*255)}'
+			blueprint.set_attribute('color', c_str)
 
 		# Create Carla actor
 		carlaActor = self.world.try_spawn_actor(blueprint, transform)


### PR DESCRIPTION
Added a check for color in the blueprint to fix crashes when creating pedestrians in Carla