### PR TITLE
[Parser] Implement special handling for tracked names

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -10,13 +10,33 @@ class AST(ast.AST):
 
 
 # special statements
-class EgoAssign(AST):
-    __match_args__ = ("value",)
+class TrackedAssign(AST):
+    __match_args__ = (
+        "target",
+        "value",
+    )
 
-    def __init__(self, value: any, *args: any, **kwargs: any) -> None:
+    def __init__(
+        self,
+        target: Union["Ego", "Workspace"],
+        value: ast.AST,
+        *args: any,
+        **kwargs: any
+    ) -> None:
         super().__init__(*args, **kwargs)
+        self.target = target
         self.value = value
-        self._fields = ["value"]
+        self._fields = ["target", "value"]
+
+
+class Ego(AST):
+    "`ego` tracked assign target"
+    functionName = "ego"
+
+
+class Workspace(AST):
+    "`workspace` tracked assign target"
+    functionName = "workspace"
 
 
 # simple statements

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -529,7 +529,7 @@ compound_stmt:
 
 scenic_stmt:
     | scenic_model_stmt
-    | scenic_ego_assignment
+    | scenic_tracked_assignment
     | scenic_param_stmt
     | scenic_require_stmt
 
@@ -1486,8 +1486,11 @@ lambda_param[ast.arg]: a=NAME {
 scenic_model_stmt:
     | "model" a=dotted_name { s.Model(name=a) }
 
-scenic_ego_assignment:
-    | 'ego' '=' a=expression { s.EgoAssign(value=a, LOCATIONS) }
+scenic_tracked_assignment:
+    | a=scenic_tracked_name '=' b=expression { s.TrackedAssign(target=a, value=b, LOCATIONS) }
+scenic_tracked_name:
+    | "ego" { s.Ego(LOCATIONS) }
+    | "workspace" { s.Workspace(LOCATIONS) }
 
 scenic_param_stmt:
     | 'param' elts=(','.scenic_param_stmt_param+) { s.Param(elts=elts, LOCATIONS) }

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -12,29 +12,33 @@ def parse_string_helper(source: str) -> Any:
     return parse_string(source, "exec")
 
 
-class TestEgoAssign:
-    def test_basic(self):
+class TestTrackedNames:
+    def test_ego_assign(self):
         mod = parse_string_helper("ego = 10")
         stmt = mod.body[0]
         match stmt:
-            case EgoAssign(Constant(10)):
+            case TrackedAssign(Ego(), Constant(10)):
                 assert True
             case _:
                 assert False
 
-    def test_with_new(self):
+    def test_ego_assign_with_new(self):
         mod = parse_string_helper("ego = new Object")
         stmt = mod.body[0]
         match stmt:
-            case EgoAssign(New("Object")):
+            case TrackedAssign(Ego(), New("Object")):
                 assert True
             case _:
                 assert False
 
-    def test_ego_keyword(self):
-        """Ego is a hard keyword and cannot be used except for ego assignment"""
-        with pytest.raises(SyntaxError):
-            parse_string_helper("ego, x = 10, 20")
+    def test_workspace_assign(self):
+        mod = parse_string_helper("workspace = Workspace()")
+        stmt = mod.body[0]
+        match stmt:
+            case TrackedAssign(Workspace(), Call(Name("Workspace"))):
+                assert True
+            case _:
+                assert False
 
 
 class TestModel:


### PR DESCRIPTION
This PR adds the code necessary to handle variables with tracked names.

## Writing to Tracked Variables

dfc58def1f23042f1a8194be0dc513168a9bd5b8 introduced the concept of **tracked names**. When assigning values to a variable with a tracked name, it would call a function and pass the value to assign on the first argument. Such variables can also be accessed by a function call but without any arguments.

In the past `ego` was the only tracked name, but dfc58def1f23042f1a8194be0dc513168a9bd5b8 expanded it to `workspace`. This PR generalizes the implementation of `EgoAssign` to `TrackedAssign` that takes `Ego` or `Workspace` for its target. `TrackedAssign` will be compiled to a function call to `ego` or `workspace` with the value as an argument.

At this moment, we only support assignment to tracked variables in the simple form `tracked = <expression>`. Any form of assignment other than this, such as

```python
# tuple assign
ego, v = newEgo, newV
# multiple targets
workspace = myWorkspace = newWorkspace
```

is **invalid** in Scenic. Because those are valid Python and we cannot make `ego` and `workspace` into hard keywords<b>*</b>, we catch those cases in the compiler. If a `Name` node of tracked variable name has a `Store` context, we raise `SyntaxError`.

<b>*</b>It is possible to catch this error at the parser level. We make `ego` and `workspace` hard keywords and add the two literals as valid expressions that will be compiled to a function call. Both approaches should work as expected, but I believe the way I implemented this PR is simpler. It also leaves possibilities for supporting non-simple assignments<b>**</b>.

<b>**</b>I believe supporting multiple targets is easy. For example, `workspace = myWorkspace = newWorkspace` can be turned into `myWorkspace = workspace(newWorkspace)`. Tuple assign is more involved. Since it would be weird to support one form of assignment but not others, for now, we should only support the simplest assignment. 

## Accessing Tracked Variables

When tracked variables are used in the `Load` context (i.e. when reading from `ego` or `workspace`), the expression needs to be turned into a function call. We handle this case in `visit_Name` on the compiler. If `ego` or `workspace` is used in the `Load` context, the compiler returns a function call to the function of the same name.

## built-in variables

Besides from tracked variables, `builtinNames` should be reserved and assignments to them should be an error. We also handle this case in `visit_Name` on the compiler.