### PR TITLE
[Parser] Fix Static Test Syntax + Small Bug Fixes

### DIFF
--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -218,7 +218,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
                     ast.Constant(value=node.lineno),
                     ast.Constant(value=node.name),
                 ],
-                keywords=[ast.keyword(arg="prob", value=node.prob)]
+                keywords=[ast.keyword(arg="prob", value=ast.Constant(node.prob))]
                 if node.prob is not None
                 else [],
             )

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1256,8 +1256,8 @@ scenic_specifiers: ss=','.scenic_specifier+ { ss }
 scenic_specifier:
     | 'with' p=NAME v=expression { s.WithSpecifier(prop=p.string, value=v, LOCATIONS) }
     | 'at' position=expression { s.AtSpecifier(position=position, LOCATIONS) }
-    | 'offset' 'by' o=expression { s.OffsetBySpecifier(offset=o, LOCATIONS) }
-    | 'offset' 'along' d=expression 'by' o=expression { s.OffsetAlongSpecifier(direction=d, offset=o, LOCATIONS) }
+    | "offset" 'by' o=expression { s.OffsetBySpecifier(offset=o, LOCATIONS) }
+    | "offset" 'along' d=expression 'by' o=expression { s.OffsetAlongSpecifier(direction=d, offset=o, LOCATIONS) }
     | direction=scenic_specifier_position_direction position=expression distance=['by' e=expression { e }] {
         s.DirectionOfSpecifier(direction=direction, position=position, distance=distance, LOCATIONS)
      }

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -468,6 +468,10 @@ class Parser(Parser):
 '''
 
 
+# rule for adding hard keywords
+scenic_hard_keyword: 'PropertyDefault'
+
+
 # STARTING RULES
 # ==============
 

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -1083,8 +1083,6 @@ def Following(field, dist, fromPt=None):
 	"""
 	if fromPt is None:
 		fromPt = ego()
-	else:
-		dist, fromPt = fromPt, dist
 	if not isinstance(field, VectorField):
 		raise RuntimeParseError('"following F" specifier with F not a vector field')
 	fromPt = toVector(fromPt, '"following F from X for D" with X not a vector')

--- a/tests/syntax/helper.scenic
+++ b/tests/syntax/helper.scenic
@@ -1,11 +1,11 @@
 
-constructor Rabbit:
+class Rabbit:
     species: 'killer'
 
 class Caerbannog(Rabbit):
     species: 'Caerbannog'
 
-helpful_rabbit = Rabbit with species 'helpful', at 10 @ 0
+helpful_rabbit = new Rabbit with species 'helpful', at 10 @ 0
 
 param helper_file = __file__
 param helper_name = __name__

--- a/tests/syntax/helper3.scenic
+++ b/tests/syntax/helper3.scenic
@@ -1,4 +1,4 @@
 
-obj = Object at Range(-10, 10) @ Range(-10, 10)
+obj = new Object at Range(-10, 10) @ Range(-10, 10)
 
 require obj.position.x > 0

--- a/tests/syntax/imports.scenic
+++ b/tests/syntax/imports.scenic
@@ -2,7 +2,7 @@
 from helper import *
 from helper2 import thingy
 
-ego = Rabbit
+ego = new Rabbit
 
 param thingy = thingy
 param imports_file = __file__

--- a/tests/syntax/test_ast.py
+++ b/tests/syntax/test_ast.py
@@ -6,7 +6,7 @@ from scenic.syntax.translator import LocalFinder
 from tests.utils import compileScenic, sampleEgoFrom, sampleParamPFrom
 
 def test_method_of_expr():
-    ego = sampleEgoFrom('ego = Object at (12@3).distanceTo(13@3) @ 0')
+    ego = sampleEgoFrom('ego = new Object at (12@3).distanceTo(13@3) @ 0')
     assert ego.x == 1
 
 def test_local_finder():

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -11,7 +11,7 @@ def test_empty():
         compileScenic('')
 
 def test_minimal():
-    scenario = compileScenic('ego = Object')
+    scenario = compileScenic('ego = new Object')
     assert len(scenario.objects) == 1
     obj = scenario.objects[0]
     assert type(obj) is Object
@@ -26,7 +26,7 @@ def test_minimal():
     assert len(scene.params) == 0
 
 def test_ego_second():
-    scenario = compileScenic('Object\n' 'ego = Object at 0 @ -5')
+    scenario = compileScenic('new Object\n' 'ego = new Object at 0 @ -5')
     assert len(scenario.objects) == 2
     obj = scenario.objects[0]
     assert obj is scenario.egoObject
@@ -37,42 +37,42 @@ def test_ego_second():
 
 def test_ego_nonobject():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Point')
+        compileScenic('ego = new Point')
     with pytest.raises(RuntimeParseError):
         compileScenic('ego = dict()')
 
 def test_ego_undefined():
     with pytest.raises(RuntimeParseError):
-        compileScenic('x = ego\n' 'ego = Object')
+        compileScenic('x = ego\n' 'ego = new Object')
 
 def test_noninterference():
-    scenario = compileScenic('ego = Object')
+    scenario = compileScenic('ego = new Object')
     assert len(scenario.objects) == 1
     ego1 = scenario.egoObject
     for i in range(5):
         scene = sampleScene(scenario, maxIterations=1)
-    scenario = compileScenic('ego = Object')
+    scenario = compileScenic('ego = new Object')
     assert len(scenario.objects) == 1
     ego2 = scenario.egoObject
     assert ego1 is not ego2
 
 def test_param():
-    p = sampleParamPFrom('ego = Object\n' 'param p = Range(3, 5)')
+    p = sampleParamPFrom('ego = new Object\n' 'param p = Range(3, 5)')
     assert 3 <= p <= 5
-    p = sampleParamPFrom('ego = Object\n' 'param p = [1, 4, 9]')
+    p = sampleParamPFrom('ego = new Object\n' 'param p = [1, 4, 9]')
     assert type(p) is list
     assert p == [1, 4, 9]
-    p = sampleParamPFrom('ego = Object\n' 'param p = (1, 4)')
+    p = sampleParamPFrom('ego = new Object\n' 'param p = (1, 4)')
     assert type(p) is tuple
     assert p == (1, 4)
 
 def test_quoted_param():
-    p = sampleParamPFrom('ego = Object\n' 'param "p" = Range(3, 5)')
+    p = sampleParamPFrom('ego = new Object\n' 'param "p" = Range(3, 5)')
     assert 3 <= p <= 5
 
 def test_mutate():
     scenario = compileScenic("""
-        ego = Object at 3@1, facing 0
+        ego = new Object at 3@1, facing 0
         mutate
     """)
     ego1 = sampleEgo(scenario)
@@ -104,7 +104,7 @@ def test_mutate_scaled():
 def test_verbose():
     for verb in range(4):
         scenic.syntax.translator.verbosity = verb
-        compileScenic('ego = Object')
+        compileScenic('ego = new Object')
     scenic.syntax.translator.verbosity = 1
 
 def test_dump_python():

--- a/tests/syntax/test_classes.py
+++ b/tests/syntax/test_classes.py
@@ -11,7 +11,7 @@ def test_old_constructor_statement():
         compileScenic("""
             constructor Foo:
                 blah: (19, -3)
-            ego = Foo with blah 12
+            ego = new Foo with blah 12
         """)
 
 def test_python_class():

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -317,7 +317,7 @@ class TestCompiler:
             ):
                 assert name is None if expected_name is None else name == expected_name
                 compiled_prob = (
-                    kwargs[0].value if kwargs else 1.0
+                    kwargs[0].value.value if kwargs else 1.0
                 )  # if kwargs is empty, use 1.0
                 assert compiled_prob == expected_prob
             case _:

--- a/tests/syntax/test_distributions.py
+++ b/tests/syntax/test_distributions.py
@@ -16,7 +16,7 @@ def lazyTestScenario(expr, offset='0'):
     return compileScenic(
         'vf = VectorField("Foo", lambda pos: 2 * pos.x)\n'
         f'x = {offset} relative to vf\n'
-        f'ego = Object at 0.5 @ 0, facing {expr}'
+        f'ego = new Object at 0.5 @ 0, facing {expr}'
     )
 
 ## Options and Uniform
@@ -46,14 +46,14 @@ def test_uniform_interval_wrong_type():
         compileScenic('x = Range(-10, [])')
 
 def test_uniform_interval():
-    scenario = compileScenic('ego = Object at Range(100, 200) @ 0')
+    scenario = compileScenic('ego = new Object at Range(100, 200) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(100 <= x <= 200 for x in xs)
     assert any(x < 150 for x in xs)
     assert any(150 < x for x in xs)
 
 def test_uniform_discrete():
-    scenario = compileScenic('ego = Object at Uniform(1, 2, 3.4) @ 0')
+    scenario = compileScenic('ego = new Object at Uniform(1, 2, 3.4) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(100)]
     assert all(x == 1 or x == 2 or x == 3.4 for x in xs)
     assert any(x == 1 for x in xs)
@@ -69,7 +69,7 @@ def test_uniform_discrete_lazy():
 
 @pytest.mark.parametrize('dist', ('Options', 'Discrete'))
 def test_options(dist):
-    scenario = compileScenic(f'ego = Object at {dist}({{0: 1, 1: 9}}) @ 0')
+    scenario = compileScenic(f'ego = new Object at {dist}({{0: 1, 1: 9}}) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(200)]
     assert all(x == 0 or x == 1 for x in xs)
     assert 145 <= sum(xs) < 200
@@ -83,7 +83,7 @@ def test_options_lazy():
 ## Functions, methods, attributes, operators
 
 def test_function():
-    scenario = compileScenic('ego = Object at sin(Uniform(45 deg, 90 deg)) @ 0')
+    scenario = compileScenic('ego = new Object at sin(Uniform(45 deg, 90 deg)) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     valA, valB = (pytest.approx(math.sin(math.radians(a))) for a in (45, 90))
     assert all(x == valA or x == valB for x in xs)
@@ -108,7 +108,7 @@ def test_method():
     scenario = compileScenic(
         'field = VectorField("Foo", lambda pos: pos[1])\n'
         'ang = field[0 @ Range(100, 200)]\n'
-        'ego = Object facing ang'
+        'ego = new Object facing ang'
     )
     angles = [sampleEgo(scenario).heading for i in range(60)]
     assert all(100 <= x <= 200 for x in angles)
@@ -125,7 +125,7 @@ def test_method_lazy():
             def bar(self, arg):
                 return -arg
         vf = VectorField("Baz", lambda pos: 1 + pos.x)
-        ego = Object facing Foo().bar(Range(100, 200) * (0 relative to vf))
+        ego = new Object facing Foo().bar(Range(100, 200) * (0 relative to vf))
     """)
     angles = [sampleEgo(scenario).heading for i in range(60)]
     assert all(-200 <= x <= -100 for x in angles)
@@ -141,7 +141,7 @@ def test_method_lazy_2():
         '    def bar(self, arg):\n'
         '        return -arg * Range(100, 200)\n'
         'vf = VectorField("Baz", lambda pos: 1 + pos.x)\n'
-        'ego = Object facing Foo().bar(0 relative to vf)'
+        'ego = new Object facing Foo().bar(0 relative to vf)'
     )
     angles = [sampleEgo(scenario).heading for i in range(60)]
     assert all(-200 <= x <= -100 for x in angles)
@@ -151,7 +151,7 @@ def test_method_lazy_2():
 def test_attribute():
     scenario = compileScenic(
         'place = Uniform(1 @ 1, 2 @ 4, 3 @ 9)\n'
-        'ego = Object at place.x @ place.y'
+        'ego = new Object at place.x @ place.y'
     )
     xs = [sampleEgo(scenario).position.x for i in range(100)]
     assert all(x == 1 or x == 2 or x == 3 for x in xs)
@@ -160,7 +160,7 @@ def test_attribute():
     assert any(x == 3 for x in xs)
 
 def test_operator():
-    scenario = compileScenic('ego = Object at -(100 + Range(0, 100)) @ 0')
+    scenario = compileScenic('ego = new Object at -(100 + Range(0, 100)) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(-200 <= x <= -100 for x in xs)
     assert any(x < -150 for x in xs)
@@ -176,7 +176,7 @@ def test_operator_lazy():
 ## Vectors
 
 def test_vector_operator():
-    scenario = compileScenic('ego = Object at Range(-3, 3) @ 0 + Range(100, 110) @ 0')
+    scenario = compileScenic('ego = new Object at Range(-3, 3) @ 0 + Range(100, 110) @ 0')
     xs = [sampleEgo(scenario).position.x for i in range(100)]
     assert all(97 <= x <= 113 for x in xs)
     assert any(x < 105 for x in xs)
@@ -197,7 +197,7 @@ def test_vector_method_lazy_2():
 ## Lists, tuples, namedtuples
 
 def test_list():
-    scenario = compileScenic('ego = Object with foo [3, Uniform(1, 2)]')
+    scenario = compileScenic('ego = new Object with foo [3, Uniform(1, 2)]')
     ts = [sampleEgo(scenario).foo for i in range(60)]
     assert all(type(t) is list for t in ts)
     assert all(t[0] == 3 for t in ts)
@@ -206,7 +206,7 @@ def test_list():
     assert any(t[1] == 2 for t in ts)
 
 def test_list_param():
-    scenario = compileScenic('ego = Object\n' 'param p = [3, Uniform(1, 2)]')
+    scenario = compileScenic('ego = new Object\n' 'param p = [3, Uniform(1, 2)]')
     ts = [sampleParamP(scenario) for i in range(60)]
     assert all(type(t) is list for t in ts)
     assert all(t[0] == 3 for t in ts)
@@ -220,7 +220,7 @@ def test_list_param_lazy():
             'vf = VectorField("Foo", lambda pos: 2 * pos.x)\n'
             'x = 0 relative to vf\n'
             'param p = Uniform([0, x], [0, x*2])[1]\n'
-            'ego = Object'
+            'ego = new Object'
         )
 
 def test_list_object_lazy():
@@ -233,7 +233,7 @@ def test_list_object_lazy():
 def test_list_nested():
     scenario = compileScenic("""
         mylist = Uniform(list(range(1000)), [1000])
-        ego = Object with foo Uniform(*mylist)
+        ego = new Object with foo Uniform(*mylist)
     """)
     vs = [sampleEgo(scenario).foo for i in range(60)]
     assert 5 <= sum((v == 1000) for v in vs) <= 55
@@ -241,7 +241,7 @@ def test_list_nested():
 def test_list_nested_argument():
     scenario = compileScenic("""
         mylist = Uniform(list(range(1000)), [1, 1, 1, 1, 2000])
-        ego = Object with foo max(*mylist)
+        ego = new Object with foo max(*mylist)
     """)
     vs = [sampleEgo(scenario).foo for i in range(60)]
     assert 5 <= sum((v == 2000) for v in vs) <= 55
@@ -250,14 +250,14 @@ def test_list_filtered():
     scenario = compileScenic("""
         mylist = [Range(-10, -5), Range(3, 7), Range(-1, 1)]
         filtered = filter(lambda x: x > 0, mylist)
-        ego = Object with foo Uniform(*filtered)
+        ego = new Object with foo Uniform(*filtered)
     """)
     vs = [sampleEgo(scenario).foo for i in range(60)]
     assert all(v > 0 for v in vs)
     assert any(v < 1 for v in vs)
 
 def test_tuple():
-    scenario = compileScenic('ego = Object with foo tuple([3, Uniform(1, 2)])')
+    scenario = compileScenic('ego = new Object with foo tuple([3, Uniform(1, 2)])')
     ts = [sampleEgo(scenario).foo for i in range(60)]
     assert all(type(t) is tuple for t in ts)
     assert all(t[0] == 3 for t in ts)
@@ -266,7 +266,7 @@ def test_tuple():
     assert any(t[1] == 2 for t in ts)
 
 def test_tuple_param():
-    scenario = compileScenic('ego = Object\n' 'param p = tuple([3, Uniform(1, 2)])')
+    scenario = compileScenic('ego = new Object\n' 'param p = tuple([3, Uniform(1, 2)])')
     ts = [sampleParamP(scenario) for i in range(60)]
     assert all(type(t) is tuple for t in ts)
     assert all(t[0] == 3 for t in ts)
@@ -278,7 +278,7 @@ def test_namedtuple():
     scenario = compileScenic(
         'from collections import namedtuple\n'
         'Data = namedtuple("Data", ["bar", "baz"])\n'
-        'ego = Object with foo Data(bar=3, baz=Uniform(1, 2))'
+        'ego = new Object with foo Data(bar=3, baz=Uniform(1, 2))'
     )
     ts = [sampleEgo(scenario).foo for i in range(60)]
     assert all(t.bar == 3 for t in ts)
@@ -291,9 +291,9 @@ def test_namedtuple():
 @pytest.mark.slow
 def test_reproducibility():
     scenario = compileScenic(
-        'ego = Object\n'
-        'Object offset by 0@3, facing Range(0, 360) deg\n'
-        'Object offset by 0@6, facing Range(0, 360) deg\n'
+        'ego = new Object\n'
+        'new Object offset by 0@3, facing Range(0, 360) deg\n'
+        'new Object offset by 0@6, facing Range(0, 360) deg\n'
         'param foo = Uniform(1, 4, 9, 16, 25, 36)\n'
         'x = Range(0, 1)\n'
         'require x > 0.8'
@@ -314,7 +314,7 @@ def test_reproducibility():
 ## Independence
 
 def test_independence():
-    scenario = compileScenic('ego = Object at Range(0, 1) @ Range(0, 1)')
+    scenario = compileScenic('ego = new Object at Range(0, 1) @ Range(0, 1)')
     pos = sampleEgo(scenario).position
     assert pos.x != pos.y
 
@@ -323,7 +323,7 @@ def test_independence():
 def test_shared_dependency():
     scenario = compileScenic(
         'x = Range(-1, 1)\n'
-        'ego = Object at (x * x) @ 0'
+        'ego = new Object at (x * x) @ 0'
     )
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(0 <= x <= 1 for x in xs)
@@ -335,7 +335,7 @@ def test_shared_dependency_lazy_1():
         vf = VectorField("Foo", lambda pos: 2 * pos.x)
         x = 1 relative to vf
         y = Uniform(0, x)
-        ego = Object with foo y, with bar y
+        ego = new Object with foo y, with bar y
     """)
     for i in range(60):
         ego = sampleEgo(scenario)
@@ -346,8 +346,8 @@ def test_shared_dependency_lazy_2():
     scenario = compileScenic(
         'vf = VectorField("Foo", lambda pos: 2 * pos.x)\n'
         'x = Range(0, 1) relative to vf\n'
-        'ego = Object at 1 @ 0, facing x\n'
-        'other = Object at -1 @ 0, facing x'
+        'ego = new Object at 1 @ 0, facing x\n'
+        'other = new Object at -1 @ 0, facing x'
     )
     for i in range(60):
         scene = sampleScene(scenario, maxIterations=1)
@@ -369,8 +369,8 @@ def test_inside_delayed_argument():
 
 def test_object_expression():
     scenario = compileScenic("""
-        v = Uniform((Object at Range(-2,-1) @ 0), Object at Range(1,2) @ 5).position.x
-        ego = Object facing v, at 0 @ 10
+        v = Uniform((new Object at Range(-2,-1) @ 0), new Object at Range(1,2) @ 5).position.x
+        ego = new Object facing v, at 0 @ 10
         require abs(v) > 1.5
     """)
     for i in range(3):

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -23,7 +23,7 @@ def test_bad_extension(tmpdir):
     with pytest.raises(RuntimeError), open(path, 'w'):
         scenic.scenarioFromFile(path)
 
-### Parse errors during token translation
+### Parse errors
 
 ## Constructor definitions
 
@@ -95,16 +95,12 @@ def test_incomplete_multiline_string():
     with pytest.raises(TokenError):
         compileScenic('x = """foobar\n' 'wog\n')
 
-### Parse errors during Python parsing
-
 def test_incomplete_infix_operator():
     """Binary infix operator with too few arguments."""
     with pytest.raises(SyntaxError):
         compileScenic('x = 3 @')
     with pytest.raises(SyntaxError):
         compileScenic('x = 3 at')
-
-### Parse errors during parse tree surgery
 
 ## Infix operators
 

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -2,6 +2,7 @@
 import sys
 import os.path
 import subprocess
+from tokenize import TokenError
 
 import pytest
 
@@ -24,49 +25,25 @@ def test_bad_extension(tmpdir):
 
 ### Parse errors during token translation
 
-## Operators used in Python but not Scenic
-
-@pytest.mark.parametrize('op', ('~',))
-def test_illegal_unary_operators(op):
-    with pytest.raises(TokenParseError):
-        compileScenic(f'x = {op}2')
-
-@pytest.mark.parametrize('op', ('<<', '>>', '|', '&', '^', '//'))
-def test_illegal_binary_operators(op):
-    # Basic usage
-    with pytest.raises(TokenParseError):
-        compileScenic(f'x = 3 {op} 2')
-    # Augmented assignments
-    with pytest.raises(TokenParseError):
-        compileScenic(f'x {op}= 4')
-
 ## Constructor definitions
 
 badNames = ('', '3', '+', 'Behavior')
 
 @pytest.mark.parametrize('name', badNames)
 def test_illegal_constructor_name(name):
-    with pytest.raises(TokenParseError):
-        compileScenic(f'constructor {name}:\n' '    pass')
+    with pytest.raises(SyntaxError):
+        compileScenic(f'class {name}:\n' '    pass')
 
 @pytest.mark.parametrize('name', badNames)
 def test_illegal_constructor_superclass(name):
-    with pytest.raises(TokenParseError):
-        compileScenic(f'constructor Foo({name}):\n' '    pass')
-
-def test_constructor_python_superclass():
-    with pytest.raises(TokenParseError):
-        compileScenic('constructor Foo(object):\n' '    pass')
-
-def test_constructor_undefined_superclass():
-    with pytest.raises(TokenParseError):
-        compileScenic('constructor Foo(Bar):\n' '    pass')
+    with pytest.raises(SyntaxError):
+        compileScenic(f'class Foo({name}):\n' '    pass')
 
 def test_malformed_constructor():
-    with pytest.raises(TokenParseError):
-        compileScenic('constructor Foo\n' '    pass')
-    with pytest.raises(TokenParseError):
-        compileScenic('constructor Foo(Bar:\n' '    pass')
+    with pytest.raises(SyntaxError):
+        compileScenic('class Foo\n' '    pass')
+    with pytest.raises(SyntaxError):
+        compileScenic('class Foo(Bar:\n' '    pass')
 
 def test_multiple_inheritance():
     with pytest.raises(SyntaxError):
@@ -79,52 +56,52 @@ def test_new_python_class():
 ## Soft requirements
 
 def test_malformed_soft_requirement():
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('require[x] 3 == 3')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('require[1+x] 3 == 3')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('require[] 3 == 3')
 
 ## Specifiers
 
 def test_undefined_specifier():
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('Object cattywampus')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('Object athwart 3')
 
 ## Illegal usages of keywords
 
 def test_reserved_functions():
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('PropertyDefault()')
 
 ## Unmatched parentheses and multiline strings
 
 def test_unmatched_parentheses():
-    with pytest.raises(TokenParseError):
+    with pytest.raises(TokenError):
         compileScenic('(')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(TokenError):
         compileScenic('x = (3 + 4')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic(')')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = (4 - 2))')
 
 def test_incomplete_multiline_string():
-    with pytest.raises(TokenParseError):
+    with pytest.raises(TokenError):
         compileScenic('"""foobar')
-    with pytest.raises(TokenParseError):
+    with pytest.raises(TokenError):
         compileScenic('x = """foobar\n' 'wog\n')
 
 ### Parse errors during Python parsing
 
 def test_incomplete_infix_operator():
     """Binary infix operator with too few arguments."""
-    with pytest.raises(PythonParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = 3 @')
-    with pytest.raises(PythonParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = 3 at')
 
 ### Parse errors during parse tree surgery
@@ -133,14 +110,14 @@ def test_incomplete_infix_operator():
 
 def test_incomplete_infix_package():
     """Packaged (3+-ary) infix operator with too few arguments."""
-    with pytest.raises(ASTParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = 4 offset along 12')
 
 def test_extra_infix_package():
     """Packaged (3+-ary) infix operator with too many arguments."""
-    with pytest.raises(ASTParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = 4 at 12 by 17')
-    with pytest.raises(ASTParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('x = 4 offset along 12 by 17 by 19')
 
 ## Ranges
@@ -154,7 +131,7 @@ def test_malformed_range():
 ## Requirements
 
 def test_multiple_requirements():
-    with pytest.raises(ASTParseError):
+    with pytest.raises(SyntaxError):
         compileScenic('require True, True, True')
 
 ### Line numbering

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -108,13 +108,13 @@ def test_incomplete_infix_operator():
 
 ## Infix operators
 
-def test_incomplete_infix_package():
-    """Packaged (3+-ary) infix operator with too few arguments."""
+def test_incomplete_ternary_operator():
+    """3+-ary infix operator with too few arguments."""
     with pytest.raises(SyntaxError):
         compileScenic('x = 4 offset along 12')
 
-def test_extra_infix_package():
-    """Packaged (3+-ary) infix operator with too many arguments."""
+def test_extra_ternary_operator():
+    """3+-ary infix operator with too many arguments."""
     with pytest.raises(SyntaxError):
         compileScenic('x = 4 at 12 by 17')
     with pytest.raises(SyntaxError):

--- a/tests/syntax/test_functions.py
+++ b/tests/syntax/test_functions.py
@@ -9,16 +9,16 @@ def test_max_min():
     ego = sampleEgoFrom("""
         a = Range(0, 1)
         b = Range(0, 1)
-        ego = Object with foo max(a, b), with bar min(a, b)
+        ego = new Object with foo max(a, b), with bar min(a, b)
     """)
     assert ego.foo >= ego.bar
-    ego = sampleEgoFrom('ego = Object with foo min([], default=Range(1,2))')
+    ego = sampleEgoFrom('ego = new Object with foo min([], default=Range(1,2))')
     assert 1 <= ego.foo <= 2
-    ego = sampleEgoFrom('ego = Object with foo min(1, 2, key=lambda x: -x)')
+    ego = sampleEgoFrom('ego = new Object with foo min(1, 2, key=lambda x: -x)')
     assert ego.foo == 2
 
 def test_str():
-    ego = sampleEgoFrom('ego = Object with foo str(Range(12, 17))')
+    ego = sampleEgoFrom('ego = new Object with foo str(Range(12, 17))')
     assert isinstance(ego.foo, str)
     assert 12 <= float(ego.foo) <= 17
 
@@ -28,7 +28,7 @@ def test_unpacking():
     ego = sampleEgoFrom("""
         def func(*args, **kwargs):
             return [args, kwargs]
-        ego = Object with foo func(*[1,2,3], func=4)
+        ego = new Object with foo func(*[1,2,3], func=4)
     """)
     assert ego.foo == [(1, 2, 3), {'func': 4}]
 
@@ -37,10 +37,10 @@ def test_unpacking_distribution():
         def func(x, y):
             return [y, x]
         pairs = Uniform([1,2], [3,4])
-        ego = Object with foo func(*pairs)
+        ego = new Object with foo func(*pairs)
     """)
     assert ego.foo[0] > ego.foo[1]
 
 def test_unpacking_distribution_2():
     with pytest.raises(TypeError):
-        sampleEgoFrom('ego = Object with foo max(*Range(1,2))')
+        sampleEgoFrom('ego = new Object with foo max(*Range(1,2))')

--- a/tests/syntax/test_imports.py
+++ b/tests/syntax/test_imports.py
@@ -55,7 +55,7 @@ def test_import_top_relative(request):
         os.chdir(oldDirectory)
 
 def test_module_name_main():
-    scenario = compileScenic('param name = __name__\n' 'ego = Object')
+    scenario = compileScenic('param name = __name__\n' 'ego = new Object')
     scene, iterations = scenario.generate(maxIterations=1)
     assert scene.params['name'] == '__main__'
 
@@ -67,7 +67,7 @@ def test_inherit_requirements(runLocally):
     with runLocally():
         scenario = compileScenic(
             'import helper3\n'
-            'ego = Object'
+            'ego = new Object'
         )
         assert len(scenario.requirements) == 1
         for i in range(50):
@@ -80,7 +80,7 @@ def test_inherit_constructors(runLocally):
     with runLocally():
         scenario = compileScenic(
             'from helper import Caerbannog\n'
-            'ego = Caerbannog'
+            'ego = new Caerbannog'
         )
 
 def test_multiple_imports(runLocally):
@@ -88,7 +88,7 @@ def test_multiple_imports(runLocally):
         scenario = compileScenic("""
             import helper
             import helper
-            ego = Object
+            ego = new Object
             import helper
         """)
         assert len(scenario.objects) == 2
@@ -103,7 +103,7 @@ def test_import_in_try(runLocally):
                 x = 12
             finally:
                 y = 4
-            ego = Caerbannog at x @ y
+            ego = new Caerbannog at x @ y
         """)
 
 def test_import_in_except(runLocally):
@@ -113,28 +113,28 @@ def test_import_in_except(runLocally):
                 import __non_ex_ist_ent___
             except ImportError:
                 from helper import Caerbannog
-            ego = Caerbannog
+            ego = new Caerbannog
         """)
 
 def test_import_multiline_1():
     compileScenic(
         'from math import factorial, \\\n'
         '    pow\n'
-        'ego = Object with width pow(factorial(4), 2)'
+        'ego = new Object with width pow(factorial(4), 2)'
     )
 
 def test_import_multiline_2():
     compileScenic(
         'from math import (factorial,\n'
         '  pow)\n'
-        'ego = Object with width pow(factorial(4), 2)'
+        'ego = new Object with width pow(factorial(4), 2)'
     )
 
 def test_import_override_param():
     scene = sampleSceneFrom("""
         param helper_file = 'foo'
         import tests.syntax.helper
-        ego = Object
+        ego = new Object
     """)
     assert scene.params['helper_file'] != 'foo'
 
@@ -142,6 +142,6 @@ def test_model_not_override_param():
     scene = sampleSceneFrom("""
         param helper_file = 'foo'
         model tests.syntax.helper
-        ego = Object
+        ego = new Object
     """)
     assert scene.params['helper_file'] == 'foo'

--- a/tests/syntax/test_internals.py
+++ b/tests/syntax/test_internals.py
@@ -6,7 +6,7 @@ from tests.utils import checkVeneerIsInactive
 
 def test_veneer_activation():
     checkVeneerIsInactive()
-    compileScenic('ego = Object')
+    compileScenic('ego = new Object')
     checkVeneerIsInactive()
     with pytest.raises(Exception):
         compileScenic('raise Exception')

--- a/tests/syntax/test_operators.py
+++ b/tests/syntax/test_operators.py
@@ -11,8 +11,8 @@ from tests.utils import compileScenic, sampleEgoFrom, sampleParamP, sampleParamP
 
 def test_relative_heading():
     p = sampleParamPFrom("""
-        ego = Object facing 30 deg
-        other = Object facing 65 deg, at 10@10
+        ego = new Object facing 30 deg
+        other = new Object facing 65 deg, at 10@10
         param p = relative heading of other
     """)
     assert p == pytest.approx(math.radians(65 - 30))
@@ -20,20 +20,20 @@ def test_relative_heading():
 def test_relative_heading_no_ego():
     with pytest.raises(RuntimeParseError):
         compileScenic("""
-            other = Object
-            ego = Object at 2@2, facing relative heading of other
+            other = new Object
+            ego = new Object at 2@2, facing relative heading of other
         """)
 
 def test_relative_heading_from():
-    ego = sampleEgoFrom('ego = Object facing relative heading of 70 deg from -10 deg')
+    ego = sampleEgoFrom('ego = new Object facing relative heading of 70 deg from -10 deg')
     assert ego.heading == pytest.approx(math.radians(70 + 10))
 
 # apparent heading
 
 def test_apparent_heading():
     p = sampleParamPFrom("""
-        ego = Object facing 30 deg
-        other = Object facing 65 deg, at 10@10
+        ego = new Object facing 30 deg
+        other = new Object facing 65 deg, at 10@10
         param p = apparent heading of other
     """)
     assert p == pytest.approx(math.radians(65 + 45))
@@ -41,14 +41,14 @@ def test_apparent_heading():
 def test_apparent_heading_no_ego():
     with pytest.raises(RuntimeParseError):
         compileScenic("""
-            other = Object
-            ego = Object at 2@2, facing apparent heading of other
+            other = new Object
+            ego = new Object at 2@2, facing apparent heading of other
         """)
 
 def test_apparent_heading_from():
     ego = sampleEgoFrom("""
-        OP = OrientedPoint at 10@15, facing -60 deg
-        ego = Object facing apparent heading of OP from 15@10
+        OP = new OrientedPoint at 10@15, facing -60 deg
+        ego = new Object facing apparent heading of OP from 15@10
     """)
     assert ego.heading == pytest.approx(math.radians(-60 - 45))
 
@@ -56,8 +56,8 @@ def test_apparent_heading_from():
 
 def test_distance():
     p = sampleParamPFrom("""
-        ego = Object at 5@10
-        other = Object at 7@-4
+        ego = new Object at 5@10
+        other = new Object at 7@-4
         param p = distance to other
     """)
     assert p == pytest.approx(math.hypot(7 - 5, -4 - 10))
@@ -65,34 +65,34 @@ def test_distance():
 def test_distance_no_ego():
     with pytest.raises(RuntimeParseError):
         compileScenic("""
-            other = Object
-            ego = Object at 2@2, facing distance to other
+            other = new Object
+            ego = new Object at 2@2, facing distance to other
         """)
 
 def test_distance_from():
-    ego = sampleEgoFrom('ego = Object with wobble distance from -3@2 to 4@5')
+    ego = sampleEgoFrom('ego = new Object with wobble distance from -3@2 to 4@5')
     assert ego.wobble == pytest.approx(math.hypot(4 - -3, 5 - 2))
 
 def test_distance_to_region():
     p = sampleParamPFrom("""
         r = CircularRegion(10@5, 3)
-        ego = Object at 13@9
+        ego = new Object at 13@9
         param p = distance to r
     """)
     assert p == pytest.approx(2)
 
 def test_distance_past():
     p = sampleParamPFrom("""
-        ego = Object at 5@10, facing 45 deg
-        other = Object at 2@3
+        ego = new Object at 5@10, facing 45 deg
+        other = new Object at 2@3
         param p = distance past other
     """)
     assert p == pytest.approx(2 * math.sqrt(2))
 
 def test_distance_past_of():
     p = sampleParamPFrom("""
-        ego = Object at 1@2, facing 30 deg
-        op = OrientedPoint at 3@-6, facing -45 deg
+        ego = new Object at 1@2, facing 30 deg
+        op = new OrientedPoint at 3@-6, facing -45 deg
         param p = distance past ego of op
     """)
     assert p == pytest.approx(-3 * math.sqrt(2))
@@ -101,8 +101,8 @@ def test_distance_past_of():
 
 def test_angle():
     p = sampleParamPFrom("""
-        ego = Object facing 30 deg
-        other = Object facing 65 deg, at 10@10
+        ego = new Object facing 30 deg
+        other = new Object facing 65 deg, at 10@10
         param p = angle to other
     """)
     assert p == pytest.approx(math.radians(-45))
@@ -110,12 +110,12 @@ def test_angle():
 def test_angle_no_ego():
     with pytest.raises(RuntimeParseError):
         compileScenic("""
-            other = Object
-            ego = Object at 2@2, facing angle to other
+            other = new Object
+            ego = new Object at 2@2, facing angle to other
         """)
 
 def test_angle_from():
-    ego = sampleEgoFrom('ego = Object facing angle from 2@4 to 3@5')
+    ego = sampleEgoFrom('ego = new Object facing angle from 2@4 to 3@5')
     assert ego.heading == pytest.approx(math.radians(-45))
 
 ## Boolean operators
@@ -124,33 +124,33 @@ def test_angle_from():
 
 def test_point_can_see_vector():
     p = sampleParamPFrom("""
-        ego = Object
-        pt = Point at 10@20, with visibleDistance 5
+        ego = new Object
+        pt = new Point at 10@20, with visibleDistance 5
         param p = tuple([pt can see 8@19, pt can see 10@26])
     """)
     assert p == (True, False)
 
 def test_point_can_see_object():
     p = sampleParamPFrom("""
-        ego = Object with width 10, with length 10
-        other = Object at 35@10
-        pt = Point at 15@10, with visibleDistance 15
+        ego = new Object with width 10, with length 10
+        other = new Object at 35@10
+        pt = new Point at 15@10, with visibleDistance 15
         param p = tuple([pt can see ego, pt can see other])
     """)
     assert p == (True, False)
 
 def test_oriented_point_can_see_vector():
     p = sampleParamPFrom("""
-        ego = Object facing -45 deg, with visibleDistance 5, with viewAngle 20 deg
+        ego = new Object facing -45 deg, with visibleDistance 5, with viewAngle 20 deg
         param p = tuple([ego can see 2@2, ego can see 4@4, ego can see 1@0])
     """)
     assert p == (True, False, False)
 
 def test_oriented_point_can_see_object():
     p = sampleParamPFrom("""
-        ego = Object facing -45 deg, with visibleDistance 5, with viewAngle 20 deg
-        other = Object at 4@4, with width 2, with length 2
-        other2 = Object at 4@0, with requireVisible False
+        ego = new Object facing -45 deg, with visibleDistance 5, with viewAngle 20 deg
+        other = new Object at 4@4, with width 2, with length 2
+        other2 = new Object at 4@0, with requireVisible False
         param p = tuple([ego can see other, ego can see other2])
     """)
     assert p == (True, False)
@@ -159,10 +159,10 @@ def test_oriented_point_can_see_object():
 
 def test_point_in_region():
     p = sampleParamPFrom("""
-        ego = Object
+        ego = new Object
         reg = RectangularRegion(10@5, 0, 4, 2)
-        ptA = Point at 11@4.5
-        ptB = Point at 11@3.5
+        ptA = new Point at 11@4.5
+        ptB = new Point at 11@3.5
         param p = tuple([9@5.5 in reg, 9@7 in reg, ptA in reg, ptB in reg])
     """)
     assert p == (True, False, True, False)
@@ -170,8 +170,8 @@ def test_point_in_region():
 def test_object_in_region():
     p = sampleParamPFrom("""
         reg = RectangularRegion(10@5, 0, 4, 2)
-        ego = Object at 11.5@5.5, with width 0.25, with length 0.25
-        other = Object at 9@4.5, with width 2.5
+        ego = new Object at 11.5@5.5, with width 0.25, with length 0.25
+        other = new Object at 9@4.5, with width 2.5
         param p = tuple([ego in reg, other in reg])
     """)
     assert p == (True, False)
@@ -183,7 +183,7 @@ def test_object_in_region():
 def test_field_at_vector():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: (3 * pos.x) + pos.y)
-        ego = Object facing (vf at 0.02 @ -1)
+        ego = new Object facing (vf at 0.02 @ -1)
     """)
     assert ego.heading == pytest.approx((3 * 0.02) - 1)
 
@@ -192,44 +192,44 @@ def test_field_at_vector():
 def test_heading_relative_to_field():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 3 * pos.x)
-        ego = Object at 0.07 @ 0, facing 0.5 relative to vf
+        ego = new Object at 0.07 @ 0, facing 0.5 relative to vf
     """)
     assert ego.heading == pytest.approx(0.5 + (3 * 0.07))
 
 def test_field_relative_to_heading():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 3 * pos.x)
-        ego = Object at 0.07 @ 0, facing vf relative to 0.5
+        ego = new Object at 0.07 @ 0, facing vf relative to 0.5
     """)
     assert ego.heading == pytest.approx(0.5 + (3 * 0.07))
 
 def test_field_relative_to_field():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 3 * pos.x)
-        ego = Object at 0.07 @ 0, facing vf relative to vf
+        ego = new Object at 0.07 @ 0, facing vf relative to vf
     """)
     assert ego.heading == pytest.approx(2 * (3 * 0.07))
 
 def test_heading_relative_to_heading():
-    ego = sampleEgoFrom('ego = Object facing 0.5 relative to -0.3')
+    ego = sampleEgoFrom('ego = new Object facing 0.5 relative to -0.3')
     assert ego.heading == pytest.approx(0.5 - 0.3)
 
 def test_heading_relative_to_heading_lazy():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 0.5)
-        ego = Object facing 0.5 relative to (0.5 relative to vf)
+        ego = new Object facing 0.5 relative to (0.5 relative to vf)
     """)
     assert ego.heading == pytest.approx(1.5)
 
 def test_mistyped_relative_to():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object facing 0 relative to 1@2')
+        compileScenic('ego = new Object facing 0 relative to 1@2')
 
 def test_mistyped_relative_to_lazy():
     with pytest.raises(RuntimeParseError):
         compileScenic("""
             vf = VectorField("Foo", lambda pos: 0.5)
-            ego = Object facing 1@2 relative to (0 relative to vf)
+            ego = new Object facing 1@2 relative to (0 relative to vf)
         """)
 
 ## Vector operators
@@ -237,20 +237,20 @@ def test_mistyped_relative_to_lazy():
 # offset by
 
 def test_offset_by():
-    ego = sampleEgoFrom('ego = Object at 3@2 offset by -4@10')
+    ego = sampleEgoFrom('ego = new Object at 3@2 offset by -4@10')
     assert tuple(ego.position) == pytest.approx((-1, 12))
 
 # offset along
 
 def test_offset_along_heading():
-    ego = sampleEgoFrom('ego = Object at 3@2 offset along 45 deg by -4@10')
+    ego = sampleEgoFrom('ego = new Object at 3@2 offset along 45 deg by -4@10')
     d = 1 / math.sqrt(2)
     assert tuple(ego.position) == pytest.approx((3 - 10*d - 4*d, 2 + 10*d - 4*d))
 
 def test_offset_along_field():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 3 deg * pos.x)
-        ego = Object at 15@7 offset along vf by 2@-3
+        ego = new Object at 15@7 offset along vf by 2@-3
     """)
     d = 1 / math.sqrt(2)
     assert tuple(ego.position) == pytest.approx((15 + 3*d + 2*d, 7 - 3*d + 2*d))
@@ -262,7 +262,7 @@ def test_follow():
         vf = VectorField("Foo", lambda pos: 90 deg * (pos.x + pos.y - 1),
                          minSteps=4, defaultStepSize=1)
         p = follow vf from 1@1 for 4
-        ego = Object at p, facing p.heading
+        ego = new Object at p, facing p.heading
     """)
     assert tuple(ego.position) == pytest.approx((-1, 3))
     assert ego.heading == pytest.approx(math.radians(90))
@@ -273,10 +273,10 @@ def test_follow():
 
 def test_visible():
     scenario = compileScenic("""
-        ego = Object at 100 @ 200, facing -45 deg,
+        ego = new Object at 100 @ 200, facing -45 deg,
                      with visibleDistance 10, with viewAngle 90 deg
         reg = RectangularRegion(100@205, 0, 10, 20)
-        param p = Point in visible reg
+        param p = new Point in visible reg
     """)
     for i in range(30):
         p = sampleParamP(scenario, maxIterations=100)
@@ -289,7 +289,7 @@ def test_not_visible():
         ego = Object at 100 @ 200, facing -45 deg,
                      with visibleDistance 30, with viewAngle 90 deg
         reg = RectangularRegion(100@200, 0, 10, 10)
-        param p = Point in not visible reg
+        param p = new Point in not visible reg
     """)
     ps = [sampleParamP(scenario, maxIterations=100) for i in range(50)]
     assert all(p.x <= 100 or p.y <= 200 for p in ps)

--- a/tests/syntax/test_properties.py
+++ b/tests/syntax/test_properties.py
@@ -7,36 +7,36 @@ from tests.utils import compileScenic, sampleEgoFrom
 
 def test_position_wrong_type():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object with position 4')
+        compileScenic('ego = new Object with position 4')
 
 def test_position_oriented_point():
     sampleEgoFrom("""
-        a = OrientedPoint at 1@0
-        b = OrientedPoint at 0@1
-        ego = Object with position Uniform(a, b)
+        a = new OrientedPoint at 1@0
+        b = new OrientedPoint at 0@1
+        ego = new Object with position Uniform(a, b)
     """)
 
 def test_position_numpy_types():
     ego = sampleEgoFrom("""
         import numpy as np
-        ego = Object with position np.single(3.4) @ np.single(7)
+        ego = new Object with position np.single(3.4) @ np.single(7)
     """)
     assert tuple(ego.position) == pytest.approx((3.4, 7))
 
 def test_heading_wrong_type():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object with heading 4 @ 1')
+        compileScenic('ego = new Object with heading 4 @ 1')
 
 def test_heading_numpy_types():
     ego = sampleEgoFrom("""
         import numpy as np
-        ego = Object with heading np.single(3.4)
+        ego = new Object with heading np.single(3.4)
     """)
     assert ego.heading == pytest.approx(3.4)
 
 def test_left():
     ego = sampleEgoFrom("""
-        other = Object with width 4
-        ego = Object at other.left offset by 0@5
+        other = new Object with width 4
+        ego = new Object at other.left offset by 0@5
     """)
     assert tuple(ego.position) == pytest.approx((-2, 5))

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -10,7 +10,7 @@ def test_containment():
     """Test pruning based on object containment."""
     scenario = compileScenic("""
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
-        ego = Object in workspace
+        ego = new Object in workspace
     """)
     # Sampling should only require 1 iteration after pruning
     xs = [sampleEgo(scenario).position.x for i in range(60)]
@@ -36,8 +36,8 @@ def test_relative_heading():
         r2 = PolygonalRegion([20@0, 30@0, 30@10, 20@10])    # Second cell: heading 90 deg
         vf = PolygonalVectorField("Foo", [[r1.polygons, 0], [r2.polygons, 90 deg]])
         union = r1.union(r2)
-        ego = Object in union, facing vf                # Objects can be in either cell
-        other = Object in union, facing vf
+        ego = new Object in union, facing vf                # Objects can be in either cell
+        other = new Object in union, facing vf
         require (relative heading of other) >= 60 deg   # Forces ego in cell 1, other in cell 2
     """)
     # Sampling should only require 1 iteration after pruning
@@ -54,8 +54,8 @@ def test_relative_heading_distance():
         vf = PolygonalVectorField("Foo", [[r1.polygons, 0], [r2.polygons, 90 deg],
                                            [r3.polygons, 90 deg]])
         union = r1.union(r2).union(r3)
-        ego = Object in union, facing vf, with visibleDistance 100
-        other = Object in union, facing vf
+        ego = new Object in union, facing vf, with visibleDistance 100
+        other = new Object in union, facing vf
         require (relative heading of other) >= 60 deg       # Forces ego in cell 1, other cell 2/3
         require (distance to other) <= 35                   # Forces other in cell 2
     """)
@@ -68,7 +68,7 @@ def test_relative_heading_inconsistent():
     """A special case where we can detect inconsistency of the requirements."""
     with pytest.raises(InconsistentScenarioError):
         scenario = compileScenic("""
-            ego = Object
-            other = Object at 10@10
+            ego = new Object
+            other = new Object at 10@10
             require abs(relative heading of other) < -1
         """)

--- a/tests/syntax/test_regions.py
+++ b/tests/syntax/test_regions.py
@@ -11,12 +11,12 @@ from tests.utils import compileScenic, sampleScene, sampleEgo, sampleEgoFrom
 # Built-in regions
 
 def test_everywhere():
-    scenario = compileScenic('ego = Object with regionContainedIn everywhere')
+    scenario = compileScenic('ego = new Object with regionContainedIn everywhere')
     sampleScene(scenario, maxIterations=1)
 
 def test_nowhere():
     with pytest.raises(InvalidScenarioError):
-        compileScenic('ego = Object with regionContainedIn nowhere')
+        compileScenic('ego = new Object with regionContainedIn nowhere')
 
 # CircularRegion
 
@@ -44,8 +44,8 @@ def test_circular_lazy():
 def test_polygonal_empty_intersection():
     scenario = compileScenic("""
         r1 = PolygonalRegion([0@0, 10@0, 10@10, 0@10])
-        ego = Object at -10@0, facing Range(-90, 0) deg, with viewAngle 60 deg
-        Object in visible r1, with requireVisible False
+        ego = new Object at -10@0, facing Range(-90, 0) deg, with viewAngle 60 deg
+        new Object in visible r1, with requireVisible False
     """)
     for i in range(30):
         sampleScene(scenario, maxIterations=1000)
@@ -56,7 +56,7 @@ def test_polyline_start():
     ego = sampleEgoFrom("""
         r = PolylineRegion([1@1, 3@-1, 6@2])
         pt = r.start
-        ego = Object at pt, facing pt.heading
+        ego = new Object at pt, facing pt.heading
     """)
     assert tuple(ego.position) == pytest.approx((1, 1))
     assert ego.heading == pytest.approx(math.radians(-135))
@@ -65,7 +65,7 @@ def test_polyline_end():
     ego = sampleEgoFrom("""
         r = PolylineRegion([1@1, 3@-1, 6@2])
         pt = r.end
-        ego = Object at pt, facing pt.heading
+        ego = new Object at pt, facing pt.heading
     """)
     assert tuple(ego.position) == pytest.approx((6, 2))
     assert ego.heading == pytest.approx(math.radians(-45))

--- a/tests/syntax/test_requirements.py
+++ b/tests/syntax/test_requirements.py
@@ -9,7 +9,7 @@ from tests.utils import compileScenic, sampleScene, sampleSceneFrom, sampleEgo
 
 def test_requirement():
     scenario = compileScenic("""
-        ego = Object at Range(-10, 10) @ 0
+        ego = new Object at Range(-10, 10) @ 0
         require ego.position.x >= 0
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
@@ -18,7 +18,7 @@ def test_requirement():
 @pytest.mark.slow
 def test_soft_requirement():
     scenario = compileScenic("""
-        ego = Object at Range(-10, 10) @ 0
+        ego = new Object at Range(-10, 10) @ 0
         require[0.9] ego.position.x >= 0
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(350)]
@@ -27,7 +27,7 @@ def test_soft_requirement():
 
 def test_named_requirement():
     scenario = compileScenic("""
-        ego = Object at Range(0, 10) @ 0
+        ego = new Object at Range(0, 10) @ 0
         require ego.position.x >= 5 as posReq
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
@@ -36,7 +36,7 @@ def test_named_requirement():
 @pytest.mark.slow
 def test_named_soft_requirement():
     scenario = compileScenic("""
-        ego = Object at Range(0, 10) @ 0
+        ego = new Object at Range(0, 10) @ 0
         require[0.9] ego.position.x >= 5 as posReq
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(350)]
@@ -47,33 +47,33 @@ def test_named_soft_requirement():
 
 def test_object_in_requirement():
     scenario = compileScenic("""
-        require Object
-        ego = Object
+        require new Object
+        ego = new Object
     """)
     with pytest.raises(ScenicSyntaxError):
         sampleScene(scenario)
 
 def test_param_in_requirement():
-    with pytest.raises(ScenicSyntaxError):
+    with pytest.raises(SyntaxError):
         compileScenic("""
             require param x = 4
-            ego = Object
+            ego = new Object
         """)
 
 @pytest.mark.xfail(reason='looser keyword policy now allows this', strict=True)
 def test_mutate_in_requirement():
     scenario = compileScenic("""
         require mutate
-        ego = Object
+        ego = new Object
     """)
     with pytest.raises(ScenicSyntaxError):
         sampleScene(scenario)
 
 def test_require_in_requirement():
-    with pytest.raises(ScenicSyntaxError):
+    with pytest.raises(SyntaxError):
         compileScenic("""
             require (require True)
-            ego = Object
+            ego = new Object
         """)
 
 ## Error handling
@@ -81,7 +81,7 @@ def test_require_in_requirement():
 def test_runtime_parse_error_in_requirement():
     scenario = compileScenic("""
         require visible 4
-        ego = Object
+        ego = new Object
     """)
     with pytest.raises(ScenicSyntaxError):
         sampleScene(scenario)
@@ -91,7 +91,7 @@ def test_runtime_parse_error_in_requirement():
 def test_containment_requirement():
     scenario = compileScenic("""
         foo = RectangularRegion(0@0, 0, 10, 10)
-        ego = Object at Range(0, 10) @ 0, with regionContainedIn foo
+        ego = new Object at Range(0, 10) @ 0, with regionContainedIn foo
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
     assert all(0 <= x <= 5 for x in xs)
@@ -99,47 +99,47 @@ def test_containment_requirement():
 def test_containment_workspace():
     scenario = compileScenic("""
         workspace = Workspace(RectangularRegion(0@0, 0, 10, 10))
-        ego = Object at Range(0, 10) @ 0
+        ego = new Object at Range(0, 10) @ 0
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
     assert all(0 <= x <= 5 for x in xs)
 
 def test_visibility_requirement():
     scenario = compileScenic("""
-        ego = Object with visibleDistance 10, with viewAngle 90 deg, facing 45 deg
-        other = Object at Range(-10, 10) @ 0
+        ego = new Object with visibleDistance 10, with viewAngle 90 deg, facing 45 deg
+        other = new Object at Range(-10, 10) @ 0
     """)
     xs = [sampleScene(scenario, maxIterations=60).objects[1].position.x for i in range(60)]
     assert all(-10 <= x <= 0.5 for x in xs)
 
 def test_visibility_requirement_disabled():
     scenario = compileScenic("""
-        ego = Object with visibleDistance 10, with viewAngle 90 deg, facing 45 deg
-        other = Object at Range(-10, 10) @ 0, with requireVisible False
+        ego = new Object with visibleDistance 10, with viewAngle 90 deg, facing 45 deg
+        other = new Object at Range(-10, 10) @ 0, with requireVisible False
     """)
     xs = [sampleScene(scenario, maxIterations=60).objects[1].position.x for i in range(60)]
     assert any(x > 0.5 for x in xs)
 
 def test_intersection_requirement():
     scenario = compileScenic("""
-        ego = Object at Range(0, 2) @ 0
-        other = Object
+        ego = new Object at Range(0, 2) @ 0
+        other = new Object
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
     assert all(x >= 1 for x in xs)
 
 def test_intersection_requirement_disabled_1():
     scenario = compileScenic("""
-        ego = Object at Range(0, 2) @ 0, with allowCollisions True
-        other = Object
+        ego = new Object at Range(0, 2) @ 0, with allowCollisions True
+        other = new Object
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
     assert any(x < 1 for x in xs)
 
 def test_intersection_requirement_disabled_2():
     scenario = compileScenic("""
-        ego = Object at Range(0, 2) @ 0
-        other = Object with allowCollisions True
+        ego = new Object at Range(0, 2) @ 0
+        other = new Object with allowCollisions True
     """)
     xs = [sampleEgo(scenario, maxIterations=60).position.x for i in range(60)]
     assert any(x < 1 for x in xs)
@@ -150,45 +150,45 @@ def test_static_containment_violation():
     with pytest.raises(InvalidScenarioError):
         compileScenic("""
             foo = RectangularRegion(0@0, 0, 5, 5)
-            ego = Object at 10@10, with regionContainedIn foo
+            ego = new Object at 10@10, with regionContainedIn foo
         """)
 
 def test_static_containment_workspace():
     with pytest.raises(InvalidScenarioError):
         compileScenic("""
             workspace = Workspace(RectangularRegion(0@0, 0, 5, 5))
-            ego = Object at 10@10
+            ego = new Object at 10@10
         """)
 
 def test_static_empty_container():
     with pytest.raises(InvalidScenarioError):
         compileScenic("""
             foo = PolylineRegion([0@0, 1@1]).intersect(PolylineRegion([1@0, 2@1]))
-            ego = Object at Range(0, 2) @ Range(0, 1), with regionContainedIn foo
+            ego = new Object at Range(0, 2) @ Range(0, 1), with regionContainedIn foo
         """)
 
 def test_static_visibility_violation():
     with pytest.raises(InvalidScenarioError):
         compileScenic("""
-            ego = Object at 10@0, facing -90 deg, with viewAngle 90 deg
-            Object at 0@10
+            ego = new Object at 10@0, facing -90 deg, with viewAngle 90 deg
+            new Object at 0@10
         """)
 
 def test_static_visibility_violation_disabled():
     sampleSceneFrom("""
-        ego = Object at 10@0, facing -90 deg, with viewAngle 90 deg
-        Object at 0@10, with requireVisible False
+        ego = new Object at 10@0, facing -90 deg, with viewAngle 90 deg
+        new Object at 0@10, with requireVisible False
     """)
 
 def test_static_intersection_violation():
     with pytest.raises(InvalidScenarioError):
         compileScenic("""
-            ego = Object at 0@0
-            Object at 1@0
+            ego = new Object at 0@0
+            new Object at 1@0
         """)
 
 def test_static_intersection_violation_disabled():
     sampleSceneFrom("""
-        ego = Object at 0@0
-        Object at 1@0, with allowCollisions True
+        ego = new Object at 0@0
+        new Object at 1@0, with allowCollisions True
     """)

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -10,34 +10,34 @@ from tests.utils import compileScenic, sampleScene, sampleEgo, sampleEgoFrom
 
 def test_double_specification():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object at 0 @ 0, at 1 @ 1')
+        compileScenic('ego = new Object at 0 @ 0, at 1 @ 1')
 
 def test_cyclic_dependency():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object left of 0 @ 0, facing toward 1 @ 1')
+        compileScenic('ego = new Object left of 0 @ 0, facing toward 1 @ 1')
 
 def test_lazy_cyclic_dependency():
     with pytest.raises(RuntimeParseError):
         compileScenic(
             'vf = VectorField("Foo", lambda pos: 3 * pos.x)\n'
-            'ego = Object at 0 @ (0 relative to vf)'
+            'ego = new Object at 0 @ (0 relative to vf)'
         )
 
 def test_default_dependency():
-    ego = sampleEgoFrom('ego = Object facing toward -1 @ 1')
+    ego = sampleEgoFrom('ego = new Object facing toward -1 @ 1')
     assert tuple(ego.position) == (0, 0)
     assert ego.heading == pytest.approx(math.radians(45))
 
 def test_missing_dependency():
     with pytest.raises(RuntimeParseError):
-        compileScenic('Point left of 0 @ 0 by 5\n' 'ego = Object')
+        compileScenic('new Point left of 0 @ 0 by 5\n' 'ego = new Object')
 
 def test_lazy_value_in_param():
     with pytest.raises(InvalidScenarioError):
         compileScenic(
             'vf = VectorField("Foo", lambda pos: 3 * pos.x)\n'
             'param X = 0 relative to vf\n'
-            'ego = Object\n'
+            'ego = new Object\n'
         )
 
 def test_lazy_value_in_requirement():
@@ -47,7 +47,7 @@ def test_lazy_value_in_requirement():
             'vf = VectorField("Foo", lambda pos: 3 * pos.x)\n'
             'x = 0 relative to vf\n'
             'require x >= 0\n'
-            'ego = Object\n'
+            'ego = new Object\n'
         )
 
 def test_lazy_value_in_requirement_2():
@@ -55,7 +55,7 @@ def test_lazy_value_in_requirement_2():
     scenario = compileScenic(
         'vf = VectorField("Foo", lambda pos: 3 * pos.x)\n'
         'require 0 relative to vf\n'
-        'ego = Object\n'
+        'ego = new Object\n'
     )
     with pytest.raises(InvalidScenarioError):
         sampleScene(scenario, maxIterations=1)
@@ -63,112 +63,112 @@ def test_lazy_value_in_requirement_2():
 ## Generic specifiers
 
 def test_with():
-    ego = sampleEgoFrom('ego = Object with flubber 37')
+    ego = sampleEgoFrom('ego = new Object with flubber 37')
     assert ego.flubber == 37
 
 ## Position specifiers
 
 def test_at():
-    ego = sampleEgoFrom('ego = Object at 149 @ 42')
+    ego = sampleEgoFrom('ego = new Object at 149 @ 42')
     assert tuple(ego.position) == pytest.approx((149, 42))
 
 def test_offset_by():
     ego = sampleEgoFrom(
-        'ego = Object at 10 @ 40, facing 90 deg\n'
-        'ego = Object offset by 5 @ 15'
+        'ego = new Object at 10 @ 40, facing 90 deg\n'
+        'ego = new Object offset by 5 @ 15'
     )
     assert tuple(ego.position) == pytest.approx((-5, 45))
 
 def test_offset_by_no_ego():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object offset by 10 @ 40')
+        compileScenic('ego = new Object offset by 10 @ 40')
 
 def test_offset_along():
     ego = sampleEgoFrom(
-        'ego = Object at 10 @ 40\n'
-        'ego = Object offset along -90 deg by -10 @ 5'
+        'ego = new Object at 10 @ 40\n'
+        'ego = new Object offset along -90 deg by -10 @ 5'
     )
     assert tuple(ego.position) == pytest.approx((15, 50))
 
 def test_offset_along_no_ego():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object offset along 0 by 10 @ 0')
+        compileScenic('ego = new Object offset along 0 by 10 @ 0')
 
 def test_left_of_vector():
-    ego = sampleEgoFrom('ego = Object left of 10 @ 20, facing 90 deg')
+    ego = sampleEgoFrom('ego = new Object left of 10 @ 20, facing 90 deg')
     assert tuple(ego.position) == pytest.approx((10, 19.5))
-    ego = sampleEgoFrom('ego = Object left of 10 @ 20, with width 10')
+    ego = sampleEgoFrom('ego = new Object left of 10 @ 20, with width 10')
     assert tuple(ego.position) == pytest.approx((5, 20))
 
 def test_left_of_vector_by():
-    ego = sampleEgoFrom('ego = Object left of 10 @ 20 by 20')
+    ego = sampleEgoFrom('ego = new Object left of 10 @ 20 by 20')
     assert tuple(ego.position) == pytest.approx((-10.5, 20))
-    ego = sampleEgoFrom('ego = Object left of 10 @ 20 by 20 @ 5')
+    ego = sampleEgoFrom('ego = new Object left of 10 @ 20 by 20 @ 5')
     assert tuple(ego.position) == pytest.approx((-10.5, 25))
 
 def test_right_of_vector():
-    ego = sampleEgoFrom('ego = Object right of 10 @ 20, facing 90 deg')
+    ego = sampleEgoFrom('ego = new Object right of 10 @ 20, facing 90 deg')
     assert tuple(ego.position) == pytest.approx((10, 20.5))
-    ego = sampleEgoFrom('ego = Object right of 10 @ 20, with width 10')
+    ego = sampleEgoFrom('ego = new Object right of 10 @ 20, with width 10')
     assert tuple(ego.position) == pytest.approx((15, 20))
 
 def test_right_of_vector_by():
-    ego = sampleEgoFrom('ego = Object right of 10 @ 20 by 20')
+    ego = sampleEgoFrom('ego = new Object right of 10 @ 20 by 20')
     assert tuple(ego.position) == pytest.approx((30.5, 20))
-    ego = sampleEgoFrom('ego = Object right of 10 @ 20 by 20 @ 5')
+    ego = sampleEgoFrom('ego = new Object right of 10 @ 20 by 20 @ 5')
     assert tuple(ego.position) == pytest.approx((30.5, 25))
 
 def test_ahead_of_vector():
-    ego = sampleEgoFrom('ego = Object ahead of 10 @ 20, facing 90 deg')
+    ego = sampleEgoFrom('ego = new Object ahead of 10 @ 20, facing 90 deg')
     assert tuple(ego.position) == pytest.approx((9.5, 20))
-    ego = sampleEgoFrom('ego = Object ahead of 10 @ 20, with length 10')
+    ego = sampleEgoFrom('ego = new Object ahead of 10 @ 20, with length 10')
     assert tuple(ego.position) == pytest.approx((10, 25))
 
 def test_ahead_of_vector_by():
-    ego = sampleEgoFrom('ego = Object ahead of 10 @ 20 by 20')
+    ego = sampleEgoFrom('ego = new Object ahead of 10 @ 20 by 20')
     assert tuple(ego.position) == pytest.approx((10, 40.5))
-    ego = sampleEgoFrom('ego = Object ahead of 10 @ 20 by 20 @ 5')
+    ego = sampleEgoFrom('ego = new Object ahead of 10 @ 20 by 20 @ 5')
     assert tuple(ego.position) == pytest.approx((30, 25.5))
 
 def test_behind_vector():
-    ego = sampleEgoFrom('ego = Object behind 10 @ 20, facing 90 deg')
+    ego = sampleEgoFrom('ego = new Object behind 10 @ 20, facing 90 deg')
     assert tuple(ego.position) == pytest.approx((10.5, 20))
-    ego = sampleEgoFrom('ego = Object behind 10 @ 20, with length 10')
+    ego = sampleEgoFrom('ego = new Object behind 10 @ 20, with length 10')
     assert tuple(ego.position) == pytest.approx((10, 15))
 
 def test_behind_vector_by():
-    ego = sampleEgoFrom('ego = Object behind 10 @ 20 by 20')
+    ego = sampleEgoFrom('ego = new Object behind 10 @ 20 by 20')
     assert tuple(ego.position) == pytest.approx((10, -0.5))
-    ego = sampleEgoFrom('ego = Object behind 10 @ 20 by 20 @ 5')
+    ego = sampleEgoFrom('ego = new Object behind 10 @ 20 by 20 @ 5')
     assert tuple(ego.position) == pytest.approx((30, 14.5))
 
 def test_beyond():
     ego = sampleEgoFrom(
-        'ego = Object at 10 @ 5\n'
-        'ego = Object beyond 4 @ 13 by 5'
+        'ego = new Object at 10 @ 5\n'
+        'ego = new Object beyond 4 @ 13 by 5'
     )
     assert tuple(ego.position) == pytest.approx((1, 17))
     ego = sampleEgoFrom(
-        'ego = Object at 10 @ 5\n'
-        'ego = Object beyond 4 @ 13 by 10 @ 5'
+        'ego = new Object at 10 @ 5\n'
+        'ego = new Object beyond 4 @ 13 by 10 @ 5'
     )
     assert tuple(ego.position) == pytest.approx((9, 23))
 
 def test_beyond_no_ego():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object beyond 10 @ 10 by 5')
+        compileScenic('ego = new Object beyond 10 @ 10 by 5')
 
 def test_beyond_from():
-    ego = sampleEgoFrom('ego = Object beyond 5 @ 0 by 20 from 5 @ 10')
+    ego = sampleEgoFrom('ego = new Object beyond 5 @ 0 by 20 from 5 @ 10')
     assert tuple(ego.position) == pytest.approx((5, -20))
-    ego = sampleEgoFrom('ego = Object beyond 5 @ 0 by 15 @ 20 from 5 @ 10')
+    ego = sampleEgoFrom('ego = new Object beyond 5 @ 0 by 15 @ 20 from 5 @ 10')
     assert tuple(ego.position) == pytest.approx((-10, -20))
 
 def test_visible():
     scenario = compileScenic(
-        'ego = Object at 100 @ 200, facing -45 deg,\n'
+        'ego = new Object at 100 @ 200, facing -45 deg,\n'
         '             with visibleDistance 10, with viewAngle 90 deg\n'
-        'ego = Object visible'
+        'ego = new Object visible'
     )
     for i in range(30):
         scene = sampleScene(scenario, maxIterations=50)
@@ -179,12 +179,12 @@ def test_visible():
 
 def test_visible_no_ego():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object visible')
+        compileScenic('ego = new Object visible')
 
 def test_visible_from_point():
     scenario = compileScenic(
-        'x = Point at 300@200, with visibleDistance 2\n'
-        'ego = Object visible from x'
+        'x = new Point at 300@200, with visibleDistance 2\n'
+        'ego = new Object visible from x'
     )
     for i in range(30):
         scene = sampleScene(scenario, maxIterations=1)
@@ -192,7 +192,7 @@ def test_visible_from_point():
 
 def test_visible_from_oriented_point():
     scenario = compileScenic(
-        'op = OrientedPoint at 100 @ 200, facing 45 deg,\n'
+        'op = new OrientedPoint at 100 @ 200, facing 45 deg,\n'
         '                   with visibleDistance 5, with viewAngle 90 deg\n'
         'ego = Object visible from op'
     )
@@ -207,7 +207,7 @@ def test_visible_from_oriented_point():
 def test_not_visible():
     scenario = compileScenic("""
         workspace = Workspace(RectangularRegion(100@205, 0, 20, 12))
-        ego = Object at 100 @ 200, facing -45 deg,
+        ego = new Object at 100 @ 200, facing -45 deg,
                      with visibleDistance 10, with viewAngle 90 deg
         ego = Object not visible
     """)
@@ -221,7 +221,7 @@ def test_not_visible():
 def test_in():
     scenario = compileScenic(
         'r = RectangularRegion(100 @ 200, 90 deg, 50, 10)\n'
-        'ego = Object in r'
+        'ego = new Object in r'
     )
     for i in range(30):
         scene = sampleScene(scenario, maxIterations=1)
@@ -233,7 +233,7 @@ def test_in():
 def test_in_heading():
     scenario = compileScenic(
         'r = PolylineRegion([50 @ -50, -20 @ 20])\n'
-        'ego = Object on r'
+        'ego = new Object on r'
     )
     for i in range(30):
         scene = sampleScene(scenario, maxIterations=1)
@@ -245,13 +245,13 @@ def test_in_heading():
 
 def test_in_mistyped():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object in 3@2')
+        compileScenic('ego = new Object in 3@2')
 
 def test_in_distribution():
     scenario = compileScenic(
         'ra = RectangularRegion(0@0, 0, 2, 2)\n'
         'rb = RectangularRegion(10@0, 0, 2, 2)\n'
-        'ego = Object in Uniform(ra, rb)'
+        'ego = new Object in Uniform(ra, rb)'
     )
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(-1 <= x <= 1 or 9 <= x <= 11 for x in xs)
@@ -263,7 +263,7 @@ def test_in_heading_distribution():
         'ra = RectangularRegion(0@0, 0, 2, 2)\n'
         'ra.orientation = VectorField("foo", lambda pt: 1)\n'
         'rb = PolylineRegion([0 @ 0, 1 @ 1])\n'
-        'ego = Object in Uniform(ra, rb)'
+        'ego = new Object in Uniform(ra, rb)'
     )
     hs = [sampleEgo(scenario).heading for i in range(60)]
     h2 = pytest.approx(-math.pi/4)
@@ -275,7 +275,7 @@ def test_following():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 90 deg * (pos.x + pos.y - 1),
                          minSteps=4, defaultStepSize=1)
-        ego = Object following vf from 1@1 for 4
+        ego = new Object following vf from 1@1 for 4
     """)
     assert tuple(ego.position) == pytest.approx((-1, 3))
     assert ego.heading == pytest.approx(math.radians(90))
@@ -284,6 +284,6 @@ def test_following_random():
     ego = sampleEgoFrom("""
         vf = VectorField('Foo', lambda pos: -90 deg)
         x = Range(1, 2)
-        ego = Object following vf from 1@2 for x, facing x
+        ego = new Object following vf from 1@2 for x, facing x
     """)
     assert tuple(ego.position) == pytest.approx((1+ego.heading, 2))

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -209,7 +209,7 @@ def test_not_visible():
         workspace = Workspace(RectangularRegion(100@205, 0, 20, 12))
         ego = new Object at 100 @ 200, facing -45 deg,
                      with visibleDistance 10, with viewAngle 90 deg
-        ego = Object not visible
+        ego = new Object not visible
     """)
     base = Vector(100, 200)
     for i in range(30):

--- a/tests/syntax/test_tokenization.py
+++ b/tests/syntax/test_tokenization.py
@@ -8,21 +8,21 @@ from tests.utils import compileScenic, sampleEgoFrom, sampleSceneFrom
 
 templates = [
 '''
