### PR TITLE
[Parser] implement `model` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -20,6 +20,16 @@ class EgoAssign(AST):
 
 
 # simple statements
+
+
+class Model(AST):
+    __match_args__ = ("name",)
+
+    def __init__(self, name: str, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = name
+
+
 class Param(AST):
     "`param identifier = value, …` statements"
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -43,6 +43,18 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_Model(self, node: s.Model):
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="model", ctx=loadCtx),
+                args=[
+                    ast.Name(id="_Scenic_module_namespace", ctx=loadCtx),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
     def visit_Param(self, node: s.Param):
         d = dict()
         for parameter in node.elts:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -528,6 +528,7 @@ compound_stmt:
     | match_stmt
 
 scenic_stmt:
+    | scenic_model_stmt
     | scenic_ego_assignment
     | scenic_param_stmt
 
@@ -1480,6 +1481,9 @@ lambda_param[ast.arg]: a=NAME {
 
 # SCENIC STATEMENTS
 # =================
+
+scenic_model_stmt:
+    | "model" a=dotted_name { s.Model(name=a) }
 
 scenic_ego_assignment:
     | 'ego' '=' a=expression { s.EgoAssign(value=a, LOCATIONS) }

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -17,6 +17,18 @@ class TestCompiler:
                 assert False
 
     # Simple Statement
+    def test_model_basic(self):
+        node, _ = compileScenicAST(Model("model"))
+        match node:
+            case Expr(
+                Call(
+                    Name("model"), [Name("_Scenic_module_namespace"), Constant("model")]
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_param_basic(self):
         node, _ = compileScenicAST(Param([parameter("p1", Name("v1"))]))
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -37,6 +37,26 @@ class TestEgoAssign:
             parse_string_helper("ego, x = 10, 20")
 
 
+class TestModel:
+    def test_basic(self):
+        mod = parse_string_helper("model some_model")
+        stmt = mod.body[0]
+        match stmt:
+            case Model("some_model"):
+                assert True
+            case _:
+                assert False
+
+    def test_dotted(self):
+        mod = parse_string_helper("model scenic.simulators.carla")
+        stmt = mod.body[0]
+        match stmt:
+            case Model("scenic.simulators.carla"):
+                assert True
+            case _:
+                assert False
+
+
 class TestParam:
     def test_basic(self):
         mod = parse_string_helper("param i = v")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -48,10 +48,10 @@ class TestModel:
                 assert False
 
     def test_dotted(self):
-        mod = parse_string_helper("model scenic.simulators.carla")
+        mod = parse_string_helper("model scenic.simulators.carla.model")
         stmt = mod.body[0]
         match stmt:
-            case Model("scenic.simulators.carla"):
+            case Model("scenic.simulators.carla.model"):
                 assert True
             case _:
                 assert False


### PR DESCRIPTION
This PR implements `model ...` statements.

- The grammar is defined using `dotted_name` which is used for `import` statements
- model is a soft keyword because otherwise we wouldn't be able to parse `model scenic.simulators.carla.model`
  - the last `model` is a token that's not part of the statement
