### PR TITLE
[Parser] Implement Operators

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -400,6 +400,86 @@ class NotVisibleOp(AST):
         self._fields = ["region"]
 
 
+class PositionOfOp(AST):
+    __match_args__ = ("position", "target")
+
+    def __init__(
+        self,
+        position: Union[
+            "Front",
+            "Back",
+            "Left",
+            "Right",
+            "FrontLeft",
+            "FrontRight",
+            "BackLeft",
+            "BackRight",
+        ],
+        target: ast.AST,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.position = position
+        self.target = target
+
+
+class Front(AST):
+    "Represents position of `front of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class Back(AST):
+    "Represents position of `back of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class Left(AST):
+    "Represents position of `left of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class Right(AST):
+    "Represents position of `right of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class FrontLeft(AST):
+    "Represents position of `front left of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class FrontRight(AST):
+    "Represents position of `front right of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class BackLeft(AST):
+    "Represents position of `back left of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class BackRight(AST):
+    "Represents position of `back right of` operator"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
 class VectorOp(AST):
     __match_args__ = ("left", "right")
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -378,3 +378,11 @@ class VisibleOp(AST):
         super().__init__(*args, **kwargs)
         self.region = region
         self._fields = ["region"]
+
+class NotVisibleOp(AST):
+    __match_args__ = ("region",)
+
+    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.region = region
+        self._fields = ["region"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -330,8 +330,9 @@ class DistanceFromOp(AST):
 
     def __init__(
         self,
-        target: ast.AST,  # to
-        base: Optional[ast.AST] = None,  # from
+        # because `to` and `from` are symmetric, the first operand will be `target` and the second will be `base`
+        target: ast.AST,
+        base: Optional[ast.AST] = None,
         *args: any,
         **kwargs: any
     ) -> None:

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -351,3 +351,21 @@ class AngleFromOp(AST):
         self.target = target
         self.base = base
         self._fields = ["target", "base"]
+
+
+class FollowOp(AST):
+    __match_args__ = ("target", "base", "distance")
+
+    def __init__(
+        self,
+        target: ast.AST,
+        base: ast.AST,
+        distance: ast.AST,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self.distance = distance
+        self._fields = ["target", "base", "distance"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -402,10 +402,22 @@ class NotVisibleOp(AST):
 
 class VectorOp(AST):
     __match_args__ = ("left", "right")
+
     def __init__(
         self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.left = left
         self.right = right
-        self._fields=["left", "right"]
+        self._fields = ["left", "right"]
+
+
+class FieldAtOp(AST):
+    __match_args__ = ("left", "right")
+
+    def __init__(
+        self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.left = left
+        self.right = right

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -299,3 +299,15 @@ class RelativeHeadingOp(AST):
         self.target = target
         self.base = base
         self._fields = ["target", "base"]
+
+class ApparentHeadingOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self._fields = ["target", "base"]
+

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -398,3 +398,14 @@ class NotVisibleOp(AST):
         super().__init__(*args, **kwargs)
         self.region = region
         self._fields = ["region"]
+
+
+class VectorOp(AST):
+    __match_args__ = ("left", "right")
+    def __init__(
+        self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.left = left
+        self.right = right
+        self._fields=["left", "right"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -298,6 +298,7 @@ class RelativePositionOp(AST):
         super().__init__(*args, **kwargs)
         self.target = target
         self.base = base
+        self._fields = ["target", "base"]
 
 
 class RelativeHeadingOp(AST):

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -286,3 +286,16 @@ class ApparentlyFacingSpecifier(AST):
         self.heading = heading
         self.base = base
         self._fields = ["heading", "base"]
+
+
+# Operators
+class RelativeHeadingOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self._fields = ["target", "base"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -289,6 +289,17 @@ class ApparentlyFacingSpecifier(AST):
 
 
 # Operators
+class RelativePositionOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+
+
 class RelativeHeadingOp(AST):
     __match_args__ = ("target", "base")
 
@@ -378,6 +389,7 @@ class VisibleOp(AST):
         super().__init__(*args, **kwargs)
         self.region = region
         self._fields = ["region"]
+
 
 class NotVisibleOp(AST):
     __match_args__ = ("region",)

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -300,6 +300,7 @@ class RelativeHeadingOp(AST):
         self.base = base
         self._fields = ["target", "base"]
 
+
 class ApparentHeadingOp(AST):
     __match_args__ = ("target", "base")
 
@@ -311,3 +312,14 @@ class ApparentHeadingOp(AST):
         self.base = base
         self._fields = ["target", "base"]
 
+
+class DistanceFromOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self._fields = ["target", "base"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -528,15 +528,15 @@ class RelativeToOp(AST):
 
 
 class OffsetAlongOp(AST):
-    __match_args__ = ("left", "middle", "right")
+    __match_args__ = ("base", "direction", "offset")
 
     def __init__(
-        self, left: ast.AST, middle: ast.AST, right: ast.AST, *args: any, **kwargs: any
+        self, base: ast.AST, direction: ast.AST, offset: ast.AST, *args: any, **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.left = left
-        self.middle = middle
-        self.right = right
+        self.base = base
+        self.direction = direction
+        self.offset = offset
 
 
 class CanSeeOp(AST):

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -531,7 +531,12 @@ class OffsetAlongOp(AST):
     __match_args__ = ("base", "direction", "offset")
 
     def __init__(
-        self, base: ast.AST, direction: ast.AST, offset: ast.AST, *args: any, **kwargs: any
+        self,
+        base: ast.AST,
+        direction: ast.AST,
+        offset: ast.AST,
+        *args: any,
+        **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.base = base

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -421,3 +421,14 @@ class FieldAtOp(AST):
         super().__init__(*args, **kwargs)
         self.left = left
         self.right = right
+
+
+class RelativeToOp(AST):
+    __match_args__ = ("left", "right")
+
+    def __init__(
+        self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.left = left
+        self.right = right

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -330,8 +330,8 @@ class DistanceFromOp(AST):
 
     def __init__(
         self,
-        target: Optional[ast.AST] = None, # to
-        base: Optional[ast.AST] = None, # from
+        target: Optional[ast.AST] = None,  # to
+        base: Optional[ast.AST] = None,  # from
         *args: any,
         **kwargs: any
     ) -> None:

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -329,7 +329,11 @@ class DistanceFromOp(AST):
     __match_args__ = ("target", "base")
 
     def __init__(
-        self, target: ast.AST, base: Optional[ast.AST] = None, *args: any, **kwargs: any
+        self,
+        target: Optional[ast.AST] = None, # to
+        base: Optional[ast.AST] = None, # from
+        *args: any,
+        **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.target = target

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -317,7 +317,19 @@ class DistanceFromOp(AST):
     __match_args__ = ("target", "base")
 
     def __init__(
-        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
+        self, target: ast.AST, base: Optional[ast.AST] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self._fields = ["target", "base"]
+
+
+class DistancePastOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self, target: ast.AST, base: Optional[ast.AST] = None, *args: any, **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.target = target

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -444,3 +444,14 @@ class OffsetAlongOp(AST):
         self.left = left
         self.middle = middle
         self.right = right
+
+
+class CanSeeOp(AST):
+    __match_args__ = ("left", "right")
+
+    def __init__(
+        self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.left = left
+        self.right = right

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -369,3 +369,12 @@ class FollowOp(AST):
         self.base = base
         self.distance = distance
         self._fields = ["target", "base", "distance"]
+
+
+class VisibleOp(AST):
+    __match_args__ = ("region",)
+
+    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.region = region
+        self._fields = ["region"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -431,6 +431,7 @@ class PositionOfOp(AST):
 
 class Front(AST):
     "Represents position of `front of` operator"
+    functionName = "Front"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -438,6 +439,7 @@ class Front(AST):
 
 class Back(AST):
     "Represents position of `back of` operator"
+    functionName = "Back"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -445,6 +447,7 @@ class Back(AST):
 
 class Left(AST):
     "Represents position of `left of` operator"
+    functionName = "Left"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -452,6 +455,7 @@ class Left(AST):
 
 class Right(AST):
     "Represents position of `right of` operator"
+    functionName = "Right"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -459,6 +463,7 @@ class Right(AST):
 
 class FrontLeft(AST):
     "Represents position of `front left of` operator"
+    functionName = "FrontLeft"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -466,6 +471,7 @@ class FrontLeft(AST):
 
 class FrontRight(AST):
     "Represents position of `front right of` operator"
+    functionName = "FrontRight"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -473,6 +479,7 @@ class FrontRight(AST):
 
 class BackLeft(AST):
     "Represents position of `back left of` operator"
+    functionName = "BackLeft"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
@@ -480,6 +487,7 @@ class BackLeft(AST):
 
 class BackRight(AST):
     "Represents position of `back right of` operator"
+    functionName = "BackRight"
 
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -432,3 +432,15 @@ class RelativeToOp(AST):
         super().__init__(*args, **kwargs)
         self.left = left
         self.right = right
+
+
+class OffsetAlongOp(AST):
+    __match_args__ = ("left", "middle", "right")
+
+    def __init__(
+        self, left: ast.AST, middle: ast.AST, right: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.left = left
+        self.middle = middle
+        self.right = right

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -330,7 +330,7 @@ class DistanceFromOp(AST):
 
     def __init__(
         self,
-        target: Optional[ast.AST] = None,  # to
+        target: ast.AST,  # to
         base: Optional[ast.AST] = None,  # from
         *args: any,
         **kwargs: any

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -480,6 +480,14 @@ class BackRight(AST):
         super().__init__(*args, **kwargs)
 
 
+class DegOp(AST):
+    __match_args__ = ("operand",)
+
+    def __init__(self, operand: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.operand = operand
+
+
 class VectorOp(AST):
     __match_args__ = ("left", "right")
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -335,3 +335,19 @@ class DistancePastOp(AST):
         self.target = target
         self.base = base
         self._fields = ["target", "base"]
+
+
+class AngleFromOp(AST):
+    __match_args__ = ("target", "base")
+
+    def __init__(
+        self,
+        target: Optional[ast.AST] = None,
+        base: Optional[ast.AST] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.target = target
+        self.base = base
+        self._fields = ["target", "base"]

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -367,3 +367,14 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.left), self.visit(node.right)],
             keywords=[],
         )
+
+    def visit_OffsetAlongOp(self, node: s.OffsetAlongOp):
+        return ast.Call(
+            func=ast.Name(id="OffsetAlong", ctx=loadCtx),
+            args=[
+                self.visit(node.left),
+                self.visit(node.middle),
+                self.visit(node.right),
+            ],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -293,20 +293,13 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_DistanceFromOp(self, node: s.DistanceFromOp):
-        def createCall(X: ast.AST, Y: Optional[ast.AST] = None):
-            return ast.Call(
-                func=ast.Name(id="DistanceFrom", ctx=loadCtx),
-                args=[X],
-                keywords=[ast.keyword(arg="Y", value=Y)] if Y is not None else [],
-            )
-
-        if node.target is not None and node.base is not None:
-            return createCall(self.visit(node.target), self.visit(node.base))
-        if node.target is not None:
-            return createCall(self.visit(node.target))
-        if node.base is not None:
-            return createCall(self.visit(node.base))
-        assert False, "neither target nor base were specified in DistanceFromOp"
+        return ast.Call(
+            func=ast.Name(id="DistanceFrom", ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[ast.keyword(arg="Y", value=self.visit(node.base))]
+            if node.base is not None
+            else [],
+        )
 
     def visit_DistancePastOp(self, node: s.DistancePastOp):
         return ast.Call(

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -370,6 +370,11 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             keywords=[],
         )
 
+    def visit_DegOp(self, node: s.DegOp):
+        return ast.BinOp(
+            left=self.visit(node.operand), op=ast.Mult(), right=ast.Constant(0.01745329)
+        )
+
     def visit_VectorOp(self, node: s.VectorOp):
         return ast.Call(
             func=ast.Name(id="Vector", ctx=loadCtx),

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -358,24 +358,8 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_PositionOfOp(self, node: s.PositionOfOp):
-        classToFunctionName = {
-            s.Front: "Front",
-            s.Back: "Back",
-            s.Left: "Left",
-            s.Right: "Right",
-            s.FrontLeft: "FrontLeft",
-            s.FrontRight: "FrontRight",
-            s.BackLeft: "BackLeft",
-            s.BackRight: "BackRight",
-        }
-        f = None
-        for c, n in classToFunctionName.items():
-            if isinstance(node.position, c):
-                f = n
-                break
-        assert f is not None, f"impossible position {node.position.__class__.__name__}"
         return ast.Call(
-            func=ast.Name(id=f, ctx=loadCtx),
+            func=ast.Name(id=node.position.functionName, ctx=loadCtx),
             args=[self.visit(node.target)],
             keywords=[],
         )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -360,3 +360,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.left), self.visit(node.right)],
             keywords=[],
         )
+
+    def visit_RelativeToOp(self, node: s.RelativeToOp):
+        return ast.Call(
+            func=ast.Name(id="RelativeTo", ctx=loadCtx),
+            args=[self.visit(node.left), self.visit(node.right)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -347,6 +347,29 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             keywords=[],
         )
 
+    def visit_PositionOfOp(self, node: s.PositionOfOp):
+        classToFunctionName = {
+            s.Front: "Front",
+            s.Back: "Back",
+            s.Left: "Left",
+            s.Right: "Right",
+            s.FrontLeft: "FrontLeft",
+            s.FrontRight: "FrontRight",
+            s.BackLeft: "BackLeft",
+            s.BackRight: "BackRight",
+        }
+        f = None
+        for c, n in classToFunctionName.items():
+            if isinstance(node.position, c):
+                f = n
+                break
+        assert f is not None, f"impossible position {node.position.__class__.__name__}"
+        return ast.Call(
+            func=ast.Name(id=f, ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[],
+        )
+
     def visit_VectorOp(self, node: s.VectorOp):
         return ast.Call(
             func=ast.Name(id="Vector", ctx=loadCtx),

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -299,6 +299,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                 args=[X],
                 keywords=[ast.keyword(arg="Y", value=Y)] if Y is not None else [],
             )
+
         if node.target is not None and node.base is not None:
             return createCall(self.visit(node.target), self.visit(node.base))
         if node.target is not None:
@@ -320,12 +321,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         assert (
             node.base is not None or node.target is not None
         ), "neither target nor base were specified in AngleFromOp"
-        base = ego if node.base is None else self.visit(node.base)
-        target = ego if node.target is None else self.visit(node.target)
+        keywords = []
+        if node.base is not None:
+            keywords.append(ast.keyword("X", self.visit(node.base)))
+        if node.target is not None:
+            keywords.append(ast.keyword("Y", self.visit(node.target)))
         return ast.Call(
             func=ast.Name(id="AngleFrom", ctx=loadCtx),
-            args=[base, target],
-            keywords=[],
+            args=[],
+            keywords=keywords,
         )
 
     def visit_FollowOp(self, node: s.FollowOp):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -401,9 +401,9 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         return ast.Call(
             func=ast.Name(id="OffsetAlong", ctx=loadCtx),
             args=[
-                self.visit(node.left),
-                self.visit(node.middle),
-                self.visit(node.right),
+                self.visit(node.base),
+                self.visit(node.direction),
+                self.visit(node.offset),
             ],
             keywords=[],
         )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1,4 +1,5 @@
 import ast
+from json import load
 from typing import Tuple, List
 
 import scenic.syntax.ast as s
@@ -309,5 +310,16 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         return ast.Call(
             func=ast.Name(id="AngleFrom", ctx=loadCtx),
             args=[base, target],
+            keywords=[],
+        )
+
+    def visit_FollowOp(self, node: s.FollowOp):
+        return ast.Call(
+            func=ast.Name(id="Follow", ctx=loadCtx),
+            args=[
+                self.visit(node.target),
+                self.visit(node.base),
+                self.visit(node.distance),
+            ],
             keywords=[],
         )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -378,3 +378,13 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             ],
             keywords=[],
         )
+
+    def visit_CanSeeOp(self, node: s.CanSeeOp):
+        return ast.Call(
+            func=ast.Name(id="CanSee", ctx=loadCtx),
+            args=[
+                self.visit(node.left),
+                self.visit(node.right),
+            ],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -266,6 +266,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     # Operators
 
+    def visit_RelativePositionOp(self, node: s.RelativePositionOp):
+        return ast.Call(
+            func=ast.Name(id="RelativePosition", ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[]
+            if node.base is None
+            else [ast.keyword(arg="Y", value=self.visit(node.base))],
+        )
+
     def visit_RelativeHeadingOp(self, node: s.RelativeHeadingOp):
         return ast.Call(
             func=ast.Name(id="RelativeHeading", ctx=loadCtx),

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -261,3 +261,14 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             if node.base is not None
             else [],
         )
+
+    # Operators
+
+    def visit_RelativeHeadingOp(self, node: s.RelativeHeadingOp):
+        return ast.Call(
+            func=ast.Name(id="RelativeHeading", ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[]
+            if node.base is None
+            else [ast.keyword(arg="Y", value=self.visit(node.base))],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -323,3 +323,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             ],
             keywords=[],
         )
+
+    def visit_VisibleOp(self, node: s.VisibleOp):
+        return ast.Call(
+            func=ast.Name(id="Visible", ctx=loadCtx),
+            args=[self.visit(node.region)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -16,6 +16,7 @@ def compileScenicAST(scenicAST: ast.AST) -> Tuple[ast.AST, List[ast.AST]]:
 # shorthands for convenience
 
 loadCtx = ast.Load()
+ego = ast.Name("ego")
 
 noArgs = ast.arguments(
     posonlyargs=[],
@@ -298,4 +299,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             keywords=[]
             if node.base is None
             else [ast.keyword(arg="Y", value=self.visit(node.base))],
+        )
+
+    def visit_AngleFromOp(self, node: s.AngleFromOp):
+        if node.base is None and node.target is None:
+            assert False, "neither target nor base were specified in AngleFromOp"
+        base = ego if node.base is None else self.visit(node.base)
+        target = ego if node.target is None else self.visit(node.target)
+        return ast.Call(
+            func=ast.Name(id="AngleFrom", ctx=loadCtx),
+            args=[base, target],
+            keywords=[],
         )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -272,3 +272,12 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             if node.base is None
             else [ast.keyword(arg="Y", value=self.visit(node.base))],
         )
+
+    def visit_ApparentHeadingOp(self, node: s.ApparentHeadingOp):
+        return ast.Call(
+            func=ast.Name(id="ApparentHeading", ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[]
+            if node.base is None
+            else [ast.keyword(arg="Y", value=self.visit(node.base))],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -293,12 +293,13 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_DistanceFromOp(self, node: s.DistanceFromOp):
+        assert node.target is not None or node.base is not None
+        target = ego if node.target is None else self.visit(node.target)
+        base = ego if node.base is None else self.visit(node.base)
         return ast.Call(
             func=ast.Name(id="DistanceFrom", ctx=loadCtx),
-            args=[self.visit(node.target)],
-            keywords=[]
-            if node.base is None
-            else [ast.keyword(arg="Y", value=self.visit(node.base))],
+            args=[target],
+            keywords=[ast.keyword(arg="Y", value=base)],
         )
 
     def visit_DistancePastOp(self, node: s.DistancePastOp):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -330,3 +330,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.region)],
             keywords=[],
         )
+
+    def visit_NotVisibleOp(self, node: s.VisibleOp):
+        return ast.Call(
+            func=ast.Name(id="NotVisible", ctx=loadCtx),
+            args=[self.visit(node.region)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -281,3 +281,12 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             if node.base is None
             else [ast.keyword(arg="Y", value=self.visit(node.base))],
         )
+
+    def visit_DistanceFromOp(self, node: s.DistanceFromOp):
+        return ast.Call(
+            func=ast.Name(id="DistanceFrom", ctx=loadCtx),
+            args=[self.visit(node.base)],
+            keywords=[]
+            if node.target is None
+            else [ast.keyword(arg="Y", value=self.visit(node.target))],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -311,8 +311,9 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_AngleFromOp(self, node: s.AngleFromOp):
-        if node.base is None and node.target is None:
-            assert False, "neither target nor base were specified in AngleFromOp"
+        assert (
+            node.base is not None or node.target is not None
+        ), "neither target nor base were specified in AngleFromOp"
         base = ego if node.base is None else self.visit(node.base)
         target = ego if node.target is None else self.visit(node.target)
         return ast.Call(

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -353,3 +353,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.left), self.visit(node.right)],
             keywords=[],
         )
+
+    def visit_FieldAtOp(self, node: s.FieldAtOp):
+        return ast.Call(
+            func=ast.Name(id="FieldAt", ctx=loadCtx),
+            args=[self.visit(node.left), self.visit(node.right)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1,5 +1,4 @@
 import ast
-from json import load
 from typing import Tuple, List
 
 import scenic.syntax.ast as s

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -346,3 +346,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             args=[self.visit(node.region)],
             keywords=[],
         )
+
+    def visit_VectorOp(self, node: s.VectorOp):
+        return ast.Call(
+            func=ast.Name(id="Vector", ctx=loadCtx),
+            args=[self.visit(node.left), self.visit(node.right)],
+            keywords=[],
+        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -285,8 +285,17 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
     def visit_DistanceFromOp(self, node: s.DistanceFromOp):
         return ast.Call(
             func=ast.Name(id="DistanceFrom", ctx=loadCtx),
-            args=[self.visit(node.base)],
+            args=[self.visit(node.target)],
             keywords=[]
-            if node.target is None
-            else [ast.keyword(arg="Y", value=self.visit(node.target))],
+            if node.base is None
+            else [ast.keyword(arg="Y", value=self.visit(node.base))],
+        )
+
+    def visit_DistancePastOp(self, node: s.DistancePastOp):
+        return ast.Call(
+            func=ast.Name(id="DistancePast", ctx=loadCtx),
+            args=[self.visit(node.target)],
+            keywords=[]
+            if node.base is None
+            else [ast.keyword(arg="Y", value=self.visit(node.base))],
         )

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1351,6 +1351,7 @@ primary:
 
 scenic_prefix_operators:
     | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2) }
+    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2) }
     | atom
 
 slices:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1357,8 +1357,8 @@ scenic_prefix_operators:
     | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
-    | "visible" e=expression { s.VisibleOp(region=e) }
-    | 'not' "visible" e=expression { s.NotVisibleOp(region=e) }
+    | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
+    | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
     | atom
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1351,6 +1351,7 @@ primary:
     | scenic_prefix_operators
 
 scenic_prefix_operators:
+    | "relative" "position" "of" e1=expression e2=['from' x=expression {x}] { s.RelativePositionOp(target=e1, base=e2, LOCATIONS) }
     | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
     | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
     | &"distance" scenic_distance_from_op

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1352,7 +1352,13 @@ primary:
 scenic_prefix_operators:
     | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2) }
     | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2) }
+    | &"distance" scenic_distance_from_op
     | atom
+
+scenic_distance_from_op:
+    | "distance" 'from' e1=expression 'to' e2=expression { s.DistanceFromOp(base=e1, target=e2) }
+    | "distance" 'to' e1=expression 'from' e2=expression { s.DistanceFromOp(target=e1, base=e2) }
+    | "distance" ('to'|'from') e1=expression { s.DistanceFromOp(target=e1) }
 
 slices:
     | a=slice !',' { a }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1356,6 +1356,7 @@ scenic_prefix_operators:
     | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
+    | "visible" e=expression { s.VisibleOp(region=e) }
     | atom
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1296,7 +1296,7 @@ bitwise_xor:
     | bitwise_and
 
 scenic_bitwise_xor:
-    | a=bitwise_xor "offset" "along" b=bitwise_xor "by" c=bitwise_and { s.OffsetAlongOp(left=a, middle=b, right=c, LOCATIONS) }
+    | a=bitwise_xor "offset" "along" b=bitwise_xor "by" c=bitwise_and { s.OffsetAlongOp(base=a, direction=b, offset=c, LOCATIONS) }
 
 bitwise_and:
     | scenic_bitwise_and

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1332,6 +1332,7 @@ scenic_prefix_operators:
     # distance past
     | "distance" "past" e1=expression 'of' e2=scenic_prefix_operators { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | "distance" "past" e1=scenic_prefix_operators { s.DistancePastOp(target=e1, LOCATIONS) }
+    # angle from/to
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
@@ -1346,10 +1347,10 @@ scenic_distance_from_op:
     | "distance" 'from' e2=scenic_prefix_operators { s.DistanceFromOp(base=e2, LOCATIONS) }
 
 scenic_angle_from_op:
-    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }
-    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
-    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1, LOCATIONS) }
-    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1, LOCATIONS) }
+    | "angle" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }
+    | "angle" 'to' e1=expression 'from' e2=scenic_prefix_operators { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
+    | "angle" 'to' e1=scenic_prefix_operators { s.AngleFromOp(target=e1, LOCATIONS) }
+    | "angle" 'from' e1=scenic_prefix_operators { s.AngleFromOp(base=e1, LOCATIONS) }
 
 scenic_position_of_op_position:
     | "front" "left" { s.FrontLeft(LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1336,7 +1336,7 @@ scenic_prefix_operators:
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=scenic_prefix_operators { s.VisibleOp(region=e, LOCATIONS) }
-    | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
+    | 'not' "visible" e=scenic_prefix_operators { s.NotVisibleOp(region=e, LOCATIONS) }
     | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
     | sum
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1337,7 +1337,7 @@ scenic_prefix_operators:
     | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=scenic_prefix_operators { s.VisibleOp(region=e, LOCATIONS) }
     | 'not' "visible" e=scenic_prefix_operators { s.NotVisibleOp(region=e, LOCATIONS) }
-    | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
+    | p=scenic_position_of_op_position 'of' e=scenic_prefix_operators { s.PositionOfOp(position=p, target=e, LOCATIONS) }
     | sum
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1283,8 +1283,12 @@ is_bitwise_or: 'is' a=bitwise_or { (ast.Is(), a) }
 # -----------------
 
 bitwise_or:
+    | scenic_bitwise_or
     | a=bitwise_or '|' b=bitwise_xor { ast.BinOp(left=a, op=ast.BitOr(), right=b, LOCATIONS) }
     | bitwise_xor
+
+scenic_bitwise_or:
+    | a=bitwise_or "can" "see" b=bitwise_xor { s.CanSeeOp(left=a, right=b, LOCATIONS) }
 
 bitwise_xor:
     | scenic_bitwise_xor

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1327,8 +1327,11 @@ scenic_prefix_operators:
     # apparent heading of
     | "apparent" "heading" "of" e1=expression 'from' e2=scenic_prefix_operators { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
     | "apparent" "heading" "of" e1=scenic_prefix_operators { s.ApparentHeadingOp(target=e1, LOCATIONS) }
+    # distance from/to
     | &"distance" scenic_distance_from_op
-    | "distance" "past" e1=expression e2=['of' x=scenic_prefix_operators {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
+    # distance past
+    | "distance" "past" e1=expression 'of' e2=scenic_prefix_operators { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
+    | "distance" "past" e1=scenic_prefix_operators { s.DistancePastOp(target=e1, LOCATIONS) }
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1210,8 +1210,8 @@ conjunction (memo):
     | inversion
 
 inversion (memo):
-    # [SCENIC NOTE]: Fail `not visible` to be handled later
-    | 'not' !"visible" a=inversion { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
+    # [SCENIC NOTE]: Fail `not visible <inversion>` to be handled later
+    | 'not' !("visible" inversion) a=inversion { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
     | comparison
 
 # Scenic instance creation

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1380,6 +1380,7 @@ scenic_prefix_operators:
     | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
     | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
+    | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
     | atom
 
 scenic_distance_from_op:
@@ -1392,6 +1393,16 @@ scenic_angle_from_op:
     | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
     | "angle" 'to' e1=expression { s.AngleFromOp(target=e1, LOCATIONS) }
     | "angle" 'from' e1=expression { s.AngleFromOp(base=e1, LOCATIONS) }
+
+scenic_position_of_op_position:
+    | "front" "left" { s.FrontLeft(LOCATIONS) }
+    | "front" "right" { s.FrontRight(LOCATIONS) }
+    | "back" "left" { s.BackLeft(LOCATIONS) }
+    | "back" "right" { s.BackRight(LOCATIONS) }
+    | "front" { s.Front(LOCATIONS) }
+    | "back" { s.Back(LOCATIONS) }
+    | "left" { s.Left(LOCATIONS) }
+    | "right" { s.Right(LOCATIONS) }
 
 slices:
     | a=slice !',' { a }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1287,8 +1287,12 @@ bitwise_or:
     | bitwise_xor
 
 bitwise_xor:
+    | scenic_bitwise_xor
     | a=bitwise_xor '^' b=bitwise_and { ast.BinOp(left=a, op=ast.BitXor(), right=b, LOCATIONS) }
     | bitwise_and
+
+scenic_bitwise_xor:
+    | a=bitwise_xor "offset" "along" b=bitwise_xor "by" c=bitwise_and { s.OffsetAlongOp(left=a, middle=b, right=c, LOCATIONS) }
 
 bitwise_and:
     | scenic_bitwise_and

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1347,6 +1347,10 @@ primary:
         )
      }
     | a=primary '[' b=slices ']' { ast.Subscript(value=a, slice=b, ctx=Load, LOCATIONS) }
+    | scenic_prefix_operators
+
+scenic_prefix_operators:
+    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2) }
     | atom
 
 slices:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1310,10 +1310,48 @@ shift_expr:
     | scenic_shift_expr
     | a=shift_expr '<<' b=sum { ast.BinOp(left=a, op=ast.LShift(), right=b, LOCATIONS) }
     | a=shift_expr '>>' b=sum { ast.BinOp(left=a, op=ast.RShift(), right=b, LOCATIONS) }
-    | sum
+    | scenic_prefix_operators
 
 scenic_shift_expr:
     | a=shift_expr 'at' b=sum { s.FieldAtOp(left=a, right=b, LOCATIONS) }
+
+# Scenic prefix operators
+# -----------------------
+scenic_prefix_operators:
+    # relative position of
+    | "relative" "position" "of" e1=expression 'from' e2=scenic_prefix_operators { s.RelativePositionOp(target=e1, base=e2, LOCATIONS) }
+    | "relative" "position" "of" e1=scenic_prefix_operators { s.RelativePositionOp(target=e1, LOCATIONS) }
+    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
+    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
+    | &"distance" scenic_distance_from_op
+    | "distance" "past" e1=expression e2=['of' x=scenic_prefix_operators {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
+    | &"angle" scenic_angle_from_op
+    | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
+    | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
+    | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
+    | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
+    | sum
+
+scenic_distance_from_op:
+    | "distance" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.DistanceFromOp(base=e1, target=e2, LOCATIONS) }
+    | "distance" 'to' e1=expression 'from' e2=scenic_prefix_operators { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
+    | "distance" ('to'|'from') e1=scenic_prefix_operators { s.DistanceFromOp(target=e1, LOCATIONS) }
+
+scenic_angle_from_op:
+    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }
+    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
+    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1, LOCATIONS) }
+    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1, LOCATIONS) }
+
+scenic_position_of_op_position:
+    | "front" "left" { s.FrontLeft(LOCATIONS) }
+    | "front" "right" { s.FrontRight(LOCATIONS) }
+    | "back" "left" { s.BackLeft(LOCATIONS) }
+    | "back" "right" { s.BackRight(LOCATIONS) }
+    | "front" { s.Front(LOCATIONS) }
+    | "back" { s.Back(LOCATIONS) }
+    | "left" { s.Left(LOCATIONS) }
+    | "right" { s.Right(LOCATIONS) }
 
 # Arithmetic operators
 # --------------------
@@ -1369,41 +1407,7 @@ primary:
         )
      }
     | a=primary '[' b=slices ']' { ast.Subscript(value=a, slice=b, ctx=Load, LOCATIONS) }
-    | scenic_prefix_operators
-
-scenic_prefix_operators:
-    | "relative" "position" "of" e1=expression e2=['from' x=expression {x}] { s.RelativePositionOp(target=e1, base=e2, LOCATIONS) }
-    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
-    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
-    | &"distance" scenic_distance_from_op
-    | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
-    | &"angle" scenic_angle_from_op
-    | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
-    | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
-    | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
-    | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
     | atom
-
-scenic_distance_from_op:
-    | "distance" 'from' e1=expression 'to' e2=expression { s.DistanceFromOp(base=e1, target=e2, LOCATIONS) }
-    | "distance" 'to' e1=expression 'from' e2=expression { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
-    | "distance" ('to'|'from') e1=expression { s.DistanceFromOp(target=e1, LOCATIONS) }
-
-scenic_angle_from_op:
-    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }
-    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
-    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1, LOCATIONS) }
-    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1, LOCATIONS) }
-
-scenic_position_of_op_position:
-    | "front" "left" { s.FrontLeft(LOCATIONS) }
-    | "front" "right" { s.FrontRight(LOCATIONS) }
-    | "back" "left" { s.BackLeft(LOCATIONS) }
-    | "back" "right" { s.BackRight(LOCATIONS) }
-    | "front" { s.Front(LOCATIONS) }
-    | "back" { s.Back(LOCATIONS) }
-    | "left" { s.Left(LOCATIONS) }
-    | "right" { s.Right(LOCATIONS) }
 
 slices:
     | a=slice !',' { a }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1324,7 +1324,9 @@ scenic_prefix_operators:
     # relative heading of
     | "relative" "heading" "of" e1=expression 'from' e2=scenic_prefix_operators { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
     | "relative" "heading" "of" e1=scenic_prefix_operators { s.RelativeHeadingOp(target=e1, LOCATIONS) }
-    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
+    # apparent heading of
+    | "apparent" "heading" "of" e1=expression 'from' e2=scenic_prefix_operators { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
+    | "apparent" "heading" "of" e1=scenic_prefix_operators { s.ApparentHeadingOp(target=e1, LOCATIONS) }
     | &"distance" scenic_distance_from_op
     | "distance" "past" e1=expression e2=['of' x=scenic_prefix_operators {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | &"angle" scenic_angle_from_op

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1308,6 +1308,7 @@ sum:
     | term
 
 term:
+    | scenic_term
     | a=term '*' b=factor { ast.BinOp(left=a, op=ast.Mult(), right=b, LOCATIONS) }
     | a=term '/' b=factor { ast.BinOp(left=a, op=ast.Div(), right=b, LOCATIONS) }
     | a=term '//' b=factor { ast.BinOp(left=a, op=ast.FloorDiv(), right=b, LOCATIONS) }
@@ -1316,6 +1317,9 @@ term:
         self.check_version((3, 5), "The '@' operator is", ast.BinOp(left=a, op=ast.MatMult(), right=b, LOCATIONS))
      }
     | factor
+
+scenic_term:
+    | a=term '@' b=factor { s.VectorOp(left=a, right=b, LOCATIONS) }
 
 factor (memo):
     | '+' a=factor { ast.UnaryOp(op=ast.UAdd(), operand=a, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1337,10 +1337,9 @@ scenic_prefix_operators:
     | sum
 
 scenic_distance_from_op:
-    | "distance" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.DistanceFromOp(base=e1, target=e2, LOCATIONS) }
+    | "distance" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
     | "distance" 'to' e1=expression 'from' e2=scenic_prefix_operators { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
-    | "distance" 'to' e1=scenic_prefix_operators { s.DistanceFromOp(target=e1, LOCATIONS) }
-    | "distance" 'from' e2=scenic_prefix_operators { s.DistanceFromOp(base=e2, LOCATIONS) }
+    | "distance" ('to'|'from') e1=scenic_prefix_operators { s.DistanceFromOp(target=e1, LOCATIONS) }
 
 scenic_angle_from_op:
     | "angle" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1355,6 +1355,7 @@ scenic_prefix_operators:
     | &"distance" scenic_distance_from_op
     | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | &"angle" scenic_angle_from_op
+    | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | atom
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1339,7 +1339,8 @@ scenic_prefix_operators:
 scenic_distance_from_op:
     | "distance" 'from' e1=expression 'to' e2=scenic_prefix_operators { s.DistanceFromOp(base=e1, target=e2, LOCATIONS) }
     | "distance" 'to' e1=expression 'from' e2=scenic_prefix_operators { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
-    | "distance" ('to'|'from') e1=scenic_prefix_operators { s.DistanceFromOp(target=e1, LOCATIONS) }
+    | "distance" 'to' e1=scenic_prefix_operators { s.DistanceFromOp(target=e1, LOCATIONS) }
+    | "distance" 'from' e2=scenic_prefix_operators { s.DistanceFromOp(base=e2, LOCATIONS) }
 
 scenic_angle_from_op:
     | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1336,6 +1336,7 @@ term:
 
 scenic_term:
     | a=term '@' b=factor { s.VectorOp(left=a, right=b, LOCATIONS) }
+    | a=term "deg" { s.DegOp(operand=a, LOCATIONS) }
 
 factor (memo):
     | '+' a=factor { ast.UnaryOp(op=ast.UAdd(), operand=a, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1354,12 +1354,19 @@ scenic_prefix_operators:
     | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2) }
     | &"distance" scenic_distance_from_op
     | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2) }
+    | &"angle" scenic_angle_from_op
     | atom
 
 scenic_distance_from_op:
     | "distance" 'from' e1=expression 'to' e2=expression { s.DistanceFromOp(base=e1, target=e2) }
     | "distance" 'to' e1=expression 'from' e2=expression { s.DistanceFromOp(target=e1, base=e2) }
     | "distance" ('to'|'from') e1=expression { s.DistanceFromOp(target=e1) }
+
+scenic_angle_from_op:
+    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2) }
+    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2) }
+    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1) }
+    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1) }
 
 slices:
     | a=slice !',' { a }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1291,8 +1291,12 @@ bitwise_xor:
     | bitwise_and
 
 bitwise_and:
+    | scenic_bitwise_and
     | a=bitwise_and '&' b=shift_expr { ast.BinOp(left=a, op=ast.BitAnd(), right=b, LOCATIONS) }
     | shift_expr
+
+scenic_bitwise_and:
+    | a=bitwise_and ("relative" "to" | "offset" "by") b=shift_expr { s.RelativeToOp(left=a, right=b, LOCATIONS) }
 
 shift_expr:
     | scenic_shift_expr

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1283,37 +1283,33 @@ is_bitwise_or: 'is' a=bitwise_or { (ast.Is(), a) }
 # -----------------
 
 bitwise_or:
-    | scenic_bitwise_or
+    | scenic_can_see
     | a=bitwise_or '|' b=bitwise_xor { ast.BinOp(left=a, op=ast.BitOr(), right=b, LOCATIONS) }
     | bitwise_xor
 
-scenic_bitwise_or:
-    | a=bitwise_or "can" "see" b=bitwise_xor { s.CanSeeOp(left=a, right=b, LOCATIONS) }
+scenic_can_see: a=bitwise_or "can" "see" b=bitwise_xor { s.CanSeeOp(left=a, right=b, LOCATIONS) }
 
 bitwise_xor:
-    | scenic_bitwise_xor
+    | scenic_offset_along
     | a=bitwise_xor '^' b=bitwise_and { ast.BinOp(left=a, op=ast.BitXor(), right=b, LOCATIONS) }
     | bitwise_and
 
-scenic_bitwise_xor:
-    | a=bitwise_xor "offset" "along" b=bitwise_xor "by" c=bitwise_and { s.OffsetAlongOp(base=a, direction=b, offset=c, LOCATIONS) }
+scenic_offset_along: a=bitwise_xor "offset" "along" b=bitwise_xor "by" c=bitwise_and { s.OffsetAlongOp(base=a, direction=b, offset=c, LOCATIONS) }
 
 bitwise_and:
-    | scenic_bitwise_and
+    | scenic_relative_to
     | a=bitwise_and '&' b=shift_expr { ast.BinOp(left=a, op=ast.BitAnd(), right=b, LOCATIONS) }
     | shift_expr
 
-scenic_bitwise_and:
-    | a=bitwise_and ("relative" "to" | "offset" "by") b=shift_expr { s.RelativeToOp(left=a, right=b, LOCATIONS) }
+scenic_relative_to: a=bitwise_and ("relative" "to" | "offset" "by") b=shift_expr { s.RelativeToOp(left=a, right=b, LOCATIONS) }
 
 shift_expr:
-    | scenic_shift_expr
+    | scenic_at
     | a=shift_expr '<<' b=sum { ast.BinOp(left=a, op=ast.LShift(), right=b, LOCATIONS) }
     | a=shift_expr '>>' b=sum { ast.BinOp(left=a, op=ast.RShift(), right=b, LOCATIONS) }
     | scenic_prefix_operators
 
-scenic_shift_expr:
-    | a=shift_expr 'at' b=sum { s.FieldAtOp(left=a, right=b, LOCATIONS) }
+scenic_at: a=shift_expr 'at' b=sum { s.FieldAtOp(left=a, right=b, LOCATIONS) }
 
 # Scenic prefix operators
 # -----------------------
@@ -1371,7 +1367,8 @@ sum:
     | term
 
 term:
-    | scenic_term
+    | scenic_vector
+    | scenic_deg
     | a=term '*' b=factor { ast.BinOp(left=a, op=ast.Mult(), right=b, LOCATIONS) }
     | a=term '/' b=factor { ast.BinOp(left=a, op=ast.Div(), right=b, LOCATIONS) }
     | a=term '//' b=factor { ast.BinOp(left=a, op=ast.FloorDiv(), right=b, LOCATIONS) }
@@ -1381,9 +1378,8 @@ term:
      }
     | factor
 
