### PR TITLE
Add `--dump-scenic-ast` debug flag

### DIFF
--- a/src/scenic/__main__.py
+++ b/src/scenic/__main__.py
@@ -66,7 +66,7 @@ debugOpts.add_argument('--pdb-on-reject', action='store_true',
 ver = metadata.version('scenic')
 debugOpts.add_argument('--version', action='version', version=f'Scenic {ver}',
                        help='print Scenic version information and exit')
-debugOpts.add_argument('--dump-initial-python', help='dump initial translated Python',
+debugOpts.add_argument('--dump-scenic-ast', help='dump Scenic AST',
                        action='store_true')
 debugOpts.add_argument('--dump-ast', help='dump final AST', action='store_true')
 debugOpts.add_argument('--dump-python', help='dump Python equivalent of final AST',
@@ -102,7 +102,7 @@ for name, value in args.param:
         except ValueError:
             pass
     params[name] = value
-translator.dumpTranslatedPython = args.dump_initial_python
+translator.dumpScenicAST = args.dump_scenic_ast
 translator.dumpFinalAST = args.dump_ast
 translator.dumpASTPython = args.dump_python
 translator.verbosity = args.verbosity

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -28,6 +28,7 @@ class Model(AST):
     def __init__(self, name: str, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
         self.name = name
+        self._fields = ["name"]
 
 
 class Param(AST):
@@ -51,7 +52,7 @@ class parameter(AST):
         super().__init__(*args, **kwargs)
         self.identifier = identifier
         self.value = value
-        self._fields = ["value"]
+        self._fields = ["identifier" ,"value"]
 
 
 class Require(AST):
@@ -69,7 +70,7 @@ class Require(AST):
         self.cond = cond
         self.prob = prob
         self.name = name
-        self._fields = ["cond"]
+        self._fields = ["cond", "prob", "name"]
 
 
 # Instance Creation
@@ -84,7 +85,7 @@ class New(AST):
         super().__init__(*args, **kwargs)
         self.className = className
         self.specifiers = specifiers if specifiers is not None else []
-        self._fields = ["specifiers"]
+        self._fields = ["className", "specifiers"]
 
 
 # Specifiers
@@ -97,7 +98,7 @@ class WithSpecifier(AST):
         super().__init__(*args, **kwargs)
         self.prop = prop
         self.value = value
-        self._fields = ["value"]
+        self._fields = ["prob", "value"]
 
 
 class AtSpecifier(AST):
@@ -183,6 +184,7 @@ class BeyondSpecifier(AST):
         self.position = position
         self.offset = offset
         self.base = base
+        self._fields = ["position", "offset", "base"]
 
 
 class VisibleSpecifier(AST):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -85,6 +85,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                         list(d.values()),
                     )
                 ],
+                keywords=[],
             )
         )
 

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -247,6 +247,12 @@ def compileStream(stream, namespace, params={}, model=None, filename='<stream>')
 		# Parse the translated source
 		source = stream.read().decode('utf-8')
 		scenic_tree = parse_string(source, "exec", None)
+
+		if dumpScenicAST:
+			print(f'### Begin Scenic AST of {filename}')
+			print(ast.dump(scenic_tree, include_attributes=False, indent=4))
+			print('### End Scenic AST')
+
 		tree, requirements = compileScenicAST(scenic_tree)
 
 		if dumpFinalAST:
@@ -284,7 +290,7 @@ def compileStream(stream, namespace, params={}, model=None, filename='<stream>')
 
 ## Options
 
-dumpTranslatedPython = False
+dumpScenicAST = False
 dumpFinalAST = False
 dumpASTPython = False
 verbosity = 0

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -87,14 +87,14 @@ def test_verbose():
     scenic.syntax.translator.verbosity = 1
 
 def test_dump_python():
-    scenic.syntax.translator.dumpTranslatedPython = True
+    scenic.syntax.translator.dumpScenicAST = True
     try:
-        compileScenic('ego = Object')
+        compileScenic('ego = new Object')
     finally:
         scenic.syntax.translator.dumpTranslatedPython = False
     scenic.syntax.translator.dumpFinalAST = True
     try:
-        compileScenic('ego = Object')
+        compileScenic('ego = new Object')
     finally:
         scenic.syntax.translator.dumpFinalAST = False
 
@@ -102,6 +102,6 @@ def test_dump_final_python():
     pytest.importorskip('astor')
     scenic.syntax.translator.dumpASTPython = True
     try:
-        compileScenic('ego = Object')
+        compileScenic('ego = new Object')
     finally:
         scenic.syntax.translator.dumpASTPython = False

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -91,7 +91,7 @@ def test_dump_python():
     try:
         compileScenic('ego = new Object')
     finally:
-        scenic.syntax.translator.dumpTranslatedPython = False
+        scenic.syntax.translator.dumpScenicAST = False
     scenic.syntax.translator.dumpFinalAST = True
     try:
         compileScenic('ego = new Object')


### PR DESCRIPTION
This PR adds `--dump-scenic-ast`. This flag replaces `--dump-initial-python` and dumps the Scenic AST tree that is generated by the new parser.

