### PR TITLE
[Parser] add `mutate` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -72,6 +72,15 @@ class Require(AST):
         self._fields = ["cond"]
 
 
+class Mutate(AST):
+    __match_args__ = ("elts",)
+
+    def __init__(self, elts: list[ast.Name], *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.elts = elts
+        self._fields = ["elts"]
+
+
 # Instance Creation
 
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -70,6 +70,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_Mutate(self, node: s.Mutate):
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="mutate", ctx=loadCtx),
+                args=[self.visit(el) for el in node.elts],
+                keywords=[],
+            )
+        )
+
     def visit_Param(self, node: s.Param):
         d = dict()
         for parameter in node.elts:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -532,6 +532,7 @@ scenic_stmt:
     | scenic_ego_assignment
     | scenic_param_stmt
     | scenic_require_stmt
+    | scenic_mutate_stmt
 
 # SIMPLE STATEMENTS
 # =================
@@ -1503,6 +1504,10 @@ scenic_require_stmt:
 scenic_require_stmt_name:
     | a=(NAME | NUMBER) { a.string }
     | a=STRING { a.string[1:-1] }
+
+scenic_mutate_stmt:
+    | 'mutate' elts=[(','.scenic_mutate_stmt_id+)] { s.Mutate(elts=elts if elts is not None else [], LOCATIONS) }
+scenic_mutate_stmt_id: a=NAME { ast.Name(id=a.string, ctx=Load, LOCATIONS) }
 
 # LITERALS
 # ========

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -29,6 +29,40 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_mutate_basic(self):
+        node, _ = compileScenicAST(Mutate([Name("x", Load())]))
+        match node:
+            case Expr(Call(Name("mutate"), [Name("x")])):
+                assert True
+            case _:
+                assert False
+
+    def test_mutate_multiple(self):
+        node, _ = compileScenicAST(
+            Mutate([Name("x", Load()), Name("y", Load()), Name("z", Load())])
+        )
+        match node:
+            case Expr(Call(Name("mutate"), [Name("x"), Name("y"), Name("z")])):
+                assert True
+            case _:
+                assert False
+
+    def test_mutate_ego(self):
+        node, _ = compileScenicAST(Mutate([Name("ego", Load())]))
+        match node:
+            case Expr(Call(Name("mutate"), [Call(Name("ego"))])):
+                assert True
+            case _:
+                assert False
+
+    def test_mutate_empty(self):
+        node, _ = compileScenicAST(Mutate([]))
+        match node:
+            case Expr(Call(Name("mutate"), [])):
+                assert True
+            case _:
+                assert False
+
     def test_param_basic(self):
         node, _ = compileScenicAST(Param([parameter("p1", Name("v1"))]))
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -57,6 +57,44 @@ class TestModel:
                 assert False
 
 
+class TestMutate:
+    def test_basic(self):
+        mod = parse_string_helper("mutate x")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([Name("x", Load())]):
+                assert True
+            case _:
+                assert False
+
+    def test_multiple(self):
+        mod = parse_string_helper("mutate x, y, z")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([Name("x", Load()), Name("y", Load()), Name("z", Load())]):
+                assert True
+            case _:
+                assert False
+
+    def test_ego(self):
+        mod = parse_string_helper("mutate ego")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([Name("ego", Load())]):
+                assert True
+            case _:
+                assert False
+
+    def test_empty(self):
+        mod = parse_string_helper("mutate")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([]):
+                assert True
+            case _:
+                assert False
+
+
 class TestParam:
     def test_basic(self):
         mod = parse_string_helper("param i = v")


### PR DESCRIPTION
This PR adds `mutate` statements to the new parser and compiler.

- Because it is not implemented in `veneer`, `mutate identifier by number` syntax is not supported
  - Only `mutate id1, id2, ...` for now
- Only NAMEs can be identifiers
  - but the tracked names (`ego` `workspace`) can