-ego = Object with length 2, {continuation}
+ego = new Object with length 2, {continuation}
 {indent}with width 3, {continuation}
 {indent}at 10@20
 ''',
 '''
-ego = Object with length 2, {continuation}
+ego = new Object with length 2, {continuation}
 {indent}with width 3, at 10@20
 ''',
 '''
-ego = Object with length 2, {continuation}
+ego = new Object with length 2, {continuation}
 {indent}#with width 2,{continuation}
 {indent}with width 3
 ''',
 '''
-ego = Object with length 2, {continuation}
+ego = new Object with length 2, {continuation}
 # with width 2,{continuation}
 # blah {continuation}
 {indent}with width 3
@@ -36,15 +36,15 @@ ego = Object with length 2, {continuation}
 def test_specifier_layout(template, continuation, indent, gap):
     """Test legal specifier layouts, with and without line continuations."""
     preamble = template.format(continuation=continuation, indent=indent)
-    program = preamble + gap + 'Object at 20@20'
+    program = preamble + gap + 'new Object at 20@20'
     print('TESTING PROGRAM:', program)
     compileScenic(program)
 
 def test_dangling_specifier_list():
-    with pytest.raises(TokenParseError):
-        compileScenic('ego = Object with width 4,')
-    with pytest.raises(TokenParseError):
-        compileScenic('ego = Object with width 4,   # comment')
+    with pytest.raises(SyntaxError):
+        compileScenic('ego = new Object with width 4,')
+    with pytest.raises(SyntaxError):
+        compileScenic('ego = new Object with width 4,   # comment')
 
 def test_dangling_specifier_list_2():
     """Variant of the above test catching a quirk of the Python 3.7.0 tokenizer.
@@ -71,22 +71,22 @@ def test_dangling_specifier_list_2():
 
 def test_constructor_ended_by_paren():
     compileScenic("""
