### PR TITLE
[Parser] support `by` keyword for `mutate` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -126,12 +126,19 @@ class Require(AST):
 
 
 class Mutate(AST):
-    __match_args__ = ("elts",)
+    __match_args__ = ("elts", "scale")
 
-    def __init__(self, elts: list[ast.Name], *args: any, **kwargs: any) -> None:
+    def __init__(
+        self,
+        elts: list[ast.Name],
+        scale: Optional[ast.AST] = None,
+        *args: any,
+        **kwargs: any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.elts = elts
-        self._fields = ["elts"]
+        self.scale = scale
+        self._fields = ["elts", "scale"]
 
 
 # Instance Creation

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -179,7 +179,9 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             value=ast.Call(
                 func=ast.Name(id="mutate", ctx=loadCtx),
                 args=[self.visit(el) for el in node.elts],
-                keywords=[],
+                keywords=[ast.keyword(arg="scale", value=self.visit(node.scale))]
+                if node.scale is not None
+                else [],
             )
         )
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1604,7 +1604,9 @@ scenic_require_stmt_name:
     | a=STRING { a.string[1:-1] }
 
 scenic_mutate_stmt:
-    | 'mutate' elts=[(','.scenic_mutate_stmt_id+)] { s.Mutate(elts=elts if elts is not None else [], LOCATIONS) }
+    | 'mutate' elts=[(','.scenic_mutate_stmt_id+)] scale=['by' x=expression {x}] {
+        s.Mutate(elts=elts if elts is not None else [], scale=scale, LOCATIONS)
+     }
 scenic_mutate_stmt_id: a=NAME { ast.Name(id=a.string, ctx=Load, LOCATIONS) }
 
 # LITERALS

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -622,16 +622,14 @@ class ParameterTableProxy(collections.abc.Mapping):
 def globalParameters():
 	return ParameterTableProxy(_globalParameters)
 
-def mutate(*objects):		# TODO update syntax
+def mutate(*objects, scale = 1):
 	"""Function implementing the mutate statement."""
 	if evaluatingRequirement:
 		raise RuntimeParseError('used mutate statement inside a requirement')
-	scale = 1
-	if objects and isinstance(objects[-1], (float, int)):
-		scale = objects[-1]
-		objects = objects[:-1]
 	if len(objects) == 0:
 		objects = currentScenario._objects
+	if not isinstance(scale, (int, float)):
+		raise RuntimeParseError('"mutate X by Y" with Y not a number')
 	for obj in objects:
 		if not isinstance(obj, Object):
 			raise RuntimeParseError('"mutate X" with X not an object')

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -4,7 +4,7 @@ import pytest
 import scenic
 from scenic.core.errors import InvalidScenarioError, RuntimeParseError
 from scenic.core.object_types import Object
-from tests.utils import compileScenic, sampleParamP, sampleScene, sampleEgo, sampleParamPFrom
+from tests.utils import compileScenic, sampleScene, sampleEgo, sampleParamPFrom
 
 def test_empty():
     with pytest.raises(InvalidScenarioError):
@@ -106,14 +106,15 @@ def test_mutate_everything_scaled():
         ego = new Object at 3@1, facing 0
         other = new Object at 10@20, facing 0
         mutate by 4
-        param p = other
     """)
-    ego = sampleEgo(scenario)
+
+    scene = sampleScene(scenario)
+    ego, other = scene.objects
+
     assert ego.position.x != pytest.approx(3)
     assert ego.position.y != pytest.approx(1)
     assert ego.heading != pytest.approx(0)
 
-    other = sampleParamP(scenario)
     assert other.position.x != pytest.approx(10)
     assert other.position.y != pytest.approx(20)
     assert other.heading != pytest.approx(0)
@@ -123,14 +124,15 @@ def test_mutate_multiple_scaled():
         ego = new Object at 3@1, facing 0
         other = new Object at 10@20, facing 0
         mutate ego, other by 4
-        param p = other
     """)
-    ego = sampleEgo(scenario)
+
+    scene = sampleScene(scenario)
+    ego, other = scene.objects
+
     assert ego.position.x != pytest.approx(3)
     assert ego.position.y != pytest.approx(1)
     assert ego.heading != pytest.approx(0)
 
