### PR TITLE
[Parser] implement `record`, `record initial` and `record final`

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -125,6 +125,39 @@ class Require(AST):
         self._fields = ["cond", "prob", "name"]
 
 
+class Record(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
+class RecordInitial(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
+class RecordFinal(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
 class Mutate(AST):
     __match_args__ = ("elts", "scale")
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -253,6 +253,63 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_Record(self, node: s.Record):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_RecordInitial(self, node: s.RecordInitial):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record_initial", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_RecordFinal(self, node: s.RecordFinal):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record_final", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -536,6 +536,9 @@ scenic_stmt:
     | scenic_tracked_assignment
     | scenic_param_stmt
     | scenic_require_stmt
+    | scenic_record_initial_stmt
+    | scenic_record_final_stmt
+    | scenic_record_stmt
     | scenic_mutate_stmt
 
 # SIMPLE STATEMENTS
@@ -1607,6 +1610,21 @@ scenic_require_stmt:
 scenic_require_stmt_name:
     | a=(NAME | NUMBER) { a.string }
     | a=STRING { a.string[1:-1] }
+
+scenic_record_stmt:
+    | "record" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.Record(value=e, name=n, LOCATIONS)
+     }
+
+scenic_record_initial_stmt:
+    | "record" "initial" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RecordInitial(value=e, name=n, LOCATIONS)
+     }
+
+scenic_record_final_stmt:
+    | "record" "final" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RecordFinal(value=e, name=n, LOCATIONS)
+     }
 
 scenic_mutate_stmt:
     | 'mutate' elts=[(','.scenic_mutate_stmt_id+)] scale=['by' x=expression {x}] {

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -363,6 +363,75 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_record(self):
+        node, requirements = compileScenicAST(Record(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial(self):
+        node, requirements = compileScenicAST(RecordInitial(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record_initial"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_record_final(self):
+        node, requirements = compileScenicAST(RecordFinal(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record_final"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -242,7 +242,7 @@ class TestMutate:
                 assert True
             case _:
                 assert False
-    
+
     def mutate_multiple_object_by(self):
         mod = parse_string_helper("mutate x, y, z by s")
         stmt = mod.body[0]
@@ -352,6 +352,62 @@ class TestRequire:
         stmt = mod.body[0]
         match stmt:
             case Require(Name("X"), None, "123"):
+                assert True
+            case _:
+                assert False
+
+
+class TestRecord:
+    def test_record(self):
+        mod = parse_string_helper("record x")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_named(self):
+        mod = parse_string_helper("record x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial(self):
+        mod = parse_string_helper("record initial x")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial_named(self):
+        mod = parse_string_helper("record initial x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final(self):
+        mod = parse_string_helper("record final x")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final_named(self):
+        mod = parse_string_helper("record final x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), "name"):
                 assert True
             case _:
                 assert False


### PR DESCRIPTION
This PR implements `record`, `record initial`, and `record final` statements.

Although they are similar, these three statements are implemented in three different functions in `veneer.py` so I chose to implement them as three separate statements each with an AST node, rather than adding optional `initial` or `final` modifiers.