### PR TITLE
[Parser] Implement `abort` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -192,6 +192,10 @@ class Mutate(AST):
         self._fields = ["elts", "scale"]
 
 
+class Abort(AST):
+    pass
+
+
 # Instance Creation
 
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -517,11 +517,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     def visit_Abort(self, node: s.Abort):
         return ast.copy_location(
-            ast.Return(
-                ast.Attribute(
-                    ast.Name("BlockConclusion", ast.Load()), "ABORT", ast.Load()
-                )
-            ),
+            ast.Return(abortFlag),
             node,
         )
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -515,6 +515,16 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_Abort(self, node: s.Abort):
+        return ast.copy_location(
+            ast.Return(
+                ast.Attribute(
+                    ast.Name("BlockConclusion", ast.Load()), "ABORT", ast.Load()
+                )
+            ),
+            node,
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -541,6 +541,7 @@ scenic_stmt:
     | scenic_param_stmt
     | scenic_require_stmt
     | scenic_mutate_stmt
+    | scenic_abort_stmt
 
 scenic_compound_stmt:
     | scenic_tracked_assign_new_stmt
@@ -1669,6 +1670,8 @@ scenic_mutate_stmt:
         s.Mutate(elts=elts if elts is not None else [], scale=scale, LOCATIONS)
      }
 scenic_mutate_stmt_id: a=NAME { ast.Name(id=a.string, ctx=Load, LOCATIONS) }
+
+scenic_abort_stmt: "abort" { s.Abort(LOCATIONS) }
 
 # LITERALS
 # ========

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -482,6 +482,14 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_abort(self):
+        node, _ = compileScenicAST(Abort())
+        match node:
+            case Return(Attribute(Name("BlockConclusion"), "ABORT")):
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -382,6 +382,17 @@ class TestMutate:
                 assert False
 
 
+class TestAbort:
+    def test_basic(self):
+        mod = parse_string_helper("abort")
+        stmt = mod.body[0]
+        match stmt:
+            case Abort():
+                assert True
+            case _:
+                assert False
+
+
 class TestParam:
     def test_basic(self):
         mod = parse_string_helper("param i = v")


### PR DESCRIPTION
This PR adds `abort` statements which exit functions by returning a special constant value.