-scenic_term:
-    | a=term '@' b=factor { s.VectorOp(left=a, right=b, LOCATIONS) }
-    | a=term "deg" { s.DegOp(operand=a, LOCATIONS) }
+scenic_vector: a=term '@' b=factor { s.VectorOp(left=a, right=b, LOCATIONS) }
+scenic_deg: a=term "deg" { s.DegOp(operand=a, LOCATIONS) }
 
 factor (memo):
     | '+' a=factor { ast.UnaryOp(op=ast.UAdd(), operand=a, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1210,7 +1210,8 @@ conjunction (memo):
     | inversion
 
 inversion (memo):
-    | 'not' a=inversion { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
+    # [SCENIC NOTE]: Fail `not visible` to be handled later
+    | 'not' !"visible" a=inversion { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
     | comparison
 
 # Scenic instance creation
@@ -1357,6 +1358,7 @@ scenic_prefix_operators:
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=expression { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
     | "visible" e=expression { s.VisibleOp(region=e) }
+    | 'not' "visible" e=expression { s.NotVisibleOp(region=e) }
     | atom
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1350,23 +1350,23 @@ primary:
     | scenic_prefix_operators
 
 scenic_prefix_operators:
-    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2) }
-    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2) }
+    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
+    | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
     | &"distance" scenic_distance_from_op
-    | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2) }
+    | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }
     | &"angle" scenic_angle_from_op
     | atom
 
 scenic_distance_from_op:
