### PR TITLE
[Parser] Add Specifiers

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -153,3 +153,11 @@ class FacingSpecifier(AST):
     def __init__(self, heading: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.heading = heading
+
+
+class FacingTowardSpecifier(AST):
+    __match_args__ = ("position",)
+
+    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.position = position

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -115,6 +115,23 @@ class Behind(AST):
         super().__init__(*args, **kwargs)
 
 
+class BeyondSpecifier(AST):
+    __match_args__ = ("position", "offset", "base")
+
+    def __init__(
+        self,
+        position: ast.AST,
+        offset: ast.AST,
+        base: Optional[ast.AST] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.position = position
+        self.offset = offset
+        self.base = base
+
+
 class VisibleSpecifier(AST):
     __match_args__ = ("base",)
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -77,7 +77,7 @@ class OffsetAlongSpecifier(AST):
         self._fields = ["direction", "offset"]
 
 
-class PositionSpecifier(AST):
+class DirectionOfSpecifier(AST):
     __match_args__ = ("direction", "position", "distance")
 
     def __init__(

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -12,9 +12,20 @@ class EgoAssign(AST):
         self.value = value
         self._fields = ["value"]
 
+# Instance Creation
+
 class New(AST):
     def __init__(self, className: str, specifiers: list, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.className = className
         self.specifiers = specifiers
         self._fields = ["className", "specifiers"]
+
+# Specifiers
+
+class WithSpecifier(AST):
+    def __init__(self, prop: str, value: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.prop = prop
+        self.value = value
+        self._fields = ["prop", "value"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -62,6 +62,7 @@ class OffsetBySpecifier(AST):
     def __init__(self, offset: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.offset = offset
+        self._fields = ["offset"]
 
 
 class OffsetAlongSpecifier(AST):
@@ -73,6 +74,7 @@ class OffsetAlongSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.direction = direction
         self.offset = offset
+        self._fields = ["direction", "offset"]
 
 
 class PositionSpecifier(AST):
@@ -90,6 +92,7 @@ class PositionSpecifier(AST):
         self.direction = direction
         self.position = position
         self.distance = distance
+        self._fields = ["direction", "position", "distance"]
 
 
 class LeftOf(AST):
@@ -120,6 +123,7 @@ class VisibleSpecifier(AST):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.base = base
+        self._fields = ["base"]
 
 
 class InSpecifier(AST):
@@ -128,6 +132,7 @@ class InSpecifier(AST):
     def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.region = region
+        self._fields = ["region"]
 
 
 class FollowingSpecifier(AST):
@@ -145,6 +150,7 @@ class FollowingSpecifier(AST):
         self.field = field
         self.distance = distance
         self.base = base
+        self._fields = ["field", "distance", "base"]
 
 
 class FacingSpecifier(AST):
@@ -153,6 +159,7 @@ class FacingSpecifier(AST):
     def __init__(self, heading: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.heading = heading
+        self._fields = ["heading"]
 
 
 class FacingTowardSpecifier(AST):
@@ -161,6 +168,7 @@ class FacingTowardSpecifier(AST):
     def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.position = position
+        self._fields = ["position"]
 
 
 class ApparentlyFacingSpecifier(AST):
@@ -176,3 +184,4 @@ class ApparentlyFacingSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.heading = heading
         self.base = base
+        self._fields = ["heading", "base"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -1,4 +1,5 @@
 import ast
+from typing import Optional, Union
 
 
 class AST(ast.AST):
@@ -72,3 +73,40 @@ class OffsetAlongSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.direction = direction
         self.offset = offset
+
+
+class PositionSpecifier(AST):
+    __match_args__ = ("direction", "position", "distance")
+
+    def __init__(
+        self,
+        direction: Union["LeftOf", "RightOf", "AheadOf", "Behind"],
+        position: ast.AST,
+        distance: Optional[ast.AST],
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.direction = direction
+        self.position = position
+        self.distance = distance
+
+
+class LeftOf(AST):
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class RightOf(AST):
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class AheadOf(AST):
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class Behind(AST):
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -1,36 +1,54 @@
 import ast
 
+
 class AST(ast.AST):
     "Scenic AST base class"
+
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
 
+
 # special statements
 class EgoAssign(AST):
+    __match_args__ = ("value",)
+
     def __init__(self, value: any, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.value = value
         self._fields = ["value"]
 
+
 # Instance Creation
 
+
 class New(AST):
-    def __init__(self, className: str, specifiers: list, *args: any, **kwargs: any) -> None:
+    __match_args__ = ("className", "specifiers")
+
+    def __init__(
+        self, className: str, specifiers: list, *args: any, **kwargs: any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.className = className
         self.specifiers = specifiers
         self._fields = ["className", "specifiers"]
 
+
 # Specifiers
 
+
 class WithSpecifier(AST):
+    __match_args__ = ("prop", "value")
+
     def __init__(self, prop: str, value: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.prop = prop
         self.value = value
         self._fields = ["prop", "value"]
 
+
 class AtSpecifier(AST):
+    __match_args__ = ("position",)
+
     def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.position = position

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -120,3 +120,11 @@ class VisibleSpecifier(AST):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.base = base
+
+
+class InSpecifier(AST):
+    __match_args__ = ("region",)
+
+    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.region = region

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -31,7 +31,7 @@ class New(AST):
         super().__init__(*args, **kwargs)
         self.className = className
         self.specifiers = specifiers
-        self._fields = ["className", "specifiers"]
+        self._fields = ["specifiers"]
 
 
 # Specifiers
@@ -44,7 +44,7 @@ class WithSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.prop = prop
         self.value = value
-        self._fields = ["prop", "value"]
+        self._fields = ["value"]
 
 
 class AtSpecifier(AST):

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -29,3 +29,9 @@ class WithSpecifier(AST):
         self.prop = prop
         self.value = value
         self._fields = ["prop", "value"]
+
+class AtSpecifier(AST):
+    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.position = position
+        self._fields = ["position"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -53,3 +53,22 @@ class AtSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.position = position
         self._fields = ["position"]
+
+
+class OffsetBySpecifier(AST):
+    __match_args__ = ("offset",)
+
+    def __init__(self, offset: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.offset = offset
+
+
+class OffsetAlongSpecifier(AST):
+    __match_args__ = ("direction", "offset")
+
+    def __init__(
+        self, direction: ast.AST, offset: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.direction = direction
+        self.offset = offset

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -161,3 +161,18 @@ class FacingTowardSpecifier(AST):
     def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.position = position
+
+
+class ApparentlyFacingSpecifier(AST):
+    __match_args__ = ("heading", "base")
+
+    def __init__(
+        self,
+        heading: ast.AST,
+        base: Optional[ast.AST] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.heading = heading
+        self.base = base

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -110,3 +110,13 @@ class AheadOf(AST):
 class Behind(AST):
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
+
+
+class VisibleSpecifier(AST):
+    __match_args__ = ("base",)
+
+    def __init__(
+        self, base: Optional[ast.AST] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.base = base

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -128,3 +128,20 @@ class InSpecifier(AST):
     def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.region = region
+
+
+class FollowingSpecifier(AST):
+    __match_args__ = ("field", "distance", "base")
+
+    def __init__(
+        self,
+        field: ast.AST,
+        distance: ast.AST,
+        base: Optional[ast.AST] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.field = field
+        self.distance = distance
+        self.base = base

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -145,3 +145,11 @@ class FollowingSpecifier(AST):
         self.field = field
         self.distance = distance
         self.base = base
+
+
+class FacingSpecifier(AST):
+    __match_args__ = ("heading",)
+
+    def __init__(self, heading: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.heading = heading

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -154,3 +154,12 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.position)],
             keywords=[],
         )
+
+    def visit_ApparentlyFacingSpecifier(self, node: s.ApparentlyFacingSpecifier):
+        return ast.Call(
+            func=ast.Name(id="ApparentlyFacing", ctx=loadCtx),
+            args=[self.visit(node.heading)],
+            keywords=[ast.keyword(arg="fromPt", value=self.visit(node.base))]
+            if node.base is not None
+            else [],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1,5 +1,6 @@
 import ast
 from typing import Tuple, List
+
 import scenic.syntax.ast as s
 
 # exposed functions

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -131,3 +131,12 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.region)],
             keywords=[],
         )
+
+    def visit_FollowingSpecifier(self, node: s.FollowingSpecifier):
+        return ast.Call(
+            func=ast.Name(id="Following", ctx=loadCtx),
+            args=[self.visit(node.field), self.visit(node.distance)],
+            keywords=[ast.keyword(arg="fromPt", value=self.visit(node.base))]
+            if node.base is not None
+            else [],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -111,6 +111,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             ),
         )
 
+    def visit_BeyondSpecifier(self, node: s.BeyondSpecifier):
+        return ast.Call(
+            func=ast.Name(id="Beyond", ctx=loadCtx),
+            args=[self.visit(node.position), self.visit(node.offset)],
+            keywords=[ast.keyword(arg="fromPt", value=self.visit(node.base))]
+            if node.base is not None
+            else [],
+        )
+
     def visit_VisibleSpecifier(self, node: s.VisibleSpecifier):
         if node.base is not None:
             return ast.Call(

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -111,3 +111,16 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                 else [ast.keyword(arg="dist", value=self.visit(node.distance))]
             ),
         )
+
+    def visit_VisibleSpecifier(self, node: s.VisibleSpecifier):
+        if node.base is not None:
+            return ast.Call(
+                func=ast.Name(id="VisibleFrom", ctx=loadCtx),
+                args=[self.visit(node.base)],
+                keywords=[],
+            )
+        return ast.Call(
+            func=ast.Name(id="VisibleSpec", ctx=loadCtx),
+            args=[],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -140,3 +140,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             if node.base is not None
             else [],
         )
+
+    def visit_FacingSpecifier(self, node: s.FacingSpecifier):
+        return ast.Call(
+            func=ast.Name(id="Facing", ctx=loadCtx),
+            args=[self.visit(node.heading)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -53,3 +53,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             ],
             keywords=[],
         )
+
+    def visit_AtSpecifier(self, node: s.AtSpecifier):
+        return ast.Call(
+            func=ast.Name(id="At", ctx=loadCtx),
+            args=[node.position],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -97,9 +97,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         elif isinstance(node.direction, s.Behind):
             fn = "Behind"
         else:
-            raise TypeError(
-                f'"{node.direction.__class__.__name__}" cannot be used as a direction'
-            )
+            assert False, f"impossible direction {node.direction} in PositionSpecifier"
         return ast.Call(
             func=ast.Name(id=fn, ctx=loadCtx),
             args=[

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -4,11 +4,13 @@ import scenic.syntax.ast as s
 
 # exposed functions
 
+
 def compileScenicAST(scenicAST: ast.AST) -> Tuple[ast.AST, List[ast.AST]]:
     """Compiles Scenic AST to Python AST"""
     compiler = ScenicToPythonTransformer()
     node = ast.fix_missing_locations(compiler.visit(scenicAST))
     return node, compiler.requirements
+
 
 # shorthands for convenience
 
@@ -16,24 +18,29 @@ loadCtx = ast.Load()
 
 # transformer
 
+
 class ScenicToPythonTransformer(ast.NodeTransformer):
     def __init__(self) -> None:
         super().__init__()
         self.requirements = []
-    
+
     def generic_visit(self, node):
         if isinstance(node, s.AST):
-            raise Exception(f'Scenic AST node "{node.__class__.__name__}" needs visitor in compiler')
+            raise Exception(
+                f'Scenic AST node "{node.__class__.__name__}" needs visitor in compiler'
+            )
         return super().generic_visit(node)
-    
+
     # Special Case
 
     def visit_EgoAssign(self, node: s.EgoAssign):
-        return ast.Expr(value=ast.Call(
-            func=ast.Name(id="ego", ctx=loadCtx),
-            args=[self.visit(node.value)],
-            keywords=[],
-        ))
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="ego", ctx=loadCtx),
+                args=[self.visit(node.value)],
+                keywords=[],
+            )
+        )
 
     # Instance & Specifier
 
@@ -58,5 +65,24 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         return ast.Call(
             func=ast.Name(id="At", ctx=loadCtx),
             args=[node.position],
+            keywords=[],
+        )
+
+    def visit_OffsetBySpecifier(self, node: s.OffsetBySpecifier):
+        return ast.Call(
+            func=ast.Name(id="OffsetBy", ctx=loadCtx),
+            args=[
+                self.visit(node.offset),
+            ],
+            keywords=[],
+        )
+
+    def visit_OffsetAlongSpecifier(self, node: s.OffsetAlongSpecifier):
+        return ast.Call(
+            func=ast.Name(id="OffsetAlongSpec", ctx=loadCtx),
+            args=[
+                self.visit(node.direction),
+                self.visit(node.offset),
+            ],
             keywords=[],
         )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -43,3 +43,13 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[],
             keywords=[],
         )
+
+    def visit_WithSpecifier(self, node: s.WithSpecifier):
+        return ast.Call(
+            func=ast.Name(id="With", ctx=loadCtx),
+            args=[
+                ast.Constant(value=node.prop),
+                self.visit(node.value),
+            ],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -47,7 +47,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
     def visit_New(self, node: s.New):
         return ast.Call(
             func=ast.Name(id=node.className, ctx=loadCtx),
-            args=[],
+            args=[self.visit(s) for s in node.specifiers],
             keywords=[],
         )
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -86,3 +86,28 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             ],
             keywords=[],
         )
+
+    def visit_PositionSpecifier(self, node: s.PositionSpecifier):
+        if isinstance(node.direction, s.LeftOf):
+            fn = "LeftSpec"
+        elif isinstance(node.direction, s.RightOf):
+            fn = "RightSpec"
+        elif isinstance(node.direction, s.AheadOf):
+            fn = "Ahead"
+        elif isinstance(node.direction, s.Behind):
+            fn = "Behind"
+        else:
+            raise TypeError(
+                f'"{node.direction.__class__.__name__}" cannot be used as a direction'
+            )
+        return ast.Call(
+            func=ast.Name(id=fn, ctx=loadCtx),
+            args=[
+                self.visit(node.position),
+            ],
+            keywords=(
+                []
+                if node.distance is None
+                else [ast.keyword(arg="dist", value=self.visit(node.distance))]
+            ),
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -87,7 +87,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             keywords=[],
         )
 
-    def visit_PositionSpecifier(self, node: s.PositionSpecifier):
+    def visit_DirectionOfSpecifier(self, node: s.DirectionOfSpecifier):
         if isinstance(node.direction, s.LeftOf):
             fn = "LeftSpec"
         elif isinstance(node.direction, s.RightOf):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -147,3 +147,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.heading)],
             keywords=[],
         )
+
+    def visit_FacingTowardSpecifier(self, node: s.FacingTowardSpecifier):
+        return ast.Call(
+            func=ast.Name(id="FacingToward", ctx=loadCtx),
+            args=[self.visit(node.position)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -64,7 +64,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
     def visit_AtSpecifier(self, node: s.AtSpecifier):
         return ast.Call(
             func=ast.Name(id="At", ctx=loadCtx),
-            args=[node.position],
+            args=[self.visit(node.position)],
             keywords=[],
         )
 
@@ -122,5 +122,12 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         return ast.Call(
             func=ast.Name(id="VisibleSpec", ctx=loadCtx),
             args=[],
+            keywords=[],
+        )
+
+    def visit_InSpecifier(self, node: s.InSpecifier):
+        return ast.Call(
+            func=ast.Name(id="In", ctx=loadCtx),
+            args=[self.visit(node.region)],
             keywords=[],
         )

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1225,8 +1225,9 @@ scenic_specifier:
     | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
     | ('in' | 'on') r=expression { s.InSpecifier(region=r, LOCATIONS) }
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
-        s.FollowingSpecifier(field=f, distance=d, base=b)
+        s.FollowingSpecifier(field=f, distance=d, base=b, LOCATIONS)
      }
+    | "facing" h=expression { s.FacingSpecifier(heading=h, LOCATIONS) }
 
 scenic_specifier_position_direction:
     | "left" "of" { s.LeftOf(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1224,6 +1224,9 @@ scenic_specifier:
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
     | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
     | ('in' | 'on') r=expression { s.InSpecifier(region=r, LOCATIONS) }
+    | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
+        s.FollowingSpecifier(field=f, distance=d, base=b)
+     }
 
 scenic_specifier_position_direction:
     | "left" "of" { s.LeftOf(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1211,7 +1211,10 @@ inversion (memo):
 
 # Scenic instance creation
 # ------------------------
-scenic_new_expr: 'new' n=NAME { s.New(className=n.string, specifiers=[], LOCATIONS) } # TODO(shun): Support specifiers
+scenic_new_expr: 'new' n=NAME ss=[scenic_specifiers] { s.New(className=n.string, specifiers=ss, LOCATIONS) }
+scenic_specifiers: ss=','.scenic_specifier+ { ss }
+scenic_specifier:
+    | 'with' p=NAME v=expression { s.WithSpecifier(prop=p.string, value=v, LOCATIONS) }
 
 # Comparisons operators
 # ---------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1223,6 +1223,7 @@ scenic_specifier:
      }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
     | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
+    | ('in' | 'on') r=expression { s.InSpecifier(region=r, LOCATIONS) }
 
 scenic_specifier_position_direction:
     | "left" "of" { s.LeftOf(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1222,7 +1222,6 @@ scenic_specifier:
         s.DirectionOfSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
      }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
-    | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
     | ('in' | "on") r=expression { s.InSpecifier(region=r, LOCATIONS) }
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
         s.FollowingSpecifier(field=f, distance=d, base=b, LOCATIONS)

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1219,7 +1219,7 @@ scenic_specifier:
     | 'offset' 'by' o=expression { s.OffsetBySpecifier(offset=o, LOCATIONS) }
     | 'offset' 'along' d=expression 'by' o=expression { s.OffsetAlongSpecifier(direction=d, offset=o, LOCATIONS) }
     | direction=scenic_specifier_position_direction position=expression distance=['by' e=expression { e }] {
-        s.PositionSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
+        s.DirectionOfSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
      }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
     | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1223,7 +1223,7 @@ scenic_specifier:
      }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
     | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
-    | ('in' | 'on') r=expression { s.InSpecifier(region=r, LOCATIONS) }
+    | ('in' | "on") r=expression { s.InSpecifier(region=r, LOCATIONS) }
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
         s.FollowingSpecifier(field=f, distance=d, base=b, LOCATIONS)
      }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1221,6 +1221,7 @@ scenic_specifier:
     | direction=scenic_specifier_position_direction position=expression distance=['by' e=expression { e }] {
         s.DirectionOfSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
      }
+    | "beyond" v=expression 'by' o=expression b=['from' a=expression {a}] { s.BeyondSpecifier(position=v, offset=o, base=b) }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
     | ('in' | "on") r=expression { s.InSpecifier(region=r, LOCATIONS) }
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1221,6 +1221,8 @@ scenic_specifier:
     | direction=scenic_specifier_position_direction position=expression distance=['by' e=expression { e }] {
         s.PositionSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
      }
+    | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
+    | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
 
 scenic_specifier_position_direction:
     | "left" "of" { s.LeftOf(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1216,6 +1216,8 @@ scenic_specifiers: ss=','.scenic_specifier+ { ss }
 scenic_specifier:
     | 'with' p=NAME v=expression { s.WithSpecifier(prop=p.string, value=v, LOCATIONS) }
     | 'at' position=expression { s.AtSpecifier(position=position, LOCATIONS) }
+    | 'offset' 'by' o=expression { s.OffsetBySpecifier(offset=o, LOCATIONS) }
+    | 'offset' 'along' d=expression 'by' o=expression { s.OffsetAlongSpecifier(direction=d, offset=o, LOCATIONS) }
 
 # Comparisons operators
 # ---------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1229,6 +1229,9 @@ scenic_specifier:
      }
     | "facing" "toward" p=expression { s.FacingTowardSpecifier(position=p, LOCATIONS) }
     | "facing" h=expression { s.FacingSpecifier(heading=h, LOCATIONS) }
+    | "apparently" "facing" h=expression v=['from' a=expression { a }] {
+        s.ApparentlyFacingSpecifier(heading=h, base=v, LOCATIONS)
+     }
 
 scenic_specifier_position_direction:
     | "left" "of" { s.LeftOf(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1227,6 +1227,7 @@ scenic_specifier:
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
         s.FollowingSpecifier(field=f, distance=d, base=b, LOCATIONS)
      }
+    | "facing" "toward" p=expression { s.FacingTowardSpecifier(position=p, LOCATIONS) }
     | "facing" h=expression { s.FacingSpecifier(heading=h, LOCATIONS) }
 
 scenic_specifier_position_direction:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1218,6 +1218,15 @@ scenic_specifier:
     | 'at' position=expression { s.AtSpecifier(position=position, LOCATIONS) }
     | 'offset' 'by' o=expression { s.OffsetBySpecifier(offset=o, LOCATIONS) }
     | 'offset' 'along' d=expression 'by' o=expression { s.OffsetAlongSpecifier(direction=d, offset=o, LOCATIONS) }
+    | direction=scenic_specifier_position_direction position=expression distance=['by' e=expression { e }] {
+        s.PositionSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
+     }
+
+scenic_specifier_position_direction:
+    | "left" "of" { s.LeftOf(LOCATIONS) }
+    | "right" "of" { s.RightOf(LOCATIONS) }
+    | "ahead" "of" { s.AheadOf(LOCATIONS) }
+    | "behind" { s.Behind(LOCATIONS) }
 
 # Comparisons operators
 # ---------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1215,6 +1215,7 @@ scenic_new_expr: 'new' n=NAME ss=[scenic_specifiers] { s.New(className=n.string,
 scenic_specifiers: ss=','.scenic_specifier+ { ss }
 scenic_specifier:
     | 'with' p=NAME v=expression { s.WithSpecifier(prop=p.string, value=v, LOCATIONS) }
+    | 'at' position=expression { s.AtSpecifier(position=position, LOCATIONS) }
 
 # Comparisons operators
 # ---------------------

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -35,7 +35,25 @@ class TestCompiler:
     def test_at_specifier(self):
         node, _ = compileScenicAST(AtSpecifier(Name("x")))
         match node:
-            case Call(Name("At"), [Name(position)]):
-                assert position == "x"
+            case Call(Name("At"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_offset_by_specifier(self):
+        node, _ = compileScenicAST(OffsetBySpecifier(Name("x")))
+        match node:
+            case Call(Name("OffsetBy"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_offset_along_specifier(self):
+        node, _ = compileScenicAST(
+            OffsetAlongSpecifier(Name("direction"), Name("offset"))
+        )
+        match node:
+            case Call(Name("OffsetAlongSpec"), [Name("direction"), Name("offset")]):
+                assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -151,3 +151,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_facing_toward_specifier(self):
+        node, _ = compileScenicAST(FacingTowardSpecifier(Name("position")))
+        match node:
+            case Call(Name("FacingToward"), [Name("position")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -22,3 +22,12 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_with_specifier(self):
+        node, _ = compileScenicAST(WithSpecifier("foo", Constant(1)))
+        match node:
+            case Call(Name("With"), [Constant(prop), Constant(value)]):
+                assert prop == "foo"
+                assert value == 1
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -113,3 +113,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_in_specifier(self):
+        node, _ = compileScenicAST(InSpecifier(Name("region")))
+        match node:
+            case Call(Name("In"), [Name("region")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -132,7 +132,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_unknown_direction(self):
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             compileScenicAST(DirectionOfSpecifier(str(), Name("x"), None))
 
     def test_beyond_specifier(self):

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -143,3 +143,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_facing_specifier(self):
+        node, _ = compileScenicAST(FacingSpecifier(Name("heading")))
+        match node:
+            case Call(Name("Facing"), [Name("heading")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -122,7 +122,9 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_distance(self):
-        node, _ = compileScenicAST(DirectionOfSpecifier(Behind(), Name("x"), Constant(10)))
+        node, _ = compileScenicAST(
+            DirectionOfSpecifier(Behind(), Name("x"), Constant(10))
+        )
         match node:
             case Call(Name("Behind"), [Name("x")], [keyword("dist", Constant(10))]):
                 assert True

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -97,3 +97,19 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_visible_specifier(self):
+        node, _ = compileScenicAST(VisibleSpecifier())
+        match node:
+            case Call(Name("VisibleSpec")):
+                assert True
+            case _:
+                assert False
+
+    def test_visible_specifier_with_base(self):
+        node, _ = compileScenicAST(VisibleSpecifier(Name("x")))
+        match node:
+            case Call(Name("VisibleFrom"), [Name("x")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -136,6 +136,21 @@ class TestCompiler:
             compileScenicAST(DirectionOfSpecifier(str(), Name("x"), None))
         assert '"str" cannot be used as a direction' in str(excinfo.value)
 
+    def test_beyond_specifier(self):
+        node, _ = compileScenicAST(BeyondSpecifier(Name("x"), Name("y")))
+        match node:
+            case Call(Name("Beyond"), [Name("x"), Name("y")]):
+                assert True
+            case _:
+                assert False
+    def test_beyond_specifier_with_base(self):
+        node, _ = compileScenicAST(BeyondSpecifier(Name("x"), Name("y"), Name("z")))
+        match node:
+            case Call(Name("Beyond"), [Name("x"), Name("y")], [keyword("fromPt", Name("z"))]):
+                assert True
+            case _:
+                assert False
+
     def test_visible_specifier(self):
         node, _ = compileScenicAST(VisibleSpecifier())
         match node:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1,8 +1,8 @@
 from ast import *
 
 import pytest
-from scenic.syntax.ast import *
 
+from scenic.syntax.ast import *
 from scenic.syntax.compiler import compileScenicAST
 
 

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -90,7 +90,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_left(self):
-        node, _ = compileScenicAST(PositionSpecifier(LeftOf(), Name("x"), None))
+        node, _ = compileScenicAST(DirectionOfSpecifier(LeftOf(), Name("x"), None))
         match node:
             case Call(Name("LeftSpec"), [Name("x")]):
                 assert True
@@ -98,7 +98,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_right(self):
-        node, _ = compileScenicAST(PositionSpecifier(RightOf(), Name("x"), None))
+        node, _ = compileScenicAST(DirectionOfSpecifier(RightOf(), Name("x"), None))
         match node:
             case Call(Name("RightSpec"), [Name("x")]):
                 assert True
@@ -106,7 +106,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_ahead(self):
-        node, _ = compileScenicAST(PositionSpecifier(AheadOf(), Name("x"), None))
+        node, _ = compileScenicAST(DirectionOfSpecifier(AheadOf(), Name("x"), None))
         match node:
             case Call(Name("Ahead"), [Name("x")]):
                 assert True
@@ -114,7 +114,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_behind(self):
-        node, _ = compileScenicAST(PositionSpecifier(Behind(), Name("x"), None))
+        node, _ = compileScenicAST(DirectionOfSpecifier(Behind(), Name("x"), None))
         match node:
             case Call(Name("Behind"), [Name("x")]):
                 assert True
@@ -122,7 +122,7 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_distance(self):
-        node, _ = compileScenicAST(PositionSpecifier(Behind(), Name("x"), Constant(10)))
+        node, _ = compileScenicAST(DirectionOfSpecifier(Behind(), Name("x"), Constant(10)))
         match node:
             case Call(Name("Behind"), [Name("x")], [keyword("dist", Constant(10))]):
                 assert True
@@ -131,7 +131,7 @@ class TestCompiler:
 
     def test_position_specifier_unknown_direction(self):
         with pytest.raises(TypeError) as excinfo:
-            compileScenicAST(PositionSpecifier(str(), Name("x"), None))
+            compileScenicAST(DirectionOfSpecifier(str(), Name("x"), None))
         assert '"str" cannot be used as a direction' in str(excinfo.value)
 
     def test_visible_specifier(self):

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1,4 +1,6 @@
 from ast import *
+
+import pytest
 from scenic.syntax.ast import *
 
 from scenic.syntax.compiler import compileScenicAST
@@ -97,6 +99,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_position_specifier_unknown_direction(self):
+        with pytest.raises(TypeError) as excinfo:
+            compileScenicAST(PositionSpecifier(str(), Name("x"), None))
+        assert '"str" cannot be used as a direction' in str(excinfo.value)
 
     def test_visible_specifier(self):
         node, _ = compileScenicAST(VisibleSpecifier())

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -159,3 +159,25 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_apparently_facing_specifier(self):
+        node, _ = compileScenicAST(ApparentlyFacingSpecifier(Name("heading")))
+        match node:
+            case Call(Name("ApparentlyFacing"), [Name("heading")]):
+                assert True
+            case _:
+                assert False
+
+    def test_apparently_facing_specifier_from(self):
+        node, _ = compileScenicAST(
+            ApparentlyFacingSpecifier(Name("heading"), Name("base"))
+        )
+        match node:
+            case Call(
+                Name("ApparentlyFacing"),
+                [Name("heading")],
+                [keyword("fromPt", Name("base"))],
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -121,3 +121,25 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_following_specifier(self):
+        node, _ = compileScenicAST(FollowingSpecifier(Name("field"), Name("distance")))
+        match node:
+            case Call(Name("Following"), [Name("field"), Name("distance")]):
+                assert True
+            case _:
+                assert False
+
+    def test_following_specifier_from(self):
+        node, _ = compileScenicAST(
+            FollowingSpecifier(Name("field"), Name("distance"), Name("base"))
+        )
+        match node:
+            case Call(
+                Name("Following"),
+                [Name("field"), Name("distance")],
+                [keyword("fromPt", Name("base"))],
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -132,9 +132,8 @@ class TestCompiler:
                 assert False
 
     def test_position_specifier_unknown_direction(self):
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(AssertionError) as excinfo:
             compileScenicAST(DirectionOfSpecifier(str(), Name("x"), None))
-        assert '"str" cannot be used as a direction' in str(excinfo.value)
 
     def test_beyond_specifier(self):
         node, _ = compileScenicAST(BeyondSpecifier(Name("x"), Name("y")))

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -25,6 +25,35 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_new_one_specifier(self):
+        node, _ = compileScenicAST(New("Object", [WithSpecifier("foo", Constant(1))]))
+        match node:
+            case Call(
+                Name("Object"), [Call(Name("With"), [Constant("foo"), Constant(1)])]
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_new_multiple_specifiers(self):
+        node, _ = compileScenicAST(
+            New(
+                "Object",
+                [WithSpecifier("foo", Constant(1)), AtSpecifier(Name("position"))],
+            )
+        )
+        match node:
+            case Call(
+                Name("Object"),
+                [
+                    Call(Name("With"), [Constant("foo"), Constant(1)]),
+                    Call(Name("At"), [Name("position")]),
+                ],
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_with_specifier(self):
         node, _ = compileScenicAST(WithSpecifier("foo", Constant(1)))
         match node:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -142,10 +142,13 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
     def test_beyond_specifier_with_base(self):
         node, _ = compileScenicAST(BeyondSpecifier(Name("x"), Name("y"), Name("z")))
         match node:
-            case Call(Name("Beyond"), [Name("x"), Name("y")], [keyword("fromPt", Name("z"))]):
+            case Call(
+                Name("Beyond"), [Name("x"), Name("y")], [keyword("fromPt", Name("z"))]
+            ):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -57,3 +57,43 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_position_specifier_left(self):
+        node, _ = compileScenicAST(PositionSpecifier(LeftOf(), Name("x"), None))
+        match node:
+            case Call(Name("LeftSpec"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_position_specifier_right(self):
+        node, _ = compileScenicAST(PositionSpecifier(RightOf(), Name("x"), None))
+        match node:
+            case Call(Name("RightSpec"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_position_specifier_ahead(self):
+        node, _ = compileScenicAST(PositionSpecifier(AheadOf(), Name("x"), None))
+        match node:
+            case Call(Name("Ahead"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_position_specifier_behind(self):
+        node, _ = compileScenicAST(PositionSpecifier(Behind(), Name("x"), None))
+        match node:
+            case Call(Name("Behind"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
+    def test_position_specifier_distance(self):
+        node, _ = compileScenicAST(PositionSpecifier(Behind(), Name("x"), Constant(10)))
+        match node:
+            case Call(Name("Behind"), [Name("x")], [keyword("dist", Constant(10))]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -31,3 +31,11 @@ class TestCompiler:
                 assert value == 1
             case _:
                 assert False
+
+    def test_at_specifier(self):
+        node, _ = compileScenicAST(AtSpecifier(Name("x")))
+        match node:
+            case Call(Name("At"), [Name(position)]):
+                assert position == "x"
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -250,3 +250,17 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_facing(self):
+        mod = parse_string_helper("new Object facing heading")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [FacingSpecifier(Name("heading"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -115,7 +115,9 @@ class TestNew:
         mod = parse_string_helper("new Object left of left")
         stmt = mod.body[0]
         match stmt:
-            case Expr(New("Object", [DirectionOfSpecifier(LeftOf(), Name("left"), None)])):
+            case Expr(
+                New("Object", [DirectionOfSpecifier(LeftOf(), Name("left"), None)])
+            ):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -169,6 +169,34 @@ class TestNew:
             case _:
                 assert False
 
+    def test_specifier_beyond(self):
+        mod = parse_string_helper("new Object beyond position by distance")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [BeyondSpecifier(Name("position"), Name("distance"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_beyond_from(self):
+        mod = parse_string_helper("new Object beyond position by distance from base")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [BeyondSpecifier(Name("position"), Name("distance"), Name("base"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_specifier_visible(self):
         mod = parse_string_helper("new Object visible")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -17,8 +17,8 @@ class TestEgoAssign:
         mod = parse_string_helper("ego = 10")
         stmt = mod.body[0]
         match stmt:
-            case EgoAssign(value=Constant(value=v)):
-                assert v == 10
+            case EgoAssign(Constant(10)):
+                assert True
             case _:
                 assert False
 
@@ -26,8 +26,8 @@ class TestEgoAssign:
         mod = parse_string_helper("ego = new Object")
         stmt = mod.body[0]
         match stmt:
-            case EgoAssign(value=New(className=c)):
-                assert c == "Object"
+            case EgoAssign(New("Object")):
+                assert True
             case _:
                 assert False
 
@@ -42,8 +42,8 @@ class TestNew:
         mod = parse_string_helper("new Object")
         stmt = mod.body[0]
         match stmt:
-            case Expr(value=New(className=c)):
-                assert c == "Object"
+            case Expr(New("Object")):
+                assert True
             case _:
                 assert False
 
@@ -52,14 +52,12 @@ class TestNew:
         stmt = mod.body[0]
         match stmt:
             case Expr(
-                value=New(
-                    className=c,
-                    specifiers=[WithSpecifier(prop=prop, value=Constant(value=value))],
+                New(
+                    "Object",
+                    [WithSpecifier("foo", Constant(1))],
                 )
             ):
-                assert c == "Object"
-                assert prop == "foo"
-                assert value == 1
+                assert True
             case _:
                 assert False
 
@@ -68,12 +66,12 @@ class TestNew:
         stmt = mod.body[0]
         match stmt:
             case Expr(
-                value=New(
-                    className="Object",
-                    specifiers=[
-                        WithSpecifier(prop="foo", value=Constant(value=1)),
-                        WithSpecifier(prop="bar", value=Constant(value=2)),
-                        WithSpecifier(prop="baz", value=Constant(value=3)),
+                New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
                     ],
                 )
             ):
@@ -87,10 +85,10 @@ class TestNew:
         match stmt:
             case Expr(
                 New(
-                    className="Object",
-                    specifiers=[AtSpecifier(position=Name(position))],
+                    "Object",
+                    [AtSpecifier(Name("x"))],
                 )
             ):
-                assert position == "x"
+                assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -110,3 +110,59 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_position_left(self):
+        mod = parse_string_helper("new Object left of left")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(New("Object", [PositionSpecifier(LeftOf(), Name("left"), None)])):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_position_right(self):
+        mod = parse_string_helper("new Object right of right")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New("Object", [PositionSpecifier(RightOf(), Name("right"), None)])
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_position_ahead(self):
+        mod = parse_string_helper("new Object ahead of ahead")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New("Object", [PositionSpecifier(AheadOf(), Name("ahead"), None)])
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_position_behind(self):
+        mod = parse_string_helper("new Object behind behind")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New("Object", [PositionSpecifier(Behind(), Name("behind"), None)])
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_position_by(self):
+        mod = parse_string_helper("new Object left of left by distance")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [PositionSpecifier(LeftOf(), Name("left"), Name("distance"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1,9 +1,9 @@
-import pytest
+from ast import *
 from typing import Any
 
-from ast import *
-from scenic.syntax.ast import *
+import pytest
 
+from scenic.syntax.ast import *
 from scenic.syntax.parser import parse_string
 
 

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -92,3 +92,21 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_offset_by(self):
+        mod = parse_string_helper("new Object offset by x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(New("Object", [OffsetBySpecifier(Name("x"))])):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_offset_along(self):
+        mod = parse_string_helper("new Object offset along x by y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(New("Object", [OffsetAlongSpecifier(Name("x"), Name("y"))])):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -264,3 +264,18 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+
+    def test_specifier_facing_toward(self):
+        mod = parse_string_helper("new Object facing toward position")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [FacingTowardSpecifier(Name("position"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -115,7 +115,7 @@ class TestNew:
         mod = parse_string_helper("new Object left of left")
         stmt = mod.body[0]
         match stmt:
-            case Expr(New("Object", [PositionSpecifier(LeftOf(), Name("left"), None)])):
+            case Expr(New("Object", [DirectionOfSpecifier(LeftOf(), Name("left"), None)])):
                 assert True
             case _:
                 assert False
@@ -125,7 +125,7 @@ class TestNew:
         stmt = mod.body[0]
         match stmt:
             case Expr(
-                New("Object", [PositionSpecifier(RightOf(), Name("right"), None)])
+                New("Object", [DirectionOfSpecifier(RightOf(), Name("right"), None)])
             ):
                 assert True
             case _:
@@ -136,7 +136,7 @@ class TestNew:
         stmt = mod.body[0]
         match stmt:
             case Expr(
-                New("Object", [PositionSpecifier(AheadOf(), Name("ahead"), None)])
+                New("Object", [DirectionOfSpecifier(AheadOf(), Name("ahead"), None)])
             ):
                 assert True
             case _:
@@ -147,7 +147,7 @@ class TestNew:
         stmt = mod.body[0]
         match stmt:
             case Expr(
-                New("Object", [PositionSpecifier(Behind(), Name("behind"), None)])
+                New("Object", [DirectionOfSpecifier(Behind(), Name("behind"), None)])
             ):
                 assert True
             case _:
@@ -160,7 +160,7 @@ class TestNew:
             case Expr(
                 New(
                     "Object",
-                    [PositionSpecifier(LeftOf(), Name("left"), Name("distance"))],
+                    [DirectionOfSpecifier(LeftOf(), Name("left"), Name("distance"))],
                 )
             ):
                 assert True

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -166,3 +166,31 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_visible(self):
+        mod = parse_string_helper("new Object visible")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [VisibleSpecifier(None)],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_visible_from(self):
+        mod = parse_string_helper("new Object visible from base")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [VisibleSpecifier(Name("base"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -222,3 +222,31 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_following(self):
+        mod = parse_string_helper("new Object following field for distance")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [FollowingSpecifier(Name("field"), Name("distance"), None)],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_following_from(self):
+        mod = parse_string_helper("new Object following field from base for distance")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [FollowingSpecifier(Name("field"), Name("distance"), Name("base"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -47,4 +47,38 @@ class TestNew:
             case _:
                 assert False
 
-    # TODO(shun): Add tests for specifiers
+    def test_specifier_single(self):
+        mod = parse_string_helper("new Object with foo 1")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                value=New(
+                    className=c,
+                    specifiers=[
+                        WithSpecifier(prop=prop, value=Constant(value=value))
+                    ],
+                )
+            ):
+                assert c == "Object"
+                assert prop == "foo"
+                assert value == 1
+            case _:
+                assert False
+
+    def test_specifier_multiple(self):
+        mod = parse_string_helper("new Object with foo 1, with bar 2, with baz 3")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                value=New(
+                    className="Object",
+                    specifiers=[
+                        WithSpecifier(prop="foo", value=Constant(value=1)),
+                        WithSpecifier(prop="bar", value=Constant(value=2)),
+                        WithSpecifier(prop="baz", value=Constant(value=3)),
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -194,3 +194,31 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+    def test_specifier_in(self):
+        mod = parse_string_helper("new Object in region")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [InSpecifier(Name("region"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_on(self):
+        mod = parse_string_helper("new Object on region")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [InSpecifier(Name("region"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -265,7 +265,6 @@ class TestNew:
             case _:
                 assert False
 
-
     def test_specifier_facing_toward(self):
         mod = parse_string_helper("new Object facing toward position")
         stmt = mod.body[0]
@@ -274,6 +273,34 @@ class TestNew:
                 New(
                     "Object",
                     [FacingTowardSpecifier(Name("position"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_apparently_facing(self):
+        mod = parse_string_helper("new Object apparently facing heading")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [ApparentlyFacingSpecifier(Name("heading"), None)],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_apparently_facing_from(self):
+        mod = parse_string_helper("new Object apparently facing heading from base")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [ApparentlyFacingSpecifier(Name("heading"), Name("base"))],
                 )
             ):
                 assert True

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -54,9 +54,7 @@ class TestNew:
             case Expr(
                 value=New(
                     className=c,
-                    specifiers=[
-                        WithSpecifier(prop=prop, value=Constant(value=value))
-                    ],
+                    specifiers=[WithSpecifier(prop=prop, value=Constant(value=value))],
                 )
             ):
                 assert c == "Object"
@@ -80,5 +78,19 @@ class TestNew:
                 )
             ):
                 assert True
+            case _:
+                assert False
+
+    def test_specifier_at(self):
+        mod = parse_string_helper("new Object at x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    className="Object",
+                    specifiers=[AtSpecifier(position=Name(position))],
+                )
+            ):
+                assert position == "x"
             case _:
                 assert False


### PR DESCRIPTION
## Overview

This PR adds specifiers to the new parser.

## Changes

### Grammar

`scenic.gram` now contains grammar rules for specifiers. Currently, it does not support specifiers that span multiple lines, as it requires changes in the tokenizer. I added this to the TODO list.

### AST

Added AST nodes for representing specifiers. Each node now contains `__match_args__` so `test_parser.py` can pattern match on these nodes without specifying keywords for arguments. (See 9516b87feb957354091acc24fe6c4fd78e9f207c for details).

### Compiler

Added visitors for each specifier node. The visitor for `New` now handles specifiers.

## Notes

- `not visible` and `facing away from` are listed as specifiers in the documentation but are not implemented in the current version of the Scenic. I did not include these two specifiers in this PR.
- Most keywords are defined as soft keywords, so words like "left" "facing" and "following" can be used as variable names, etc. outside the specifier context.
  - See https://we-like-parsers.github.io/pegen/peg_parsers.html?highlight=soft#hard-and-soft-keywords for more information on hard and soft keywords
- I have not updated the existing tests yet because most of the cases in `test_specifiers` depend on some Scenic operators. I will do this once I have implemented enough features to be able to see results.