-    other = sampleParamP(scenario)
     assert other.position.x != pytest.approx(10)
     assert other.position.y != pytest.approx(20)
     assert other.heading != pytest.approx(0)

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -4,7 +4,7 @@ import pytest
 import scenic
 from scenic.core.errors import InvalidScenarioError, RuntimeParseError
 from scenic.core.object_types import Object
-from tests.utils import compileScenic, sampleScene, sampleEgo, sampleParamPFrom
+from tests.utils import compileScenic, sampleParamP, sampleScene, sampleEgo, sampleParamPFrom
 
 def test_empty():
     with pytest.raises(InvalidScenarioError):
@@ -100,6 +100,40 @@ def test_mutate_scaled():
     assert ego1.position.x != pytest.approx(3)
     assert ego1.position.y != pytest.approx(1)
     assert ego1.heading != pytest.approx(0)
+
+def test_mutate_everything_scaled():
+    scenario = compileScenic("""
+        ego = new Object at 3@1, facing 0
+        other = new Object at 10@20, facing 0
+        mutate by 4
+        param p = other
+    """)
+    ego = sampleEgo(scenario)
+    assert ego.position.x != pytest.approx(3)
+    assert ego.position.y != pytest.approx(1)
+    assert ego.heading != pytest.approx(0)
+
+    other = sampleParamP(scenario)
+    assert other.position.x != pytest.approx(10)
+    assert other.position.y != pytest.approx(20)
+    assert other.heading != pytest.approx(0)
+
+def test_mutate_multiple_scaled():
+    scenario = compileScenic("""
+        ego = new Object at 3@1, facing 0
+        other = new Object at 10@20, facing 0
+        mutate ego, other by 4
+        param p = other
+    """)
+    ego = sampleEgo(scenario)
+    assert ego.position.x != pytest.approx(3)
+    assert ego.position.y != pytest.approx(1)
+    assert ego.heading != pytest.approx(0)
+
+    other = sampleParamP(scenario)
+    assert other.position.x != pytest.approx(10)
+    assert other.position.y != pytest.approx(20)
+    assert other.heading != pytest.approx(0)
 
 def test_verbose():
     for verb in range(4):

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -254,6 +254,16 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_mutate_scale(self):
+        node, _ = compileScenicAST(Mutate([Name("x")], Constant(2)))
+        match node:
+            case Expr(
+                Call(Name("mutate"), [Name("x")], [keyword("scale", Constant(2))])
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_param_basic(self):
         node, _ = compileScenicAST(Param([parameter("p1", Name("v1"))]))
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -234,6 +234,24 @@ class TestMutate:
             case _:
                 assert False
 
+    def test_by(self):
+        mod = parse_string_helper("mutate x by y")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([Name("x")], Name("y")):
+                assert True
+            case _:
+                assert False
+
+    def test_every_object_by(self):
+        mod = parse_string_helper("mutate by y")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([], Name("y")):
+                assert True
+            case _:
+                assert False
+
 
 class TestParam:
     def test_basic(self):

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -242,6 +242,15 @@ class TestMutate:
                 assert True
             case _:
                 assert False
+    
+    def mutate_multiple_object_by(self):
+        mod = parse_string_helper("mutate x, y, z by s")
+        stmt = mod.body[0]
+        match stmt:
+            case Mutate([Name("x"), Name("y"), Name("z")], Name("s")):
+                assert True
+            case _:
+                assert False
 
     def test_every_object_by(self):
         mod = parse_string_helper("mutate by y")


### PR DESCRIPTION
This PR adds support for the `by` keyword for `mutate` statements that was implemented in 9a5a88d7dad90a4f2e1efe5f4fec2793af88613b .

- The `mutate` AST node now has `scale` to store value given with `by`
- `mutate` veneer function now takes `scale` as a keyword argument
  - with the new parser, we can distinguish values passed before and after the `by`
- if `scale` is passed but is not a number, raise an error

One difference from the implementation on `main` is that this grammar supports the statements with `by` without objects (i.e. `mutate by <number>`). In the old parser, the token translator would produce an illegal code `mutate(<< <number>)` and fails to parse, but I believe this should "mutate every object by the given scale factor".

