### PR TITLE
[Parser] Support Multiline Specifiers

### DIFF
--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -465,6 +465,10 @@ class Parser(Parser):
 
         self.raise_syntax_error_known_location(msg, invalid_target)
 
+    # scenic helpers
+    def extend_new_specifiers(self, node: s.New, specifiers: list[ast.AST]) -> s.New:
+        node.specifiers.extend(specifiers)
+        return node
 '''
 
 
@@ -488,7 +492,7 @@ fstring[ast.Expr]: star_expressions
 
 statements[list]: a=statement+ { list(itertools.chain.from_iterable(a)) }
 
-statement[list]: a=compound_stmt { [a] } | a=scenic_stmts { a } | a=simple_stmts { a }
+statement[list]: a=scenic_compound_stmt { [a] } | a=compound_stmt { [a] } | a=scenic_stmts { a } | a=simple_stmts { a }
 
 statement_newline[list]:
     | a=compound_stmt NEWLINE { [a] }
@@ -537,6 +541,11 @@ scenic_stmt:
     | scenic_param_stmt
     | scenic_require_stmt
     | scenic_mutate_stmt
+
+scenic_compound_stmt:
+    | scenic_tracked_assign_new_stmt
+    | scenic_assign_new_stmt
+    | scenic_expr_new_stmt
 
 # SIMPLE STATEMENTS
 # =================
@@ -736,6 +745,33 @@ scenic_class_property_attribute: &&(
       "additive" { s.Additive(LOCATIONS) }
     | "dynamic" { s.Dynamic(LOCATIONS) }
 )
+
+# Multiline Specifiers
+# --------------------
+scenic_assign_new_stmt:
+    | a=(z=star_targets '=' { z })+ b=(scenic_new_block) !'=' tc=[TYPE_COMMENT] {
+         ast.Assign(targets=a, value=b, type_comment=tc, LOCATIONS)
+     }
+
+scenic_tracked_assign_new_stmt:
+    | a=scenic_tracked_name '=' b=scenic_new_block { s.TrackedAssign(target=a, value=b, LOCATIONS) }
+
+scenic_expr_new_stmt: a=scenic_new_block { ast.Expr(value=a, LOCATIONS) }
+
+scenic_new_block:
+    | a=scenic_new_expr ',' NEWLINE INDENT b=scenic_new_block_body DEDENT {
+        self.extend_new_specifiers(a, b)
+     }
+
+scenic_new_block_body:
+    # without trailing comma
+    | b=(x=scenic_specifiers ',' NEWLINE { x })* c=scenic_specifiers NEWLINE {
+         list(itertools.chain.from_iterable(b)) + c
+     }
+    # with trailing comma
+    | b=(x=scenic_specifiers ',' NEWLINE { x })+ {
+        list(itertools.chain.from_iterable(b))
+     }
 
 # Function definitions
 # --------------------

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -82,8 +82,8 @@ def test_mutate():
 
 def test_mutate_object():
     scenario = compileScenic("""
-        ego = Object at 3@1, facing 0
-        other = Object
+        ego = new Object at 3@1, facing 0
+        other = new Object
         mutate other
     """)
     ego = sampleEgo(scenario)
@@ -93,7 +93,7 @@ def test_mutate_object():
 
 def test_mutate_scaled():
     scenario = compileScenic("""
-        ego = Object at 3@1, facing 0
+        ego = new Object at 3@1, facing 0
         mutate ego by 4
     """)
     ego1 = sampleEgo(scenario)

--- a/tests/syntax/test_operators.py
+++ b/tests/syntax/test_operators.py
@@ -286,7 +286,7 @@ def test_visible():
 
 def test_not_visible():
     scenario = compileScenic("""
-        ego = Object at 100 @ 200, facing -45 deg,
+        ego = new Object at 100 @ 200, facing -45 deg,
                      with visibleDistance 30, with viewAngle 90 deg
         reg = RectangularRegion(100@200, 0, 10, 10)
         param p = new Point in not visible reg

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -242,7 +242,7 @@ class TestMutate:
                 assert True
             case _:
                 assert False
-    
+
     def mutate_multiple_object_by(self):
         mod = parse_string_helper("mutate x, y, z by s")
         stmt = mod.body[0]
@@ -383,6 +383,132 @@ class TestNew:
 
     def test_specifier_multiple(self):
         mod = parse_string_helper("new Object with foo 1, with bar 2, with baz 3")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_multiline_expr(self):
+        mod = parse_string_helper(
+            """
+            new Object with foo 1,
+                with bar 2, with baz 3,
+                with qux 4, with quux 5
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
+                        WithSpecifier("qux", Constant(4)),
+                        WithSpecifier("quux", Constant(5)),
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_multiline_assign(self):
+        mod = parse_string_helper(
+            """
+            obj = new Object with foo 1,
+                with bar 2, with baz 3,
+                with qux 4, with quux 5
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case Assign(
+                targets=[Name("obj")],
+                value=New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
+                        WithSpecifier("qux", Constant(4)),
+                        WithSpecifier("quux", Constant(5)),
+                    ],
+                ),
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_multiline_tracked(self):
+        mod = parse_string_helper(
+            """
+            ego = new Object with foo 1,
+                with bar 2, with baz 3,
+                with qux 4, with quux 5
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case TrackedAssign(
+                Ego(),
+                New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
+                        WithSpecifier("qux", Constant(4)),
+                        WithSpecifier("quux", Constant(5)),
+                    ],
+                ),
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_multiline_trailing_comma(self):
+        mod = parse_string_helper(
+            """
+            new Object with foo 1,
+                with bar 2, with baz 3,
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(
+                New(
+                    "Object",
+                    [
+                        WithSpecifier("foo", Constant(1)),
+                        WithSpecifier("bar", Constant(2)),
+                        WithSpecifier("baz", Constant(3)),
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_specifier_multiline_two_lines(self):
+        mod = parse_string_helper(
+            """
+            new Object with foo 1,
+                with bar 2, with baz 3
+            """
+        )
         stmt = mod.body[0]
         match stmt:
             case Expr(

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -22,7 +22,7 @@ def test_containment_polyline():
     scenario = compileScenic("""
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
         line = PolylineRegion([0@0, 1@1, 2@0])
-        ego = Object on line, facing 0
+        ego = new Object on line, facing 0
     """)
     # Sampling should only require 1 iteration after pruning
     xs = [sampleEgo(scenario).position.x for i in range(60)]

--- a/tests/syntax/test_regions.py
+++ b/tests/syntax/test_regions.py
@@ -21,7 +21,7 @@ def test_nowhere():
 # CircularRegion
 
 def test_circular_in():
-    scenario = compileScenic('ego = Object in CircularRegion(3@5, 2)')
+    scenario = compileScenic('ego = new Object in CircularRegion(3@5, 2)')
     positions = [sampleEgo(scenario).position for i in range(30)]
     center = Vector(3, 5)
     distances = [pos.distanceTo(center) for pos in positions]
@@ -35,7 +35,7 @@ def test_circular_lazy():
     ego = sampleEgoFrom("""
         vf = VectorField("Foo", lambda pos: 2 * pos.x)
         x = 0 relative to vf
-        ego = Object at 3@0, with foo CircularRegion(0@0, x)
+        ego = new Object at 3@0, with foo CircularRegion(0@0, x)
     """)
     assert ego.foo.radius == 6
 

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -194,7 +194,7 @@ def test_visible_from_oriented_point():
     scenario = compileScenic(
         'op = new OrientedPoint at 100 @ 200, facing 45 deg,\n'
         '                   with visibleDistance 5, with viewAngle 90 deg\n'
-        'ego = Object visible from op'
+        'ego = new Object visible from op'
     )
     base = Vector(100, 200)
     for i in range(30):


### PR DESCRIPTION
This PR adds support for multiline specifiers. In addition, this PR contains migration to the new syntax in several test cases.

## Multiline Specifiers

We concluded that supporting multiline specifiers in general is hard for several reasons. First, this requires substantial changes to the grammar because no Python expression involves indents/dedents. Moreover, it is unclear how multiline specifiers work with other expressions with indents (e.g. lists, tuples). 

Therefore, multiline specifiers implemented by this PR only support three essential cases, which are

- Top-level expressions
  - `new Object...`
- Tracked name assignment
  - `ego = new Object` 
- Assignment
  - `obj = new Object`

This PR adds three compound statements that take a `new` expression with multiline specifiers.

### Trailing Comma

In this PR, a trailing comma is optional at the last line of the specifier suite. For example,

```
new Object with foo 1,
  with bar 2
```

and

```
new Object with foo 1,
  with bar 2,
```

are both valid.

## Fixing tests and overall progress

This PR also adds the `new` keyword to the tests that I forgot to change in #66. As a result, every test under `syntax` except `test_dynamics` and `test_modular` are passing.

<img width="338" alt="Screen Shot 2022-08-14 at 16 31 17" src="https://user-images.githubusercontent.com/10496155/184527616-1d5e801e-15b8-4b9b-b6f2-6868ce48fb60.png">

