### PR TITLE
[Parser] Support class definitions and properties definitions

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -41,6 +41,11 @@ class Constructible(Samplable):
 		super().__init_subclass__()
 		# find all defaults provided by the class or its superclasses
 		allDefs = collections.defaultdict(list)
+
+		# catch multiple inheritance of Scenic classes
+		if len(bases := [base.__name__ for base in cls.__bases__ if issubclass(base, Constructible)]) > 1:
+			raise SyntaxError(f"cannot inherit more than one Scenic classes: {', '.join(bases)}")
+
 		for sc in cls.__mro__:
 			if issubclass(sc, Constructible) and hasattr(sc, '_scenic_properties'):
 				for prop, value in sc._scenic_properties.items():

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -42,8 +42,8 @@ class Constructible(Samplable):
 		# find all defaults provided by the class or its superclasses
 		allDefs = collections.defaultdict(list)
 		for sc in cls.__mro__:
-			if issubclass(sc, Constructible) and hasattr(sc, '__annotations__'):
-				for prop, value in sc.__annotations__.items():
+			if issubclass(sc, Constructible) and hasattr(sc, '_scenic_properties'):
+				for prop, value in sc._scenic_properties.items():
 					allDefs[prop].append(PropertyDefault.forValue(value))
 
 		# resolve conflicting defaults and gather dynamic properties
@@ -312,19 +312,21 @@ class Point(Constructible):
 		positionStdDev (float): Standard deviation of Gaussian noise to add to this
 		  object's ``position`` when mutation is enabled. Default value 1.
 	"""
-	position: PropertyDefault((), {'dynamic'}, lambda self: Vector(0, 0))
-	width: 0
-	length: 0
-	visibleDistance: 50
+	_scenic_properties = {
+		"position": PropertyDefault((), {'dynamic'}, lambda self: Vector(0, 0)),
+		"width": 0,
+		"length": 0,
+		"visibleDistance": 50,
 
-	mutationEnabled: False
-	mutator: PropertyDefault({'positionStdDev'}, {'additive'},
-							 lambda self: PositionMutator(self.positionStdDev))
-	positionStdDev: 1
+		"mutationEnabled": False,
+		"mutator": PropertyDefault({'positionStdDev'}, {'additive'},
+								lambda self: PositionMutator(self.positionStdDev)),
+		"positionStdDev": 1,
 
-	# This property is defined in Object, but we provide a default empty value
-	# for Points for implementation convenience.
-	regionContainedIn: None
+		# This property is defined in Object, but we provide a default empty value
+		# for Points for implementation convenience.
+		"regionContainedIn": None,
+	}
 
 	@cached_property
 	def visibleRegion(self):
@@ -383,12 +385,14 @@ class OrientedPoint(Point):
 		headingStdDev (float): Standard deviation of Gaussian noise to add to this
 		  object's ``heading`` when mutation is enabled. Default value 5°.
 	"""
-	heading: PropertyDefault((), {'dynamic'}, lambda self: 0)
-	viewAngle: math.tau
+	_scenic_properties = {
+		"heading": PropertyDefault((), {'dynamic'}, lambda self: 0),
+		"viewAngle": math.tau,
 
-	mutator: PropertyDefault({'headingStdDev'}, {'additive'},
-		lambda self: HeadingMutator(self.headingStdDev))
-	headingStdDev: math.radians(5)
+		"mutator": PropertyDefault({'headingStdDev'}, {'additive'},
+			lambda self: HeadingMutator(self.headingStdDev)),
+		"headingStdDev": math.radians(5),
+	}
 
 	@cached_property
 	def visibleRegion(self):
