### PR TITLE
[Parser] Unpack distribution

### DIFF
--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -207,6 +207,29 @@ class TestCompiler:
                 )
             )
 
+    def test_unpack_distribution(self):
+        node, _ = compileScenicAST(
+            Call(Name("fn"), [Starred(Name("dist", lineno=1))], [])
+        )
+        match node:
+            case Call(
+                Name("callWithStarArgs"),
+                [
+                    Name("fn"),
+                    Starred(
+                        Call(
+                            Name("wrapStarredValue"),
+                            [Name("dist"), Constant(1)],
+                            [],
+                        )
+                    ),
+                ],
+                [],
+            ):
+                assert True
+            case _:
+                assert False
+
     # Simple Statement
     def test_model_basic(self):
         node, _ = compileScenicAST(Model("model"))

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -209,7 +209,7 @@ class TestCompiler:
 
     def test_unpack_distribution(self):
         node, _ = compileScenicAST(
-            Call(Name("fn"), [Starred(Name("dist", lineno=1))], [])
+            Call(Name("fn"), [Starred(Name("dist", lineno=1)), Name("ego", Load())], [])
         )
         match node:
             case Call(
@@ -223,6 +223,7 @@ class TestCompiler:
                             [],
                         )
                     ),
+                    Call(Name("ego")),
                 ],
                 [],
             ):


### PR DESCRIPTION
This PR adds support for unpacking operator (`*`) on distributions. This procedure was done during the AST surgery phase and this PR implements the same to the new compiler.