-    | "distance" 'from' e1=expression 'to' e2=expression { s.DistanceFromOp(base=e1, target=e2) }
-    | "distance" 'to' e1=expression 'from' e2=expression { s.DistanceFromOp(target=e1, base=e2) }
-    | "distance" ('to'|'from') e1=expression { s.DistanceFromOp(target=e1) }
+    | "distance" 'from' e1=expression 'to' e2=expression { s.DistanceFromOp(base=e1, target=e2, LOCATIONS) }
+    | "distance" 'to' e1=expression 'from' e2=expression { s.DistanceFromOp(target=e1, base=e2, LOCATIONS) }
+    | "distance" ('to'|'from') e1=expression { s.DistanceFromOp(target=e1, LOCATIONS) }
 
 scenic_angle_from_op:
-    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2) }
-    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2) }
-    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1) }
-    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1) }
+    | "angle" 'from' e1=expression 'to' e2=expression { s.AngleFromOp(base=e1, target=e2, LOCATIONS) }
+    | "angle" 'to' e1=expression 'from' e2=expression { s.AngleFromOp(target=e1, base=e2, LOCATIONS) }
+    | "angle" 'to' e1=expression { s.AngleFromOp(target=e1, LOCATIONS) }
+    | "angle" 'from' e1=expression { s.AngleFromOp(base=e1, LOCATIONS) }
 
 slices:
     | a=slice !',' { a }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1321,7 +1321,9 @@ scenic_prefix_operators:
     # relative position of
     | "relative" "position" "of" e1=expression 'from' e2=scenic_prefix_operators { s.RelativePositionOp(target=e1, base=e2, LOCATIONS) }
     | "relative" "position" "of" e1=scenic_prefix_operators { s.RelativePositionOp(target=e1, LOCATIONS) }