@@ -447,21 +451,23 @@ class Object(OrientedPoint, _RotatedRectangle):
 		behavior: Behavior for dynamic agents, if any (see :ref:`dynamics`). Default
 			value ``None``.
 	"""
-	width: 1
-	length: 1
+	_scenic_properties = {
+		"width": 1,
+		"length": 1,
 
-	allowCollisions: False
-	requireVisible: True
-	regionContainedIn: None
-	cameraOffset: Vector(0, 0)
+		"allowCollisions": False,
+		"requireVisible": True,
+		"regionContainedIn": None,
+		"cameraOffset": Vector(0, 0),
 
-	velocity: PropertyDefault(('speed', 'heading'), {'dynamic'},
-	                          lambda self: Vector(0, self.speed).rotatedBy(self.heading))
-	speed: PropertyDefault((), {'dynamic'}, lambda self: 0)
-	angularSpeed: PropertyDefault((), {'dynamic'}, lambda self: 0)
+		"velocity": PropertyDefault(('speed', 'heading'), {'dynamic'},
+								lambda self: Vector(0, self.speed).rotatedBy(self.heading)),
+		"speed": PropertyDefault((), {'dynamic'}, lambda self: 0),
+		"angularSpeed": PropertyDefault((), {'dynamic'}, lambda self: 0),
 
-	behavior: None
-	lastActions: None
+		"behavior": None,
+		"lastActions": None,
+	}
 
 	def __new__(cls, *args, **kwargs):
 		obj = super().__new__(cls)

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -45,7 +45,7 @@ class PropertyDef(AST):
     def __init__(
         self,
         property: str,
-        attributes: list[str],
+        attributes: list[Union["Additive", "Dynamic"]],
         value=ast.AST,
         *args: any,
         **kwargs: any
@@ -55,6 +55,20 @@ class PropertyDef(AST):
         self.attributes = attributes
         self.value = value
         self._fields = ["value"]
+
+
+class Additive(AST):
+    keyword = "additive"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class Dynamic(AST):
+    keyword = "dynamic"
+
+    def __init__(self, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
 
 
 # simple statements

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -54,7 +54,7 @@ class PropertyDef(AST):
         self.property = property
         self.attributes = attributes
         self.value = value
-        self._fields = ["value"]
+        self._fields = ["attributes", "value"]
 
 
 class Additive(AST):

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -45,7 +45,7 @@ class PropertyDef(AST):
     def __init__(
         self,
         property: str,
-        attributes: list[ast.Name],
+        attributes: list[str],
         value=ast.AST,
         *args: any,
         **kwargs: any
@@ -54,7 +54,7 @@ class PropertyDef(AST):
         self.property = property
         self.attributes = attributes
         self.value = value
-        self._fields = ["attributes", "value"]
+        self._fields = ["value"]
 
 
 # simple statements

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -39,6 +39,24 @@ class Workspace(AST):
     functionName = "workspace"
 
 
+class PropertyDef(AST):
+    __match_args__ = ("property", "attributes", "value")
+
+    def __init__(
+        self,
+        property: str,
+        attributes: list[ast.Name],
+        value=ast.AST,
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.property = property
+        self.attributes = attributes
+        self.value = value
+        self._fields = ["attributes", "value"]
+
+
 # simple statements
 
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -54,7 +54,7 @@ class PropertyDef(AST):
         self.property = property
         self.attributes = attributes
         self.value = value
-        self._fields = ["attributes", "value"]
+        self._fields = ["property", "attributes", "value"]
 
 
 class Additive(AST):
@@ -104,7 +104,7 @@ class parameter(AST):
         super().__init__(*args, **kwargs)
         self.identifier = identifier
         self.value = value
-        self._fields = ["identifier" ,"value"]
+        self._fields = ["identifier", "value"]
 
 
 class Require(AST):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -225,8 +225,11 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     def visit_New(self, node: s.New):
         return ast.Call(
-            func=ast.Name(id=node.className, ctx=loadCtx),
-            args=[self.visit(s) for s in node.specifiers],
+            func=ast.Name(id="new", ctx=loadCtx),
+            args=[
+                ast.Name(id=node.className, ctx=loadCtx),
+                ast.List(elts=[self.visit(s) for s in node.specifiers], ctx=ast.Load()),
+            ],
             keywords=[],
         )
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -105,6 +105,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> any:
+        # use `Object` as base if none is specified
+        if not node.bases:
+            node.bases = [ast.Name("Object", loadCtx)]
+
         # extract all property definitions
         propertyDefs: list[s.PropertyDef] = []
         newBody = []

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -147,7 +147,9 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             func=ast.Name(id="PropertyDefault", ctx=ast.Load()),
             args=[
                 ast.Set(elts=[ast.Constant(value=p) for p in properties]),
-                ast.Set(elts=[ast.Constant(value=attr) for attr in node.attributes]),
+                ast.Set(
+                    elts=[ast.Constant(value=attr.keyword) for attr in node.attributes]
+                ),
                 ast.Lambda(
                     args=selfArg,
                     body=self.visit(node.value),

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -26,6 +26,39 @@ noArgs = ast.arguments(
     kwarg=None,
     defaults=[],
 )
+selfArg = ast.arguments(
+    posonlyargs=[],
+    args=[ast.arg(arg="self", annotation=None)],
+    vararg=None,
+    kwonlyargs=[],
+    kw_defaults=[],
+    kwarg=None,
+    defaults=[],
+)
+
+# helpers
+
+
+class AttributeFinder(ast.NodeVisitor):
+    """Utility class for finding all referenced attributes of a given name."""
+
+    @staticmethod
+    def find(target, node):
+        af = AttributeFinder(target)
+        af.visit(node)
+        return af.attributes
+
+    def __init__(self, target):
+        super().__init__()
+        self.target = target
+        self.attributes = set()
+
+    def visit_Attribute(self, node):
+        val = node.value
+        if isinstance(val, ast.Name) and val.id == self.target:
+            self.attributes.add(node.attr)
+        self.visit(val)
+
 
 # transformer
 
@@ -70,6 +103,57 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                 keywords=[],
             )
         )
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> any:
+        # extract all property definitions
+        propertyDefs: list[s.PropertyDef] = []
+        newBody = []
+        for stmt in node.body:
+            if isinstance(stmt, s.PropertyDef):
+                propertyDefs.append(stmt)
+            else:
+                newBody.append(stmt)
+
+        # create dictionary from property name (str) to default values
+        propertyDict = {}
+        for propertyDef in propertyDefs:
+            if propertyDef.property in propertyDict:
+                raise SyntaxError(f'duplicated property "{propertyDef.property}"')
+            propertyDict[propertyDef.property] = propertyDef
+
+        newBody.insert(
+            0,
+            ast.Assign(
+                targets=[ast.Name(id="_scenic_properties", ctx=ast.Store())],
+                value=ast.Dict(
+                    keys=[ast.Constant(value=p) for p in propertyDict.keys()],
+                    values=[
+                        self.transformPropertyDef(v) for v in propertyDict.values()
+                    ],
+                ),
+            ),
+        )
+
+        node.body = newBody
+        return self.generic_visit(node)
+
+    def transformPropertyDef(self, node: s.PropertyDef):
+        properties = AttributeFinder.find("self", node.value)
+        return ast.Call(
+            func=ast.Name(id="PropertyDefault", ctx=ast.Load()),
+            args=[
+                ast.Set(elts=[ast.Constant(value=p) for p in properties]),
+                ast.Set(elts=[ast.Constant(value=attr) for attr in node.attributes]),
+                ast.Lambda(
+                    args=selfArg,
+                    body=self.visit(node.value),
+                ),
+            ],
+            keywords=[],
+        )
+
+    def visit_PropertyDef(self, _: s.PropertyDef) -> any:
+        assert False, "PropertyDef should be handled in `visit_ClassDef`"
 
     def visit_Model(self, node: s.Model):
         return ast.Expr(

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -726,11 +726,12 @@ scenic_class_property_stmt:
         )
      }
 
-scenic_class_property_attribute:
-    | "additive" { s.Additive(LOCATIONS) }
+# fail if `NAME [ <expr> ]` pattern is found at top level of class definition and
+# <expr> is neither `additive` nor `dynamic`
+scenic_class_property_attribute: &&(
+      "additive" { s.Additive(LOCATIONS) }
     | "dynamic" { s.Dynamic(LOCATIONS) }
-    # if '['' follows NAME at class definition top level and what follows is neither "additive" nor "dynamic", raise an error
-    | a=NAME { self.raise_syntax_error_known_location('unknown attribute "' + a.string + '"', a) }
+)
 
 # Function definitions
 # --------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -717,7 +717,7 @@ scenic_class_statement[list]:
 
 scenic_class_property_stmt:
     # not a simple statement; reads NEWLINE
-    | a=NAME b=['[' attrs=','.NAME+ ']' { [a.string for a in attrs] } ] ':' c=expression NEWLINE { 
+    | a=NAME b=['[' attrs=','.scenic_class_property_attribute+ ']' { attrs } ] ':' c=expression NEWLINE { 
         s.PropertyDef(
             property=a.string,
             attributes=b if b is not None else [],
@@ -725,6 +725,12 @@ scenic_class_property_stmt:
             LOCATIONS,
         )
      }
+
+scenic_class_property_attribute:
+    | "additive" { s.Additive(LOCATIONS) }
+    | "dynamic" { s.Dynamic(LOCATIONS) }
+    # if '['' follows NAME at class definition top level and what follows is neither "additive" nor "dynamic", raise an error
+    | a=NAME { self.raise_syntax_error_known_location('unknown attribute "' + a.string + '"', a) }
 
 # Function definitions
 # --------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -691,7 +691,7 @@ class_def[ast.ClassDef]:
 
 class_def_raw[ast.ClassDef]:
     | invalid_class_def_raw
-    | 'class' a=NAME b=['(' z=[arguments] ')' { z }] &&':' c=block {
+    | 'class' a=NAME b=['(' z=[arguments] ')' { z }] &&':' c=scenic_class_def_block {
         ast.ClassDef(
             a.string,
             bases=b[0] if b else [],
@@ -701,6 +701,43 @@ class_def_raw[ast.ClassDef]:
             LOCATIONS,
         )
      }
+
+scenic_class_def_block:
+    | NEWLINE INDENT a=scenic_class_statements DEDENT { a }
+    | simple_stmts
+    | invalid_block
+
+scenic_class_statements[list]: a=scenic_class_statement+ { list(itertools.chain.from_iterable(a)) }
+
+scenic_class_statement[list]:
+    | a=scenic_class_property_stmt { [a] }
+    | a=compound_stmt { [a] }
+    | a=scenic_stmts { a }
+    | a=simple_stmts { a }
+
+scenic_class_property_stmt:
+    # not a simple statement; reads NEWLINE
+    | a=NAME b=['[' attrs=scenic_class_property_attributes ']' { attrs } ] ':' c=expression NEWLINE { 
+        s.PropertyDef(
+            property=a.string,
+            attributes=b if b is not None else [],
+            value=c,
+            LOCATIONS,
+        )
+     }
+
+scenic_class_property_attributes: attrs=','.NAME+ {
+    [
+        ast.Name(
+            id=a.string,
+            ctx=Load,
+            lineno=a.start[0],
+            col_offset=a.start[1],
+            end_lineno=a.end[0],
+            end_col_offset=a.end[1]
+        ) for a in attrs
+    ]
+}
 
 # Function definitions
 # --------------------

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -717,7 +717,7 @@ scenic_class_statement[list]:
 
 scenic_class_property_stmt:
     # not a simple statement; reads NEWLINE
-    | a=NAME b=['[' attrs=scenic_class_property_attributes ']' { attrs } ] ':' c=expression NEWLINE { 
+    | a=NAME b=['[' attrs=','.NAME+ ']' { [a.string for a in attrs] } ] ':' c=expression NEWLINE { 
         s.PropertyDef(
             property=a.string,
             attributes=b if b is not None else [],
@@ -725,19 +725,6 @@ scenic_class_property_stmt:
             LOCATIONS,
         )
      }
-
-scenic_class_property_attributes: attrs=','.NAME+ {
-    [
-        ast.Name(
-            id=a.string,
-            ctx=Load,
-            lineno=a.start[0],
-            col_offset=a.start[1],
-            end_lineno=a.end[0],
-            end_col_offset=a.end[1]
-        ) for a in attrs
-    ]
-}
 
 # Function definitions
 # --------------------

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -9,7 +9,7 @@ global state such as the list of all created Scenic objects.
 __all__ = (
 	# Primitive statements and functions
 	'ego', 'workspace',
-	'require', 'resample', 'param', 'globalParameters', 'mutate', 'verbosePrint',
+	'new', 'require', 'resample', 'param', 'globalParameters', 'mutate', 'verbosePrint',
 	'localPath', 'model', 'simulator', 'simulation', 'require_always', 'require_eventually',
 	'terminate_when', 'terminate_simulation_when', 'terminate_after', 'in_initial_scenario',
 	'override',
@@ -362,6 +362,11 @@ class Modifier(typing.NamedTuple):
 	terminator: typing.Optional[str] = None
 
 ### Primitive statements and functions
+
+def new(cls, specifiers):
+	if not issubclass(cls, Constructible):
+		raise SyntaxError(f'"{cls.__name__}" is not a Scenic class')
+	return cls(*specifiers)
 
 def ego(obj=None):
 	"""Function implementing loads and stores to the 'ego' pseudo-variable.