-        ego = Object
-        x = (Object at 5@5)
+        ego = new Object
+        x = (new Object at 5@5)
         mutate ego, x
     """)
 
 def test_semicolon_separating_statements():
     compileScenic("""
-        ego = Object
+        ego = new Object
         param p = distance to 3@4; require ego.position.x >= 0
     """)
 
 def test_list_comprehension():
     scene = sampleSceneFrom("""
         xs = [3*i + Range(0, 1) for i in range(10)]
-        [(Object at x@0) for x in xs]
-        ego = Object at -4@2
+        [(new Object at x@0) for x in xs]
+        ego = new Object at -4@2
     """)
     assert len(scene.objects) == 11
     assert scene.objects[2].position.x - scene.objects[1].position.x != pytest.approx(3)
@@ -97,5 +97,5 @@ def test_incipit_as_name():
     Here we try 'distance' from 'distance from X' and 'offset' from 'X offset by Y'.
     """
     for name in ('distance', 'offset'):
-        ego = sampleEgoFrom(f'{name} = 4\n' f'ego = Object at {name} @ 0')
+        ego = sampleEgoFrom(f'{name} = 4\n' f'ego = new Object at {name} @ 0')
         assert tuple(ego.position) == (4, 0)

--- a/tests/syntax/test_typing.py
+++ b/tests/syntax/test_typing.py
@@ -7,7 +7,7 @@ from tests.utils import compileScenic, sampleEgoFrom, sampleParamP, sampleParamP
 
 def test_tuple_as_vector():
     p = sampleParamPFrom("""
-        ego = Object at 1 @ 2
+        ego = new Object at 1 @ 2
         param p = distance to (-2, -2)
     """)
     assert p == pytest.approx(5)