-    | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
+    # relative heading of
+    | "relative" "heading" "of" e1=expression 'from' e2=scenic_prefix_operators { s.RelativeHeadingOp(target=e1, base=e2, LOCATIONS) }
+    | "relative" "heading" "of" e1=scenic_prefix_operators { s.RelativeHeadingOp(target=e1, LOCATIONS) }
     | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2, LOCATIONS) }
     | &"distance" scenic_distance_from_op
     | "distance" "past" e1=expression e2=['of' x=scenic_prefix_operators {x}] { s.DistancePastOp(target=e1, base=e2, LOCATIONS) }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1295,9 +1295,13 @@ bitwise_and:
     | shift_expr
 
 shift_expr:
+    | scenic_shift_expr
     | a=shift_expr '<<' b=sum { ast.BinOp(left=a, op=ast.LShift(), right=b, LOCATIONS) }
     | a=shift_expr '>>' b=sum { ast.BinOp(left=a, op=ast.RShift(), right=b, LOCATIONS) }
     | sum
+
+scenic_shift_expr:
+    | a=shift_expr 'at' b=sum { s.FieldAtOp(left=a, right=b, LOCATIONS) }
 
 # Arithmetic operators
 # --------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1335,7 +1335,7 @@ scenic_prefix_operators:
     # angle from/to
     | &"angle" scenic_angle_from_op
     | "follow" e1=expression 'from' e2=expression 'for' e3=scenic_prefix_operators { s.FollowOp(target=e1, base=e2, distance=e3, LOCATIONS) }
