### PR TITLE
[Parser] implement `require` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -44,6 +44,24 @@ class parameter(AST):
         self._fields = ["value"]
 
 
+class Require(AST):
+    __match_args__ = ("cond", "prob", "name")
+
+    def __init__(
+        self,
+        cond: ast.AST,
+        prob: Optional[float] = None,
+        name: Optional[str] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.cond = cond
+        self.prob = prob
+        self.name = name
+        self._fields = ["cond"]
+
+
 # Instance Creation
 
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -79,7 +79,6 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
     def visit_Require(self, node: s.Require):
         condition = self.visit(node.cond)
         syntax_id = self._register_requirement_syntax(condition)
-        prob = node.prob if node.prob is not None else 1.0
 
         return ast.Expr(
             value=ast.Call(
@@ -92,9 +91,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                     ),
                     ast.Constant(value=node.lineno),
                     ast.Constant(value=node.name),
-                    ast.Constant(value=prob),
                 ],
-                keywords=[],
+                keywords=[ast.keyword(arg="prob", value=node.prob)]
+                if node.prob is not None
+                else [],
             )
         )
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -530,6 +530,7 @@ compound_stmt:
 scenic_stmt:
     | scenic_ego_assignment
     | scenic_param_stmt
+    | scenic_require_stmt
 
 # SIMPLE STATEMENTS
 # =================
@@ -1490,6 +1491,14 @@ scenic_param_stmt_param: name=scenic_param_stmt_id '=' e=expression { s.paramete
 scenic_param_stmt_id:
     | a=NAME { a.string }
     | a=STRING { a.string[1:-1] } # strip quotes
+
+scenic_require_stmt:
+    | 'require' p=['[' a=NUMBER ']' { float(a.string) }] e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.Require(cond=e, prob=p, name=n, LOCATIONS)
+     }
+scenic_require_stmt_name:
+    | a=(NAME | NUMBER) { a.string }
+    | a=STRING { a.string[1:-1] }
 
 # LITERALS
 # ========

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -74,12 +74,15 @@ class TestCompiler:
                         Lambda(body=Name("C")),  # requirement
                         Constant(2),  # lineno
                         Constant(name),  # name
-                        Constant(prob),  # prob
                     ],
+                    kwargs,  # prob or empty list
                 )
             ):
                 assert name is None if expected_name is None else name == expected_name
-                assert prob == expected_prob
+                compiled_prob = (
+                    kwargs[0].value if kwargs else 1.0
+                )  # if kwargs is empty, use 1.0
+                assert compiled_prob == expected_prob
             case _:
                 assert False
 

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -76,6 +76,62 @@ class TestParam:
             parse_string_helper("param")
 
 
+class TestRequire:
+    def test_basic(self):
+        mod = parse_string_helper("require X")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), None, None):
+                assert True
+            case _:
+                assert False
+
+    def test_prob(self):
+        mod = parse_string_helper("require[0.2] X")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), 0.2, None):
+                assert True
+            case _:
+                assert False
+
+    def test_name(self):
+        mod = parse_string_helper("require X as name")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), None, "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_prob_name(self):
+        mod = parse_string_helper("require[0.3] X as name")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), 0.3, "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_name_quoted(self):
+        mod = parse_string_helper("require X as 'requirement name'")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), None, "requirement name"):
+                assert True
+            case _:
+                assert False
+
+    def test_name_number(self):
+        mod = parse_string_helper("require X as 123")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(Name("X"), None, "123"):
+                assert True
+            case _:
+                assert False
+
+
 class TestNew:
     def test_basic(self):
         mod = parse_string_helper("new Object")


### PR DESCRIPTION
This PR adds support for `require` statements.

- probability can be specified using square brackets
  - omitting the probability would omit the `prob` keyword argument and will be set to 1 in veneer
- just like parameters, the name can be a NAME, NUMBER, or STRING (quoted)
  - If the name was quoted, the resulting AST would omit the quotes