--- a/tests/syntax/test_classes.py
+++ b/tests/syntax/test_classes.py
@@ -5,25 +5,14 @@ import pytest
 from scenic.core.errors import TokenParseError, ASTParseError, RuntimeParseError
 from tests.utils import compileScenic, sampleScene
 
-def test_wrong_class_statement():
-    with pytest.raises(TokenParseError):
-        compileScenic("""
-            constructor Foo(object):
-                pass
-        """)
-    with pytest.raises(TokenParseError):
-        compileScenic("""
-            import collections
-            constructor Foo(collections.defaultdict):
-                pass
-        """)
 
 def test_old_constructor_statement():
-    compileScenic("""
-        constructor Foo:
-            blah: 19 @ -3
-        ego = Foo with blah 12
-    """)
+    with pytest.raises(SyntaxError):
+        compileScenic("""
+            constructor Foo:
+                blah: (19, -3)
+            ego = Foo with blah 12
+        """)
 
 def test_python_class():
     scenario = compileScenic("""

--- a/tests/syntax/test_classes.py
+++ b/tests/syntax/test_classes.py
@@ -26,7 +26,7 @@ def test_python_class():
     assert ego.width == 4
 
 def test_invalid_attribute():
-    with pytest.raises(RuntimeParseError):
+    with pytest.raises(SyntaxError):
         compileScenic("""
             class Foo:\n
                 blah[baloney_attr]: 4

--- a/tests/syntax/test_classes.py
+++ b/tests/syntax/test_classes.py
@@ -30,7 +30,7 @@ def test_python_class():
         class Foo(object):
             def __init__(self, x):
                  self.x = x
-        ego = Object with width Foo(4).x
+        ego = new Object with width Foo(4).x
     """)
     scene = sampleScene(scenario, maxIterations=1)
     ego = scene.egoObject
@@ -46,9 +46,9 @@ def test_invalid_attribute():
 def test_property_simple():
     scenario = compileScenic("""
         class Foo:
-            position: 3 @ 9
+            position: (3, 9)
             flubber: -12
-        ego = Foo
+        ego = new Foo
     """)
     scene = sampleScene(scenario, maxIterations=1)
     ego = scene.egoObject
@@ -62,7 +62,7 @@ def test_property_inheritance():
             flubber: -12
         class Bar(Foo):
             flubber: 7
-        ego = Bar
+        ego = new Bar
     """)
     scene = sampleScene(scenario, maxIterations=1)
     ego = scene.egoObject