-    | "visible" e=expression { s.VisibleOp(region=e, LOCATIONS) }
+    | "visible" e=scenic_prefix_operators { s.VisibleOp(region=e, LOCATIONS) }
     | 'not' "visible" e=expression { s.NotVisibleOp(region=e, LOCATIONS) }
     | p=scenic_position_of_op_position 'of' e=expression { s.PositionOfOp(position=p, target=e, LOCATIONS) }
     | sum

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1353,6 +1353,7 @@ scenic_prefix_operators:
     | "relative" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.RelativeHeadingOp(target=e1, base=e2) }
     | "apparent" "heading" "of" e1=expression e2=['from' x=expression {x}] { s.ApparentHeadingOp(target=e1, base=e2) }
     | &"distance" scenic_distance_from_op
+    | "distance" "past" e1=expression e2=['of' x=expression {x}] { s.DistancePastOp(target=e1, base=e2) }
     | atom
 
 scenic_distance_from_op:

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -781,14 +781,20 @@ def DistancePast(X, Y=None):
 	Y = toType(Y, OrientedPoint, '"distance past X of Y" with Y not an OrientedPoint')
 	return Y.distancePast(X)
 
+# TODO(shun): Migrate to `AngleFrom`
 def AngleTo(X):
 	"""The 'angle to <vector>' operator (using the position of ego as the reference)."""
 	X = toVector(X, '"angle to X" with X not a vector')
 	return ego().angleTo(X)
 
-def AngleFrom(X, Y):
+def AngleFrom(X=None, Y=None):
 	"""The 'angle from <vector> to <vector>' operator."""
+	assert X is not None or Y is not None
+	if X is None:
+		X = ego()
 	X = toVector(X, '"angle from X to Y" with X not a vector')
+	if Y is None:
+		Y = ego()
 	Y = toVector(Y, '"angle from X to Y" with Y not a vector')
 	return X.angleTo(Y)
 

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -560,3 +560,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_can_see_op(self):
+        node, _ = compileScenicAST(CanSeeOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("CanSee"), [Name("X"), Name("Y")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -552,3 +552,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_offset_along_op(self):
+        node, _ = compileScenicAST(OffsetAlongOp(Name("X"), Name("Y"), Name("Z")))
+        match node:
+            case Call(Name("OffsetAlong"), [Name("X"), Name("Y"), Name("Z")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -403,3 +403,27 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+    
+    def test_relative_heading_op_base(self):
+        node, _ = compileScenicAST(RelativeHeadingOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("RelativeHeading"), [Name("X")], [keyword("Y", Name("Y"))]):
+                assert True
+            case _:
+                assert False
+
+    def test_apparent_heading_op(self):
+        node, _ = compileScenicAST(ApparentHeadingOp(Name("X")))
+        match node:
+            case Call(Name("ApparentHeading"), [Name("X")]):
+                assert True
+            case _:
+                assert False
+    
+    def test_apparent_heading_op_base(self):
+        node, _ = compileScenicAST(ApparentHeadingOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("ApparentHeading"), [Name("X")], [keyword("Y", Name("Y"))]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -544,3 +544,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_relative_to_op(self):
+        node, _ = compileScenicAST(RelativeToOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("RelativeTo"), [Name("X"), Name("Y")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -542,11 +542,19 @@ class TestCompiler:
             (BackRight, "BackRight"),
         ],
     )
-    def test_left_of_op(self, node, function_name):
+    def test_position_of_op(self, node, function_name):
         node, _ = compileScenicAST(PositionOfOp(node(), Name("X")))
         match node:
             case Call(Name(f), [Name("X")]):
                 assert f == function_name
+            case _:
+                assert False
+
+    def test_deg_op(self):
+        node, _ = compileScenicAST(DegOp(Name("X")))
+        match node:
+            case BinOp(Name("X"), Mult(), Constant()):
+                assert True
             case _:
                 assert False
 

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -529,6 +529,27 @@ class TestCompiler:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "node,function_name",
+        [
+            (Front, "Front"),
+            (Back, "Back"),
+            (Left, "Left"),
+            (Right, "Right"),
+            (FrontLeft, "FrontLeft"),
+            (FrontRight, "FrontRight"),
+            (BackLeft, "BackLeft"),
+            (BackRight, "BackRight"),
+        ],
+    )
+    def test_left_of_op(self, node, function_name):
+        node, _ = compileScenicAST(PositionOfOp(node(), Name("X")))
+        match node:
+            case Call(Name(f), [Name("X")]):
+                assert f == function_name
+            case _:
+                assert False
+
     def test_vector_op(self):
         node, _ = compileScenicAST(VectorOp(Name("X"), Name("Y")))
         match node:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -488,3 +488,11 @@ class TestCompiler:
         with pytest.raises(AssertionError):
             # target or base needs to be set
             compileScenicAST(AngleFromOp())
+
+    def test_follow_op(self):
+        node, _ = compileScenicAST(FollowOp(Name("X"), Name("Y"), Name("Z")))
+        match node:
+            case Call(Name("Follow"), [Name("X"), Name("Y"), Name("Z")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -404,7 +404,6 @@ class TestCompiler:
             case _:
                 assert False
 
-
     def test_relative_position_op_base(self):
         node, _ = compileScenicAST(RelativePositionOp(Name("X"), Name("Y")))
         match node:
@@ -526,6 +525,14 @@ class TestCompiler:
         node, _ = compileScenicAST(NotVisibleOp(Name("X")))
         match node:
             case Call(Name("NotVisible"), [Name("X")]):
+                assert True
+            case _:
+                assert False
+
+    def test_vector_op(self):
+        node, _ = compileScenicAST(VectorOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("Vector"), [Name("X"), Name("Y")]):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -460,18 +460,6 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_distance_from_op(self):
-        node, _ = compileScenicAST(DistanceFromOp(None, Name("Y")))
-        match node:
-            case Call(Name("DistanceFrom"), [Name("Y")], []):
-                assert True
-            case _:
-                assert False
-
-    def test_distance_to_op_error(self):
-        with pytest.raises(AssertionError):
-            compileScenicAST(DistanceFromOp(None, None))
-
     def test_distance_past_op(self):
         node, _ = compileScenicAST(DistancePastOp(Name("X")))
         match node:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -536,3 +536,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_field_at_op(self):
+        node, _ = compileScenicAST(FieldAtOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("FieldAt"), [Name("X"), Name("Y")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -504,3 +504,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_not_visible_op(self):
+        node, _ = compileScenicAST(NotVisibleOp(Name("X")))
+        match node:
+            case Call(Name("NotVisible"), [Name("X")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -403,7 +403,7 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
-    
+
     def test_relative_heading_op_base(self):
         node, _ = compileScenicAST(RelativeHeadingOp(Name("X"), Name("Y")))
         match node:
@@ -419,11 +419,27 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
-    
+
     def test_apparent_heading_op_base(self):
         node, _ = compileScenicAST(ApparentHeadingOp(Name("X"), Name("Y")))
         match node:
             case Call(Name("ApparentHeading"), [Name("X")], [keyword("Y", Name("Y"))]):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_from_op(self):
+        node, _ = compileScenicAST(DistanceFromOp(Name("X")))
+        match node:
+            case Call(Name("DistanceFrom"), [Name("X")]):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_from_op_to(self):
+        node, _ = compileScenicAST(DistanceFromOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("DistanceFrom"), [Name("X")], [keyword("Y", Name("Y"))]):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -443,3 +443,19 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_distance_past_op(self):
+        node, _ = compileScenicAST(DistancePastOp(Name("X")))
+        match node:
+            case Call(Name("DistancePast"), [Name("X")]):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_past_op_of(self):
+        node, _ = compileScenicAST(DistancePastOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("DistancePast"), [Name("X")], [keyword("Y", Name("Y"))]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -496,3 +496,11 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+    
+    def test_visible_op(self):
+        node, _ = compileScenicAST(VisibleOp(Name("X")))
+        match node:
+            case Call(Name("Visible"), [Name("X")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -394,3 +394,12 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    # Operators
+    def test_relative_heading_op(self):
+        node, _ = compileScenicAST(RelativeHeadingOp(Name("X")))
+        match node:
+            case Call(Name("RelativeHeading"), [Name("X")]):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -476,7 +476,7 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_angle_to(self):
+    def test_angle_to_op(self):
         node, _ = compileScenicAST(AngleFromOp(Name("X"), None))
         match node:
             case Call(Name("AngleFrom"), [Name("ego"), Name("X")]):
@@ -484,7 +484,7 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_angle_from(self):
+    def test_angle_from_op(self):
         node, _ = compileScenicAST(AngleFromOp(None, Name("X")))
         match node:
             case Call(Name("AngleFrom"), [Name("X"), Name("ego")]):
@@ -492,7 +492,7 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_angle_to_from(self):
+    def test_angle_to_from_op(self):
         node, _ = compileScenicAST(AngleFromOp(Name("X"), Name("Y")))
         match node:
             case Call(Name("AngleFrom"), [Name("Y"), Name("X")]):
@@ -500,7 +500,7 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_angle_invalid(self):
+    def test_angle_op_invalid(self):
         with pytest.raises(AssertionError):
             # target or base needs to be set
             compileScenicAST(AngleFromOp())

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -444,21 +444,33 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_distance_from_op(self):
-        node, _ = compileScenicAST(DistanceFromOp(Name("X")))
+    def test_distance_to_op(self):
+        node, _ = compileScenicAST(DistanceFromOp(Name("X"), None))
         match node:
-            case Call(Name("DistanceFrom"), [Name("X")]):
+            case Call(Name("DistanceFrom"), [Name("X")], []):
                 assert True
             case _:
                 assert False
 
-    def test_distance_from_op_to(self):
+    def test_distance_to_op_from(self):
         node, _ = compileScenicAST(DistanceFromOp(Name("X"), Name("Y")))
         match node:
             case Call(Name("DistanceFrom"), [Name("X")], [keyword("Y", Name("Y"))]):
                 assert True
             case _:
                 assert False
+
+    def test_distance_from_op(self):
+        node, _ = compileScenicAST(DistanceFromOp(None, Name("Y")))
+        match node:
+            case Call(Name("DistanceFrom"), [Name("Y")], []):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_to_op_error(self):
+        with pytest.raises(AssertionError):
+            compileScenicAST(DistanceFromOp(None, None))
 
     def test_distance_past_op(self):
         node, _ = compileScenicAST(DistancePastOp(Name("X")))

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -489,9 +489,9 @@ class TestCompiler:
                 assert False
 
     def test_angle_to_op(self):
-        node, _ = compileScenicAST(AngleFromOp(Name("X"), None))
+        node, _ = compileScenicAST(AngleFromOp(Name("Y"), None))
         match node:
-            case Call(Name("AngleFrom"), [Name("ego"), Name("X")]):
+            case Call(Name("AngleFrom"), [], [keyword("Y", Name("Y"))]):
                 assert True
             case _:
                 assert False
@@ -499,15 +499,19 @@ class TestCompiler:
     def test_angle_from_op(self):
         node, _ = compileScenicAST(AngleFromOp(None, Name("X")))
         match node:
-            case Call(Name("AngleFrom"), [Name("X"), Name("ego")]):
+            case Call(Name("AngleFrom"), [], [keyword("X", Name("X"))]):
                 assert True
             case _:
                 assert False
 
     def test_angle_to_from_op(self):
-        node, _ = compileScenicAST(AngleFromOp(Name("X"), Name("Y")))
+        node, _ = compileScenicAST(AngleFromOp(Name("Y"), Name("X")))
         match node:
-            case Call(Name("AngleFrom"), [Name("Y"), Name("X")]):
+            case Call(
+                Name("AngleFrom"),
+                [],
+                [keyword("X", Name("X")), keyword("Y", Name("Y"))],
+            ):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -459,3 +459,32 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
+
+    def test_angle_to(self):
+        node, _ = compileScenicAST(AngleFromOp(Name("X"), None))
+        match node:
+            case Call(Name("AngleFrom"), [Name("ego"), Name("X")]):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_from(self):
+        node, _ = compileScenicAST(AngleFromOp(None, Name("X")))
+        match node:
+            case Call(Name("AngleFrom"), [Name("X"), Name("ego")]):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_to_from(self):
+        node, _ = compileScenicAST(AngleFromOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("AngleFrom"), [Name("Y"), Name("X")]):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_invalid(self):
+        with pytest.raises(AssertionError):
+            # target or base needs to be set
+            compileScenicAST(AngleFromOp())

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -396,6 +396,23 @@ class TestCompiler:
                 assert False
 
     # Operators
+    def test_relative_position_op(self):
+        node, _ = compileScenicAST(RelativePositionOp(Name("X")))
+        match node:
+            case Call(Name("RelativePosition"), [Name("X")]):
+                assert True
+            case _:
+                assert False
+
+
+    def test_relative_position_op_base(self):
+        node, _ = compileScenicAST(RelativePositionOp(Name("X"), Name("Y")))
+        match node:
+            case Call(Name("RelativePosition"), [Name("X")], [keyword("Y", Name("Y"))]):
+                assert True
+            case _:
+                assert False
+
     def test_relative_heading_op(self):
         node, _ = compileScenicAST(RelativeHeadingOp(Name("X")))
         match node:
@@ -496,7 +513,7 @@ class TestCompiler:
                 assert True
             case _:
                 assert False
-    
+
     def test_visible_op(self):
         node, _ = compileScenicAST(VisibleOp(Name("X")))
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -687,6 +687,28 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "position,node",
+        [
+            ("front", Front),
+            ("back", Back),
+            ("left", Left),
+            ("right", Right),
+            ("front left", FrontLeft),
+            ("front right", FrontRight),
+            ("back left", BackLeft),
+            ("back right", BackRight),
+        ],
+    )
+    def test_position_of(self, position, node):
+        mod = parse_string_helper(f"{position} of x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(PositionOfOp(positionNode, Name("x"))):
+                assert isinstance(positionNode, node)
+            case _:
+                assert False
+
     def test_vector_1(self):
         mod = parse_string_helper("1 + 2 @ 3 * 4")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -12,6 +12,13 @@ def parse_string_helper(source: str) -> Any:
     return parse_string(source, "exec")
 
 
+def assert_equal_source_ast(source: str, expected: ast.AST) -> bool:
+    "Parse string and compare the resulting AST with the given AST"
+    mod = parse_string_helper(source)
+    stmt = mod.body[0].value
+    assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
+
+
 class TestTrackedNames:
     def test_ego_assign(self):
         mod = parse_string_helper("ego = 10")
@@ -579,11 +586,7 @@ class TestOperator:
         ],
     )
     def test_relative_position_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_relative_heading(self):
         mod = parse_string_helper("relative heading of x")
@@ -678,11 +681,7 @@ class TestOperator:
         ],
     )
     def test_relative_heading_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_apparent_heading(self):
         mod = parse_string_helper("apparent heading of x")
@@ -767,11 +766,7 @@ class TestOperator:
         ],
     )
     def test_apparent_heading_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_distance_from(self):
         mod = parse_string_helper("distance from x")
@@ -873,11 +868,7 @@ class TestOperator:
         ],
     )
     def test_distance_from_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_distance_past(self):
         mod = parse_string_helper("distance past x")
@@ -959,11 +950,7 @@ class TestOperator:
         ],
     )
     def test_distance_past_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_angle_from(self):
         mod = parse_string_helper("angle from x")
@@ -1063,11 +1050,7 @@ class TestOperator:
         ],
     )
     def test_angle_from_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_follow(self):
         mod = parse_string_helper("follow x from y for z")
@@ -1104,11 +1087,7 @@ class TestOperator:
         ],
     )
     def test_follow_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_visible(self):
         mod = parse_string_helper("visible x")