@@ -15,13 +15,13 @@ def test_tuple_as_vector():
 def test_tuple_as_vector_2():
     with pytest.raises(ScenicSyntaxError):
         compileScenic("""
-            ego = Object at 1 @ 2
+            ego = new Object at 1 @ 2
             param p = distance to (-2, -2, 0)
         """)
 
 def test_list_as_vector():
     p = sampleParamPFrom("""
-        ego = Object at 1 @ 2
+        ego = new Object at 1 @ 2
         param p = distance to [-2, -2]
     """)
     assert p == pytest.approx(5)
@@ -29,6 +29,6 @@ def test_list_as_vector():
 def test_list_as_vector_2():
     with pytest.raises(ScenicSyntaxError):
         compileScenic("""
-            ego = Object at 1 @ 2
+            ego = new Object at 1 @ 2
             param p = distance to [-2, -2, 0]
         """)

--- a/tests/syntax/test_verifai_samplers.py
+++ b/tests/syntax/test_verifai_samplers.py
@@ -36,7 +36,7 @@ def checkCEConvergence(scenario, rangeCheck=(lambda x: x == -1 or x == 1)):
 def test_halton():
     scenario = compileScenic(
         'param verifaiSamplerType = "halton"\n'
-        'ego = Object at VerifaiRange(5, 15) @ 0'
+        'ego = new Object at VerifaiRange(5, 15) @ 0'
     )
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(5 <= x <= 15 for x in xs)
@@ -50,7 +50,7 @@ def test_cross_entropy():
         'ce_params.alpha = 0.9\n'
         'ce_params.cont.buckets = 2\n'
         'param verifaiSamplerParams = ce_params\n'