@@ -72,13 +72,13 @@ def test_property_inheritance():
 def test_isinstance_issubclass():
     scenario = compileScenic("""
         class Foo: pass
-        ego = Foo
+        ego = new Foo
         if isinstance(ego, Foo):
-            other = Object at 10@0
+            other = new Object at (10, 0)
         if not isinstance(other, Foo):
-            Object at 20@0
+            new Object at (20, 0)
         if issubclass(Foo, Point):
-            Object at 30@0
+            new Object at (30, 0)
     """)
     scene = sampleScene(scenario)
     assert len(scene.objects) == 4

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -53,17 +53,30 @@ class TestCompiler:
             compileScenicAST(Assign([Name("workspace", Store())], Constant(1)))
 
     def test_classdef(self):
+        # Object is specified as a base
         # `_scenic_properties` is initialized at the beginning of class body
         node, _ = compileScenicAST(ClassDef("C", [], [], [], []))
         match node:
             case ClassDef(
                 name="C",
+                bases=[Name("Object", Load())],
                 body=[
                     Assign(
                         targets=[Name("_scenic_properties", Store())],
                         value=Dict([], []),
                     )
                 ],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_classdef_explicit_base(self):
+        node, _ = compileScenicAST(ClassDef("C", [Name("MyBase", Load())], [], [], []))
+        match node:
+            case ClassDef(
+                name="C",
+                bases=[Name("MyBase", Load())],
             ):
                 assert True
             case _:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -142,7 +142,7 @@ class TestCompiler:
                 [
                     PropertyDef(
                         "property",
-                        ["a", "b"],
+                        [Dynamic()],
                         Attribute(
                             value=Name(id="self", ctx=Load()), attr="x", ctx=Load()
                         ),
@@ -164,7 +164,7 @@ class TestCompiler:
                                     func=Name(id="PropertyDefault", ctx=Load()),
                                     args=[
                                         Set([Constant("x")]),  # includes `x`
-                                        Set([Constant("a"), Constant("b")]),
+                                        Set([Constant("dynamic")]),
                                         Lambda(
                                             body=Attribute(
                                                 value=Name(id="self", ctx=Load()),

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -333,7 +333,7 @@ class TestCompiler:
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))
         match node:
-            case Call(Name("Object")):
+            case Call(Name("new"), [Name("Object"), List([])]):
                 assert True
             case _:
                 assert False
@@ -342,7 +342,11 @@ class TestCompiler:
         node, _ = compileScenicAST(New("Object", [WithSpecifier("foo", Constant(1))]))
         match node:
             case Call(
-                Name("Object"), [Call(Name("With"), [Constant("foo"), Constant(1)])]
+                Name("new"),
+                [
+                    Name("Object"),
+                    List([Call(Name("With"), [Constant("foo"), Constant(1)])]),
+                ],
             ):
                 assert True
             case _:
@@ -357,10 +361,15 @@ class TestCompiler:
         )
         match node:
             case Call(
-                Name("Object"),
+                Name("new"),
                 [
-                    Call(Name("With"), [Constant("foo"), Constant(1)]),
-                    Call(Name("At"), [Name("position")]),
+                    Name("Object"),
+                    List(
+                        [
+                            Call(Name("With"), [Constant("foo"), Constant(1)]),
+                            Call(Name("At"), [Name("position")]),
+                        ]
+                    ),
                 ],
             ):
                 assert True

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -68,6 +68,10 @@ def test_malformed_constructor():
     with pytest.raises(TokenParseError):
         compileScenic('constructor Foo(Bar:\n' '    pass')
 
+def test_multiple_inheritance():
+    with pytest.raises(SyntaxError):
+        compileScenic("class Bad(Object, Point):\n    pass")
+
 ## Soft requirements
 
 def test_malformed_soft_requirement():

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -72,6 +72,10 @@ def test_multiple_inheritance():
     with pytest.raises(SyntaxError):
         compileScenic("class Bad(Object, Point):\n    pass")
 
+def test_new_python_class():
+    with pytest.raises(SyntaxError):
+        compileScenic("class PyCls(object):\n    pass\nnew PyCls")
+
 ## Soft requirements
 
 def test_malformed_soft_requirement():

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1,6 +1,6 @@
 from ast import *
 from typing import Any
-from textwrap import dedent
+from inspect import cleandoc
 
 import pytest
 
@@ -10,7 +10,7 @@ from scenic.syntax.parser import parse_string
 
 def parse_string_helper(source: str) -> Any:
     "Parse string and return Scenic AST"
-    return parse_string(dedent(source), "exec")
+    return parse_string(cleandoc(source), "exec")
 
 
 class TestTrackedNames:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -89,11 +89,7 @@ class TestClass:
                 name="C",
                 bases=[],
                 keywords=[],
-                body=[
-                    PropertyDef(
-                        "property", [Name("attribute", Load())], Name("value", Load())
-                    )
-                ],
+                body=[PropertyDef("property", ["attribute"], Name("value", Load()))],
             ):
                 assert True
             case _:
@@ -115,7 +111,7 @@ class TestClass:
                 body=[
                     PropertyDef(
                         "property",
-                        [Name("attribute1", Load()), Name("attribute2", Load())],
+                        ["attribute1", "attribute2"],
                         Name("value", Load()),
                     )
                 ],

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -80,7 +80,7 @@ class TestClass:
         mod = parse_string_helper(
             """
             class C:
-                property[attribute]: value
+                property[additive]: value
             """
         )
         stmt = mod.body[0]
@@ -89,7 +89,7 @@ class TestClass:
                 name="C",
                 bases=[],
                 keywords=[],
-                body=[PropertyDef("property", ["attribute"], Name("value", Load()))],
+                body=[PropertyDef("property", [Additive()], Name("value", Load()))],
             ):
                 assert True
             case _:
@@ -99,7 +99,7 @@ class TestClass:
         mod = parse_string_helper(
             """
             class C:
-                property[attribute1, attribute2]: value
+                property[additive, dynamic]: value
             """
         )
         stmt = mod.body[0]
@@ -111,7 +111,7 @@ class TestClass:
                 body=[
                     PropertyDef(
                         "property",
-                        ["attribute1", "attribute2"],
+                        [Additive(), Dynamic()],
                         Name("value", Load()),
                     )
                 ],
@@ -119,6 +119,16 @@ class TestClass:
                 assert True
             case _:
                 assert False
+
+    def test_property_def_unknown_attribute(self):
+        with pytest.raises(SyntaxError) as e:
+            parse_string_helper(
+                """
+                class C:
+                    property[unknown_attribute]: value
+                """
+            )
+        assert 'unknown attribute "unknown_attribute"' in str(e)
 
     def test_property_def_nested(self):
         # property definition is allowed only on the top level

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -120,15 +120,24 @@ class TestClass:
             case _:
                 assert False
 
-    def test_property_def_unknown_attribute(self):
-        with pytest.raises(SyntaxError) as e:
+    def test_property_def_unknown_attribute_1(self):
+        with pytest.raises(SyntaxError):
             parse_string_helper(
                 """
                 class C:
-                    property[unknown_attribute]: value
+                    property[unknown]: value
                 """
             )
-        assert 'unknown attribute "unknown_attribute"' in str(e)
+
+    def test_property_def_unknown_attribute_2(self):
+        # must raise an error even if attribute is not a NAME
+        with pytest.raises(SyntaxError):
+            parse_string_helper(
+                """
+                class C:
+                    property[2]: value
+                """
+            )
 
     def test_property_def_nested(self):
         # property definition is allowed only on the top level


### PR DESCRIPTION
## Overview

This PR implements the new strategy to compile Scenic class definitions and property definitions.

An overview of the strategy can be found in [my note](https://shun-notes.notion.site/How-to-compile-class-definitions-482061588cd14ec091c51e74d7eaba8b).

## Change in Grammar

Several changes were made to the grammar to generate AST nodes that represent property definitions.

In Scenic, properties can be added to the class using the following syntax.

```python
class MyScenicClass(Object):
    # without attributes
    property: value
    # with attributes
    property[additive]: value
```

Although the code above is syntactically valid in Python, it has a different semantic, and we want to generate different types of AST nodes.

This PR adds `PropertyDef` for this purpose. `PropertyDef` has three fields: `property` for the name of the property, `attributes` for meta attributes and `value` for the default value of the property.

Note that `PropertyDef` can only be at the top level of the class definition body. For example, the following code would not produce `PropertyDef` and instead generate Python's `AnnAssign`.

```python
class MyScenicClass(Object):
    def method():
        property: value # -> AnnAssign to the variable `property`
        property[additive]: value # -> AnnAssign to `property` subscript `additive`
```

To achieve this, I added `scenic_class_def_block`, `scenic_class_statements` and `scenic_class_statement` to the grammar. They are almost identical to the normal `block` `statements` `statement`, but in addition to all statements, it allows `scenic_class_property_stmt` with the highest precedence. By having `scenic_class_def_block` for class body, property definitions are parsed as `PropertyDef`.

Only the two literal `additive` and `dynamic` can be inside the square brackets (with a comma to separate the two if need to specify both). If a different literal is specified, that raises a syntax error.

## Compiling `ClassDef` `PropertyDef`

With this PR, we are moving away from passing default values using annotations. Instead of annotations, the compiler creates a special dictionary `_scenic_properties` that stores all properties and corresponding values for a class.

As stated, `PropertyDef` can only be in a body of `ClassDef`. On `visit_ClassDef`, we extract all property definitions and turn them into a single dictionary declaration.

For example, 

```python
class MyScenicClass(Object):
    property1: value1
    property2: value2
```

would be compiled to

```python
class MyScenicClass(Object):
    _scenic_properties = {
        "property1": PropertyDefault(set(), set(), lambda self: value1),
        "property2": PropertyDefault(set(), set(), lambda self: value2),
    }
```

Because we do this transformation in `ClassDef`, `visit_PropertyDef` should not be called. If the function is called, it will raise an assertion error.

`visit_ClassDef` also adds `Object` for the base class if no base classes were specified.

## Reading property values

`object_types.py` was changed to read property values from `_scenic_properties` instead of `__annotations__`.

The file has definitions of the built-in types (`Object`, `Point`, `OrientedPoint`). They were rewritten to define properties using `_scenic_properties`.

Finally, `__init__subclass__` on `Constructible` now asserts that no more than one Scenic class was given as the base class to enforce single inheritance of Scenic classes.

## `new` veneer function

The `new` keyword now asserts that the given class is a Scenic class (i.e., the subclass of `Constructible`).

The `new` keyword is compiled to a call to the `new` veneer function. It performs the check, raises an exception if the check fails, and returns an instance.