@@ -1139,11 +1118,7 @@ class TestOperator:
         ],
     )
     def test_visible_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_not_visible(self):
         mod = parse_string_helper("not visible x")
@@ -1183,11 +1158,7 @@ class TestOperator:
         ],
     )
     def test_visible_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     @pytest.mark.parametrize(
         "position,node",
@@ -1232,11 +1203,7 @@ class TestOperator:
         ],
     )
     def test_visible_precedence(self, code, expected):
-        mod = parse_string_helper(code)
-        stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(
-            expected, annotate_fields=False
-        )
+        assert_equal_source_ast(code, expected)
 
     def test_deg_1(self):
         mod = parse_string_helper("1 + 2 deg")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1119,6 +1119,15 @@ class TestOperator:
             case _:
                 assert False
 
+    def test_not_visible_inversion(self):
+        mod = parse_string_helper("not visible")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(UnaryOp(Not(), Name("visible"))):
+                assert True
+            case _:
+                assert False
+
     def test_not_visible_with_not(self):
         mod = parse_string_helper("not not visible x")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1119,6 +1119,32 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "visible A + B",
+                VisibleOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+            (
+                "visible A << B",
+                BinOp(
+                    VisibleOp(Name("A", Load())),
+                    LShift(),
+                    Name("B", Load()),
+                ),
+            ),
+        ],
+    )
+    def test_visible_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
+
     def test_not_visible(self):
         mod = parse_string_helper("not visible not x")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -734,3 +734,21 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_relative_to(self):
+        mod = parse_string_helper("x relative to y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativeToOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False
+
+    def test_offset_by(self):
+        mod = parse_string_helper("x offset by y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativeToOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -709,6 +709,24 @@ class TestOperator:
             case _:
                 assert False
 
+    def test_deg_1(self):
+        mod = parse_string_helper("1 + 2 deg")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(BinOp(Constant(1), Add(), DegOp(Constant(2)))):
+                assert True
+            case _:
+                assert False
+
+    def test_deg_2(self):
+        mod = parse_string_helper("6 * 2 deg")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DegOp(BinOp(Constant(6), Mult(), Constant(2)))):
+                assert True
+            case _:
+                assert False
+
     def test_vector_1(self):
         mod = parse_string_helper("1 + 2 @ 3 * 4")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1078,6 +1078,38 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "follow A + B from C + D for E + F",
+                FollowOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    BinOp(Name("C", Load()), Add(), Name("D", Load())),
+                    BinOp(Name("E", Load()), Add(), Name("F", Load())),
+                ),
+            ),
+            (
+                "follow A << B from C << D for E << F",
+                BinOp(
+                    FollowOp(
+                        BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                        BinOp(Name("C", Load()), LShift(), Name("D", Load())),
+                        Name("E", Load()),
+                    ),
+                    LShift(),
+                    Name("F", Load()),
+                ),
+            ),
+        ],
+    )
+    def test_follow_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
+
     def test_visible(self):
         mod = parse_string_helper("visible x")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1001,6 +1001,74 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "angle to angle from A to B",