-        'ego = Object at VerifaiRange(5, 15) @ 0'
+        'ego = new Object at VerifaiRange(5, 15) @ 0'
     )
     f = lambda ego: -1 if ego.position.x < 10 else 1
     xs = [ego.position.x for ego in sampleEgoWithFeedback(scenario, f, 120)]
@@ -63,7 +63,7 @@ def test_cross_entropy_inline():
         'param verifaiSamplerType = "ce"\n'
         'from dotmap import DotMap\n'
         'param verifaiSamplerParams = DotMap(alpha=0.99)\n'
-        'ego = Object at VerifaiRange(-1, 1, weights=[100, 1]) @ 0'
+        'ego = new Object at VerifaiRange(-1, 1, weights=[100, 1]) @ 0'
     )
     checkCEConvergence(scenario, rangeCheck=(lambda x: -1 <= x <= 1))
 
@@ -72,7 +72,7 @@ def test_cross_entropy_options():
         'param verifaiSamplerType = "ce"\n'
         'from dotmap import DotMap\n'
         'param verifaiSamplerParams = DotMap(alpha=0.99)\n'
-        'ego = Object at VerifaiOptions({-1: 100, 1: 1}) @ 0'
+        'ego = new Object at VerifaiOptions({-1: 100, 1: 1}) @ 0'
     )
     checkCEConvergence(scenario)
 
