### PR TITLE
Adding objects that can replay completed scenarios

### DIFF
--- a/src/scenic/core/simulators.py
+++ b/src/scenic/core/simulators.py
@@ -378,14 +378,10 @@ class ReplaySimulation(Simulation):
         objects: List of Scenic objects (instances of `Object`) existing in the
             simulation. This list will change if objects are created dynamically.
         agents: List of :term:`agents` in the simulation.
-        result (`SimulationResult`): Result of the simulation, or `None` if it has not
-            yet completed. This is the primary object which should be inspected to get
-            data out of the simulation: the other attributes of this class are primarily
-            for internal use.
+        simulationResult (`SimulationResult`):
     """
 
     def __init__(self, scene, simulationResult, timestep=1, verbosity=0):
-        self.result = None
         self.scene = scene
         self.simulation_result = simulationResult
         self.objects = list(scene.objects)
@@ -503,10 +499,6 @@ class ReplaySimulation(Simulation):
             for name, val in values.items():
                 self.records[name] = val
 
-            # Package up simulation results into a compact object
-            result = SimulationResult(trajectory, actionSequence, terminationType,
-                                      terminationReason, self.records)
-            self.result = result
             return self
         finally:
             self.destroy()


### PR DESCRIPTION
*This is a working PR that is not to be immediately merged. Feedback will be gathered and used in future commits.*

The intention of this PR is to add the capability to "reconstitute" completed Scenarios, and be able to replay through the completed scenarios in a pythonic object. Additionally, new behaviors can be added to a ReplaySimulation object, and compared against the actions taken in the completed simulation. 

This PR does not yet support the transitioning from a ReplaySimulation object to a Simulation object, for the purposes of "picking up where you left off" and resuming an in-progress simulation.

Additional questions:
- How will new behaviors be added to the ReplaySimulation object? Right now, my intention is for them to be provided in a scene, but this is making the assumption that the list of behaviors and objects provided will be the same as the number of behaviors and objects that existed in the original simulation. I can add error handling to provide for this.
- Is it possible to save the 'scene' in the SimulationResult? Is this something we even want?
- It's still not clear what parts of run() should or shouldn't exist in the ReplaySimulation version.

Added fixes and changes to come.
@dfremont @ek65 let me know your feedback. Thanks!