+                AngleFromOp(AngleFromOp(Name("B", Load()), Name("A", Load()))),
+            ),
+            (
+                "angle to angle from A from B",
+                AngleFromOp(AngleFromOp(None, Name("A", Load())), Name("B", Load())),
+            ),
+            (
+                "angle to A << B from C << D",
+                BinOp(
+                    AngleFromOp(
+                        BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                        Name("C", Load()),
+                    ),
+                    LShift(),
+                    Name("D", Load()),
+                ),
+            ),
+            (
+                "angle from A + B to C + D",
+                AngleFromOp(
+                    BinOp(Name("C", Load()), Add(), Name("D", Load())),
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+            (
+                "angle to A + B",
+                AngleFromOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    None,
+                ),
+            ),
+            (
+                "angle from A + B",
+                AngleFromOp(
+                    None,
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+            (
+                "angle to A << B",
+                BinOp(
+                    AngleFromOp(Name("A", Load()), None),
+                    LShift(),
+                    Name("B", Load()),
+                ),
+            ),
+            (
+                "angle from A << B",
+                BinOp(
+                    AngleFromOp(None, Name("A", Load())),
+                    LShift(),
+                    Name("B", Load()),
+                ),
+            ),
+        ],
+    )
+    def test_angle_from_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
+
     def test_follow(self):
         mod = parse_string_helper("follow x from y for z")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -514,6 +514,52 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "relative position of relative position of A from B",
+                RelativePositionOp(RelativePositionOp(Name('A', Load()), Name('B', Load()))),
+            ),
+            (
+                "relative position of relative position of A from B from C",
+                RelativePositionOp(RelativePositionOp(Name('A', Load()), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative position of A from relative position of B from C",
+                RelativePositionOp(Name('A', Load()), RelativePositionOp(Name('B', Load()), Name('C', Load()))),
+            ),
+            (
+                "relative position of A << B from C",
+                RelativePositionOp(BinOp(Name('A', Load()), LShift(), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative position of A from B << C",
+                BinOp(RelativePositionOp(Name('A', Load()), Name('B', Load())), LShift(), Name('C', Load())),
+            ),
+            (
+                "relative position of A + B from C",
+                RelativePositionOp(BinOp(Name('A', Load()), Add(), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative position of A from B + C",
+                RelativePositionOp(Name('A', Load()), BinOp(Name('B', Load()), Add(), Name('C', Load()))),
+            ),
+            (
+                "relative position of A << B",
+                BinOp(RelativePositionOp(Name('A', Load())), LShift(), Name('B', Load())),
+            ),
+            (
+                "relative position of A + B",
+                RelativePositionOp(BinOp(Name('A', Load()), Add(), Name('B', Load()))),
+            ),
+        ],
+    )
+    def test_relative_position_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
+
     def test_relative_heading(self):
         mod = parse_string_helper("relative heading of x")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -686,3 +686,44 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_vector_1(self):
+        mod = parse_string_helper("1 + 2 @ 3 * 4")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                BinOp(
+                    Constant(1),
+                    Add(),
+                    BinOp(VectorOp(Constant(2), Constant(3)), Mult(), Constant(4)),
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_vector_2(self):
+        mod = parse_string_helper("1 * 2 @ 3 + 4")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                BinOp(
+                    VectorOp(BinOp(Constant(1), Mult(), Constant(2)), Constant(3)),
+                    Add(),
+                    Constant(4)
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_vector_3(self):
+        mod = parse_string_helper("1 @ 2 @ 3")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                VectorOp(VectorOp(Constant(1), Constant(2)), Constant(3))
+            ):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1211,6 +1211,33 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "front of A + B",
+                PositionOfOp(
+                    Front(),
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+            (
+                "left of A << B",
+                BinOp(
+                    PositionOfOp(Left(), Name("A", Load())),
+                    LShift(),
+                    Name("B", Load()),
+                ),
+            ),
+        ],
+    )
+    def test_visible_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
+
     def test_deg_1(self):
         mod = parse_string_helper("1 + 2 deg")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -560,7 +560,7 @@ class TestOperator:
                 assert True
             case _:
                 assert False
-    
+
     def test_distance_to(self):
         mod = parse_string_helper("distance to x")
         stmt = mod.body[0]
@@ -584,6 +584,24 @@ class TestOperator:
         stmt = mod.body[0]
         match stmt:
             case Expr(DistanceFromOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_past(self):
+        mod = parse_string_helper("distance past x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistancePastOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_past_of(self):
+        mod = parse_string_helper("distance past x of y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistancePastOp(Name("x"), Name("y"))):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -551,3 +551,39 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_distance_from(self):
+        mod = parse_string_helper("distance from x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistanceFromOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+    
+    def test_distance_to(self):
+        mod = parse_string_helper("distance to x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistanceFromOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_from_to(self):
+        mod = parse_string_helper("distance from x to y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistanceFromOp(Name("y"), Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_distance_to_from(self):
+        mod = parse_string_helper("distance to x from y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(DistanceFromOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -341,13 +341,13 @@ class TestNew:
                 assert False
 
     def test_specifier_beyond_from(self):
-        mod = parse_string_helper("new Object beyond position by distance from base")
+        mod = parse_string_helper("new Object beyond position by d from base")
         stmt = mod.body[0]
         match stmt:
             case Expr(
                 New(
                     "Object",
-                    [BeyondSpecifier(Name("position"), Name("distance"), Name("base"))],
+                    [BeyondSpecifier(Name("position"), Name("d"), Name("base"))],
                 )
             ):
                 assert True

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -519,46 +519,71 @@ class TestOperator:
         [
             (
                 "relative position of relative position of A from B",
-                RelativePositionOp(RelativePositionOp(Name('A', Load()), Name('B', Load()))),
+                RelativePositionOp(
+                    RelativePositionOp(Name("A", Load()), Name("B", Load()))
+                ),
             ),
             (
                 "relative position of relative position of A from B from C",
-                RelativePositionOp(RelativePositionOp(Name('A', Load()), Name('B', Load())), Name('C', Load())),
+                RelativePositionOp(
+                    RelativePositionOp(Name("A", Load()), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative position of A from relative position of B from C",
-                RelativePositionOp(Name('A', Load()), RelativePositionOp(Name('B', Load()), Name('C', Load()))),
+                RelativePositionOp(
+                    Name("A", Load()),
+                    RelativePositionOp(Name("B", Load()), Name("C", Load())),
+                ),
             ),
             (
                 "relative position of A << B from C",
-                RelativePositionOp(BinOp(Name('A', Load()), LShift(), Name('B', Load())), Name('C', Load())),
+                RelativePositionOp(
+                    BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative position of A from B << C",
-                BinOp(RelativePositionOp(Name('A', Load()), Name('B', Load())), LShift(), Name('C', Load())),
+                BinOp(
+                    RelativePositionOp(Name("A", Load()), Name("B", Load())),
+                    LShift(),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative position of A + B from C",
-                RelativePositionOp(BinOp(Name('A', Load()), Add(), Name('B', Load())), Name('C', Load())),
+                RelativePositionOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative position of A from B + C",
-                RelativePositionOp(Name('A', Load()), BinOp(Name('B', Load()), Add(), Name('C', Load()))),
+                RelativePositionOp(
+                    Name("A", Load()),
+                    BinOp(Name("B", Load()), Add(), Name("C", Load())),
+                ),
             ),
             (
                 "relative position of A << B",
-                BinOp(RelativePositionOp(Name('A', Load())), LShift(), Name('B', Load())),
+                BinOp(
+                    RelativePositionOp(Name("A", Load())), LShift(), Name("B", Load())
+                ),
             ),
             (
                 "relative position of A + B",
-                RelativePositionOp(BinOp(Name('A', Load()), Add(), Name('B', Load()))),
+                RelativePositionOp(BinOp(Name("A", Load()), Add(), Name("B", Load()))),
             ),
         ],
     )
     def test_relative_position_precedence(self, code, expected):
         mod = parse_string_helper(code)
         stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
 
     def test_relative_heading(self):
         mod = parse_string_helper("relative heading of x")
@@ -587,52 +612,77 @@ class TestOperator:
                 assert True
             case _:
                 assert False
-    
+
     @pytest.mark.parametrize(
         "code,expected",
         [
             (
                 "relative heading of relative heading of A from B",
-                RelativeHeadingOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load()))),
+                RelativeHeadingOp(
+                    RelativeHeadingOp(Name("A", Load()), Name("B", Load()))
+                ),
             ),
             (
                 "relative heading of relative heading of A from B from C",
-                RelativeHeadingOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load())), Name('C', Load())),
+                RelativeHeadingOp(
+                    RelativeHeadingOp(Name("A", Load()), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative heading of A from relative heading of B from C",
-                RelativeHeadingOp(Name('A', Load()), RelativeHeadingOp(Name('B', Load()), Name('C', Load()))),
+                RelativeHeadingOp(
+                    Name("A", Load()),
+                    RelativeHeadingOp(Name("B", Load()), Name("C", Load())),
+                ),
             ),
             (
                 "relative heading of A << B from C",
-                RelativeHeadingOp(BinOp(Name('A', Load()), LShift(), Name('B', Load())), Name('C', Load())),
+                RelativeHeadingOp(
+                    BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative heading of A from B << C",
-                BinOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load())), LShift(), Name('C', Load())),
+                BinOp(
+                    RelativeHeadingOp(Name("A", Load()), Name("B", Load())),
+                    LShift(),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative heading of A + B from C",
-                RelativeHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load())), Name('C', Load())),
+                RelativeHeadingOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "relative heading of A from B + C",
-                RelativeHeadingOp(Name('A', Load()), BinOp(Name('B', Load()), Add(), Name('C', Load()))),
+                RelativeHeadingOp(
+                    Name("A", Load()),
+                    BinOp(Name("B", Load()), Add(), Name("C", Load())),
+                ),
             ),
             (
                 "relative heading of A << B",
-                BinOp(RelativeHeadingOp(Name('A', Load())), LShift(), Name('B', Load())),
+                BinOp(
+                    RelativeHeadingOp(Name("A", Load())), LShift(), Name("B", Load())
+                ),
             ),
             (
                 "relative heading of A + B",
-                RelativeHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load()))),
+                RelativeHeadingOp(BinOp(Name("A", Load()), Add(), Name("B", Load()))),
             ),
         ],
     )
     def test_relative_heading_precedence(self, code, expected):
         mod = parse_string_helper(code)
         stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
 
     def test_apparent_heading(self):
         mod = parse_string_helper("apparent heading of x")
@@ -657,52 +707,77 @@ class TestOperator:
         [
             (
                 "apparent heading of apparent heading of A from B",
-                ApparentHeadingOp(ApparentHeadingOp(Name('A', Load()), Name('B', Load()))),
+                ApparentHeadingOp(
+                    ApparentHeadingOp(Name("A", Load()), Name("B", Load()))
+                ),
             ),
             (
                 "apparent heading of apparent heading of A from B from C",
-                ApparentHeadingOp(ApparentHeadingOp(Name('A', Load()), Name('B', Load())), Name('C', Load())),
+                ApparentHeadingOp(
+                    ApparentHeadingOp(Name("A", Load()), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "apparent heading of A from apparent heading of B from C",
-                ApparentHeadingOp(Name('A', Load()), ApparentHeadingOp(Name('B', Load()), Name('C', Load()))),
+                ApparentHeadingOp(
+                    Name("A", Load()),
+                    ApparentHeadingOp(Name("B", Load()), Name("C", Load())),
+                ),
             ),
             (
                 "apparent heading of A << B from C",
-                ApparentHeadingOp(BinOp(Name('A', Load()), LShift(), Name('B', Load())), Name('C', Load())),
+                ApparentHeadingOp(
+                    BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "apparent heading of A from B << C",
-                BinOp(ApparentHeadingOp(Name('A', Load()), Name('B', Load())), LShift(), Name('C', Load())),
+                BinOp(
+                    ApparentHeadingOp(Name("A", Load()), Name("B", Load())),
+                    LShift(),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "apparent heading of A + B from C",
-                ApparentHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load())), Name('C', Load())),
+                ApparentHeadingOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    Name("C", Load()),
+                ),
             ),
             (
                 "apparent heading of A from B + C",
-                ApparentHeadingOp(Name('A', Load()), BinOp(Name('B', Load()), Add(), Name('C', Load()))),
+                ApparentHeadingOp(
+                    Name("A", Load()),
+                    BinOp(Name("B", Load()), Add(), Name("C", Load())),
+                ),
             ),
             (
                 "apparent heading of A << B",
-                BinOp(ApparentHeadingOp(Name('A', Load())), LShift(), Name('B', Load())),
+                BinOp(
+                    ApparentHeadingOp(Name("A", Load())), LShift(), Name("B", Load())
+                ),
             ),
             (
                 "apparent heading of A + B",
-                ApparentHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load()))),
+                ApparentHeadingOp(BinOp(Name("A", Load()), Add(), Name("B", Load()))),
             ),
         ],
     )
     def test_apparent_heading_precedence(self, code, expected):
         mod = parse_string_helper(code)
         stmt = mod.body[0].value
-        assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
 
     def test_distance_from(self):
         mod = parse_string_helper("distance from x")
         stmt = mod.body[0]
         match stmt:
-            case Expr(DistanceFromOp(Name("x"))):
+            case Expr(DistanceFromOp(None, Name("x"))):
                 assert True
             case _:
                 assert False
@@ -711,7 +786,7 @@ class TestOperator:
         mod = parse_string_helper("distance to x")
         stmt = mod.body[0]
         match stmt:
-            case Expr(DistanceFromOp(Name("x"))):
+            case Expr(DistanceFromOp(Name("x"), None)):
                 assert True
             case _:
                 assert False
@@ -733,6 +808,76 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "distance to distance from A to B",
+                DistanceFromOp(DistanceFromOp(Name("B", Load()), Name("A", Load()))),
+            ),
+            (
+                "distance to distance from A from B",
+                DistanceFromOp(
+                    DistanceFromOp(None, Name("A", Load())), Name("B", Load())
+                ),
+            ),
+            (
+                "distance to A << B from C << D",
+                BinOp(
+                    DistanceFromOp(
+                        BinOp(Name("A", Load()), LShift(), Name("B", Load())),
+                        Name("C", Load()),
+                    ),
+                    LShift(),
+                    Name("D", Load()),
+                ),
+            ),
+            (
+                "distance to A + B from C + D",
+                DistanceFromOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    BinOp(Name("C", Load()), Add(), Name("D", Load())),
+                ),
+            ),
+            (
+                "distance to A + B",
+                DistanceFromOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    None,
+                ),
+            ),
+            (
+                "distance from A + B",
+                DistanceFromOp(
+                    None,
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+            (
+                "distance to A << B",
+                BinOp(
+                    DistanceFromOp(Name("A", Load()), None),
+                    LShift(),
+                    Name("B", Load()),
+                )
+            ),
+            (
+                "distance from A << B",
+                BinOp(
+                    DistanceFromOp(None, Name("A", Load())),
+                    LShift(),
+                    Name("B", Load()),
+                )
+            ),
+        ],
+    )
+    def test_distance_from_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
 
     def test_distance_past(self):
         mod = parse_string_helper("distance past x")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -659,3 +659,12 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_not_visible(self):
+        mod = parse_string_helper("not visible not x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(NotVisibleOp(UnaryOp(Not(), Name("x")))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -710,7 +710,7 @@ class TestOperator:
                 BinOp(
                     VectorOp(BinOp(Constant(1), Mult(), Constant(2)), Constant(3)),
                     Add(),
-                    Constant(4)
+                    Constant(4),
                 )
             ):
                 assert True
@@ -721,9 +721,16 @@ class TestOperator:
         mod = parse_string_helper("1 @ 2 @ 3")
         stmt = mod.body[0]
         match stmt:
-            case Expr(
-                VectorOp(VectorOp(Constant(1), Constant(2)), Constant(3))
-            ):
+            case Expr(VectorOp(VectorOp(Constant(1), Constant(2)), Constant(3))):
+                assert True
+            case _:
+                assert False
+
+    def test_field_at(self):
+        mod = parse_string_helper("x at y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(FieldAtOp(Name("x"), Name("y"))):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -587,6 +587,52 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+    
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "relative heading of relative heading of A from B",
+                RelativeHeadingOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load()))),
+            ),
+            (
+                "relative heading of relative heading of A from B from C",
+                RelativeHeadingOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative heading of A from relative heading of B from C",
+                RelativeHeadingOp(Name('A', Load()), RelativeHeadingOp(Name('B', Load()), Name('C', Load()))),
+            ),
+            (
+                "relative heading of A << B from C",
+                RelativeHeadingOp(BinOp(Name('A', Load()), LShift(), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative heading of A from B << C",
+                BinOp(RelativeHeadingOp(Name('A', Load()), Name('B', Load())), LShift(), Name('C', Load())),
+            ),
+            (
+                "relative heading of A + B from C",
+                RelativeHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load())), Name('C', Load())),
+            ),
+            (
+                "relative heading of A from B + C",
+                RelativeHeadingOp(Name('A', Load()), BinOp(Name('B', Load()), Add(), Name('C', Load()))),
+            ),
+            (
+                "relative heading of A << B",
+                BinOp(RelativeHeadingOp(Name('A', Load())), LShift(), Name('B', Load())),
+            ),
+            (
+                "relative heading of A + B",
+                RelativeHeadingOp(BinOp(Name('A', Load()), Add(), Name('B', Load()))),
+            ),
+        ],
+    )
+    def test_relative_heading_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(expected, annotate_fields=False)
 
     def test_apparent_heading(self):
         mod = parse_string_helper("apparent heading of x")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -496,6 +496,24 @@ class TestNew:
 
 
 class TestOperator:
+    def test_relative_position(self):
+        mod = parse_string_helper("relative position of x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativePositionOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_relative_position_base(self):
+        mod = parse_string_helper("relative position of x from y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativePositionOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False
+
     def test_relative_heading(self):
         mod = parse_string_helper("relative heading of x")
         stmt = mod.body[0]

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -641,3 +641,12 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_follow(self):
+        mod = parse_string_helper("follow x from y for z")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(FollowOp(Name("x"), Name("y"), Name("z"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -523,3 +523,31 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_apparent_heading(self):
+        mod = parse_string_helper("apparent heading of x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(ApparentHeadingOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_apparent_heading_from(self):
+        mod = parse_string_helper("apparent heading of x from y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(ApparentHeadingOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False
+
+    def test_apparent_heading_precedence(self):
+        # This is incorrect code, but asserts the operator has the right precedence
+        mod = parse_string_helper("apparent heading of x or y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(ApparentHeadingOp(BoolOp(Or(), [Name("x"), Name("y")]))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -762,7 +762,7 @@ class TestOperator:
         mod = parse_string_helper("distance from x")
         stmt = mod.body[0]
         match stmt:
-            case Expr(DistanceFromOp(None, Name("x"))):
+            case Expr(DistanceFromOp(Name("x"), None)):
                 assert True
             case _:
                 assert False
@@ -780,7 +780,7 @@ class TestOperator:
         mod = parse_string_helper("distance from x to y")
         stmt = mod.body[0]
         match stmt:
-            case Expr(DistanceFromOp(Name("y"), Name("x"))):
+            case Expr(DistanceFromOp(Name("x"), Name("y"))):
                 assert True
             case _:
                 assert False
@@ -799,12 +799,12 @@ class TestOperator:
         [
             (
                 "distance to distance from A to B",
-                DistanceFromOp(DistanceFromOp(Name("B", Load()), Name("A", Load()))),
+                DistanceFromOp(DistanceFromOp(Name("A", Load()), Name("B", Load()))),
             ),
             (
                 "distance to distance from A from B",
                 DistanceFromOp(
-                    DistanceFromOp(None, Name("A", Load())), Name("B", Load())
+                    DistanceFromOp(Name("A", Load()), None), Name("B", Load())
                 ),
             ),
             (
@@ -835,8 +835,8 @@ class TestOperator:
             (
                 "distance from A + B",
                 DistanceFromOp(
-                    None,
                     BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    None,
                 ),
             ),
             (
@@ -850,7 +850,7 @@ class TestOperator:
             (
                 "distance from A << B",
                 BinOp(
-                    DistanceFromOp(None, Name("A", Load())),
+                    DistanceFromOp(Name("A", Load()), None),
                     LShift(),
                     Name("B", Load()),
                 ),

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -605,3 +605,39 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_angle_from(self):
+        mod = parse_string_helper("angle from x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(AngleFromOp(None, Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_to(self):
+        mod = parse_string_helper("angle to x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(AngleFromOp(Name("x"), None)):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_from_to(self):
+        mod = parse_string_helper("angle from x to y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(AngleFromOp(Name("y"), Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_angle_to_from(self):
+        mod = parse_string_helper("angle to x from y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(AngleFromOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -752,3 +752,12 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_offset_along(self):
+        mod = parse_string_helper("x offset along y by z")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(OffsetAlongOp(Name("x"), Name("y"), Name("z"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -761,3 +761,12 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_can_see(self):
+        mod = parse_string_helper("x can see y ")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(CanSeeOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -493,3 +493,33 @@ class TestNew:
                 assert True
             case _:
                 assert False
+
+
+class TestOperator:
+    def test_relative_heading(self):
+        mod = parse_string_helper("relative heading of x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativeHeadingOp(Name("x"))):
+                assert True
+            case _:
+                assert False
+
+    def test_relative_heading_from(self):
+        mod = parse_string_helper("relative heading of x from y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativeHeadingOp(Name("x"), Name("y"))):
+                assert True
+            case _:
+                assert False
+
+    def test_relative_heading_precedence(self):
+        # This is incorrect code, but asserts the operator has the right precedence
+        mod = parse_string_helper("relative heading of x or y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(RelativeHeadingOp(BoolOp(Or(), [Name("x"), Name("y")]))):
+                assert True
+            case _:
+                assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -860,7 +860,7 @@ class TestOperator:
                     DistanceFromOp(Name("A", Load()), None),
                     LShift(),
                     Name("B", Load()),
-                )
+                ),
             ),
             (
                 "distance from A << B",
@@ -868,7 +868,7 @@ class TestOperator:
                     DistanceFromOp(None, Name("A", Load())),
                     LShift(),
                     Name("B", Load()),
-                )
+                ),
             ),
         ],
     )
@@ -896,6 +896,74 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (
+                "distance past distance past A of B",
+                DistancePastOp(DistancePastOp(Name("A", Load()), Name("B", Load()))),
+            ),
+            (
+                "distance past distance past A of B of C",
+                DistancePastOp(
+                    DistancePastOp(Name("A", Load()), Name("B", Load())),
+                    Name("C", Load()),
+                ),
+            ),
+            (
+                "distance past A of distance past B of C",
+                DistancePastOp(
+                    Name("A", Load()),
+                    DistancePastOp(Name("B", Load()), Name("C", Load())),
+                ),
+            ),
+            (
+                "distance past A << B of C << D",
+                BinOp(
+                    DistancePastOp(
+                        BinOp(
+                            Name("A", Load()),
+                            LShift(),
+                            Name("B", Load()),
+                        ),
+                        Name("C", Load()),
+                    ),
+                    LShift(),
+                    Name("D", Load()),
+                ),
+            ),
+            (
+                "distance past A + B of C + D",
+                DistancePastOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                    BinOp(Name("C", Load()), Add(), Name("D", Load())),
+                ),
+            ),
+            (
+                "distance past A << B",
+                BinOp(
+                    DistancePastOp(
+                        Name("A", Load()),
+                    ),
+                    LShift(),
+                    Name("B", Load()),
+                ),
+            ),
+            (
+                "distance past A + B",
+                DistancePastOp(
+                    BinOp(Name("A", Load()), Add(), Name("B", Load())),
+                ),
+            ),
+        ],
+    )
+    def test_distance_past_precedence(self, code, expected):
+        mod = parse_string_helper(code)
+        stmt = mod.body[0].value
+        assert dump(stmt, annotate_fields=False) == dump(
+            expected, annotate_fields=False
+        )
 
     def test_angle_from(self):
         mod = parse_string_helper("angle from x")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -606,16 +606,6 @@ class TestOperator:
             case _:
                 assert False
 
-    def test_relative_heading_precedence(self):
-        # This is incorrect code, but asserts the operator has the right precedence
-        mod = parse_string_helper("relative heading of x or y")
-        stmt = mod.body[0]
-        match stmt:
-            case Expr(RelativeHeadingOp(BoolOp(Or(), [Name("x"), Name("y")]))):
-                assert True
-            case _:
-                assert False
-
     @pytest.mark.parametrize(
         "code,expected",
         [

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -650,3 +650,12 @@ class TestOperator:
                 assert True
             case _:
                 assert False
+
+    def test_visible(self):
+        mod = parse_string_helper("visible x")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(VisibleOp(Name("x"))):
+                assert True
+            case _:
+                assert False


### PR DESCRIPTION
## Overview

This PR adds Scenic operators to the new parser.

## Changes

### Prefix Operators

Prefix operators are operators that begin with some keywords, not expressions. This PR implements the following prefix operators.

- `relative position of <vector> [from <vector>]`
  - not documented but exists in implementation
- `relative heading of <heading> [from <heading>]`
- `apparent heading of <oriented point> [from <vector>]`
- `distance from {X} to {Y}`
  - One of `X` and `Y` is required. If only one of the two is given, the other will have the value `ego`
  - `from` and `to` are interchangeable. `distance from X to Y` and `distance to X from Y` are both valid
  - The implementation assumes this operation is commutative.
- `distance past {vector} of {OP}`
- `angle to {X} from {Y}`
  - Similarly to the `distance from` operator, one of the two operands can be omitted and `ego` will be used
  - `from` and `to` are interchangeable.
  - This operation is NOT commutative, so we must remember which operand was specified with `from` and `to`
- `follow <field> from <vector> for <number>`
- `visible <region>`
- `not visible <region>`
  - not documented but implemented in code
  - requires changes to the Python grammar to disambiguate with the inversion of the variable `visible`
- `(front | back | left | right) of Object`
- `(front | back) (left | right) of Object`

In Scenic, prefix operators have the lowest precedence. In other words, everything that comes after the keywords will be an operand of the operator. For this reason, `scenic_prefix_operators` that contains grammar rules for all prefix operators are placed in between `factor` and `atom`. 

### Infix/Postfix Operators

Other operators begin with some expressions followed by keywords. With some exceptions, most infix operators in Scenic are implemented by substituting unused Python operators. When implementing a parser, we want to preserve the same precedence as the operator used for substitution.

All operators are left associative, which also matches the current implementation.

- `<number> deg`
  - Precedence: the same as multiplication (`*`)
  - The old compiler simply replaces the occurrence of `deg` with `* 0.01745329`
- `{X} @ {Y}`
  - override the Python's matrix multiplication operator with a rule with higher precedence
- `X relative to Y`
  - Precedence: the same as bitwise and (`&`)
- `X offset along H by Y`
  - Precedence: the same as bitwise xor (`^`)
- `X at Y`
  - Precedence: the same as left shift (`<<`)
- `X can see Y`
  - Precedence: the same as bitwise or (`|`)