@@ -81,7 +81,7 @@ def test_cross_entropy_prior():
         'param verifaiSamplerType = "ce"\n'
         'from dotmap import DotMap\n'
         'param verifaiSamplerParams = DotMap(alpha=0.99)\n'
-        'ego = Object at VerifaiParameter.withPrior(Options({-1: 100, 1: 1})) @ 0'
+        'ego = new Object at VerifaiParameter.withPrior(Options({-1: 100, 1: 1})) @ 0'
     )
     checkCEConvergence(scenario)
 
@@ -90,7 +90,7 @@ def test_cross_entropy_prior_normal():
         'param verifaiSamplerType = "ce"\n'
         'from dotmap import DotMap\n'
         'param verifaiSamplerParams = DotMap(alpha=0.99)\n'
-        'ego = Object at VerifaiParameter.withPrior(Normal(-1, 0.7)) @ 0'
+        'ego = new Object at VerifaiParameter.withPrior(Normal(-1, 0.7)) @ 0'
     )
     checkCEConvergence(scenario, rangeCheck=(lambda x: True))
 
@@ -99,7 +99,7 @@ def test_cross_entropy_prior_normal():
 def test_reproducibility():
     scenario = compileScenic(
         'param verifaiSamplerType = "ce"\n'
-        'ego = Object at VerifaiRange(-1, 1) @ 0'
+        'ego = new Object at VerifaiRange(-1, 1) @ 0'
     )
     import numpy
     f = lambda ego: -1 if ego.position.x < 10 else 1
