### PR TITLE
[Parser] port `not visible` specifier to new parser

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -259,6 +259,17 @@ class VisibleSpecifier(AST):
         self._fields = ["base"]
 
 
+class NotVisibleSpecifier(AST):
+    __match_args__ = ("base",)
+
+    def __init__(
+        self, base: Optional[ast.AST] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.base = base
+        self._fields = ["base"]
+
+
 class InSpecifier(AST):
     __match_args__ = ("region",)
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -317,6 +317,19 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             keywords=[],
         )
 
+    def visit_NotVisibleSpecifier(self, node: s.NotVisibleSpecifier):
+        if node.base is not None:
+            return ast.Call(
+                func=ast.Name(id="NotVisibleFrom", ctx=loadCtx),
+                args=[self.visit(node.base)],
+                keywords=[],
+            )
+        return ast.Call(
+            func=ast.Name(id="NotVisibleSpec", ctx=loadCtx),
+            args=[],
+            keywords=[],
+        )
+
     def visit_InSpecifier(self, node: s.InSpecifier):
         return ast.Call(
             func=ast.Name(id="In", ctx=loadCtx),

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1259,6 +1259,7 @@ scenic_specifier:
      }
     | "beyond" v=expression 'by' o=expression b=['from' a=expression {a}] { s.BeyondSpecifier(position=v, offset=o, base=b) }
     | "visible" b=['from' r=expression { r }] { s.VisibleSpecifier(base=b, LOCATIONS) }
+    | 'not' "visible" b=['from' r=expression { r }] { s.NotVisibleSpecifier(base=b, LOCATIONS) }
     | ('in' | "on") r=expression { s.InSpecifier(region=r, LOCATIONS) }
     | "following" f=expression b=['from' e=expression {e}] 'for' d=expression {
         s.FollowingSpecifier(field=f, distance=d, base=b, LOCATIONS)

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -491,6 +491,22 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_not_visible_specifier(self):
+        node, _ = compileScenicAST(NotVisibleSpecifier())
+        match node:
+            case Call(Name("NotVisibleSpec")):
+                assert True
+            case _:
+                assert False
+
+    def test_not_visible_specifier_with_base(self):
+        node, _ = compileScenicAST(NotVisibleSpecifier(Name("x")))
+        match node:
+            case Call(Name("NotVisibleFrom"), [Name("x")]):
+                assert True
+            case _:
+                assert False
+
     def test_in_specifier(self):
         node, _ = compileScenicAST(InSpecifier(Name("region")))
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -518,6 +518,34 @@ class TestNew:
             case _:
                 assert False
 
+    def test_specifier_not_visible(self):
+        mod = parse_string_helper("new Object not visible")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [NotVisibleSpecifier(None)],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_not_visible_from(self):
+        mod = parse_string_helper("new Object not visible from base")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [NotVisibleSpecifier(Name("base"))],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_specifier_in(self):
         mod = parse_string_helper("new Object in region")
         stmt = mod.body[0]


### PR DESCRIPTION
This PR adds `not visible` specifier to the new parser. The specifier was found to be missing when implementing the new parser, and added to the old parser at dfc58def1f23042f1a8194be0dc513168a9bd5b8.