@@ -117,7 +117,7 @@ def test_reproducibility():
 
 def test_noninterference():
     for i in range(2):
-        scenario = compileScenic('ego = Object at VerifaiRange(0, 1) @ 0')
+        scenario = compileScenic('ego = new Object at VerifaiRange(0, 1) @ 0')
         for j in range(5):
             scene, iterations = scenario.generate(maxIterations=1)
             assert len(scenario.externalSampler.cachedSample) == 1


### PR DESCRIPTION
This PR updates the syntax of test files under `tests/syntax` to use the `new` keyword.

In addition, it has minor bug fixes (~5 lines) to the parser and compiler. I left comments about those changes in this PR.

The following files include tests with unimplemented syntax, and I did not modify those test cases in this PR.

- `test_dynamics`
- `test_modular`
- `test_errors.py`
  - partially, most cases are passing

To ignore those files, we run `pytest ./tests/syntax --ignore "./tests/syntax/test_dynamics.py" --ignore "./tests/syntax/test_errors.py" --ignore "./tests/syntax/test_modular.py"`. It revealed several major missing parts in the new parser/compiler, which are:

- specifiers that span across multiple lines
- `not visible` specifier
  - this was missing and added to the test suite after I merged #55 
  - PR: #67 
- unpacking distributions

I will work on these on separate branches. 