### PR TITLE
[Parser] implement `behavior` and `monitor` definitions

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -122,6 +122,67 @@ class Dynamic(AST):
         super().__init__(*args, **kwargs)
 
 
+# behavior / monitor
+
+
+class BehaviorDef(AST):
+    __match_args__ = ("name", "args", "docstring", "header", "body")
+
+    def __init__(
+        self,
+        name: str,
+        args: ast.arguments,
+        docstring: Optional[str],
+        header: list[Union["Precondition", "Invariant"]],
+        body: list[any],
+        *_args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*_args, **kwargs)
+        self.name = name
+        self.args = args
+        self.docstring = docstring
+        self.header = header
+        self.body = body
+        self._fields = ["name", "args", "docstring", "header", "body"]
+
+
+class MonitorDef(AST):
+    __match_args__ = ("name", "docstring", "body")
+
+    def __init__(
+        self,
+        name: str,
+        docstring: Optional[str],
+        body: list[ast.AST],
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.docstring = docstring
+        self.body = body
+        self._fields = ["name", "docstring", "body"]
+
+
+class Precondition(AST):
+    __match_args__ = ("value",)
+
+    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self._fields = ["value"]
+
+
+class Invariant(AST):
+    __match_args__ = ("value",)
+
+    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self._fields = ["value"]
+
+
 # simple statements
 
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -160,6 +160,14 @@ class LocalFinder(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+def unquote(s: str) -> str:
+    if (s[:3] == s[-3:]) and s.startswith(("'''", '"""')):
+        return s[3:-3]
+    if (s[0] == s[-1]) and s.startswith(("'", '"')):
+        return s[1:-1]
+    return s
+
+
 # transformer
 
 
@@ -564,7 +572,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         newBody = body
         docstringNode = []
         if docstring is not None:
-            docstringNode = [ast.Expr(ast.Constant(docstring))]
+            docstringNode = [ast.Expr(ast.Constant(unquote(docstring)))]
 
         # process body
         statements = self.visit(newBody)

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -795,8 +795,7 @@ scenic_behavior_def:
      }
 
 scenic_behavior_def_block:
-    # if only preconditions and/or invariants are specified
-    | NEWLINE INDENT a=[x=STRING NEWLINE { x.string }] b=scenic_behavior_header DEDENT { (a, b, [ast.Pass()]) }
+    # behavior definition must have at least one statement that is not a precondition/invariant definition
     | NEWLINE INDENT a=[x=STRING NEWLINE { x.string }] b=[scenic_behavior_header] c=scenic_behavior_statements DEDENT { (a, b or [], c) }
     | invalid_block
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -547,6 +547,8 @@ scenic_compound_stmt:
     | scenic_tracked_assign_new_stmt
     | scenic_assign_new_stmt
     | scenic_expr_new_stmt
+    | scenic_behavior_def
+    | scenic_monitor_def
     | scenic_try_interrupt_stmt
 
 
@@ -775,6 +777,71 @@ scenic_new_block_body:
     | b=(x=scenic_specifiers ',' NEWLINE { x })+ {
         list(itertools.chain.from_iterable(b))
      }
+
+
+# Behavior
+# --------
+
+scenic_behavior_def:
+    | "behavior" a=NAME b=['(' z=[params] ')' { z }] &&':' c=scenic_behavior_def_block {
+        s.BehaviorDef(
+            a.string,
+            args=b or self.make_arguments(None, [], None, [], None),
+            docstring=c[0],
+            header=c[1],
+            body=c[2],
+            LOCATIONS,
+        )
+     }
+
+scenic_behavior_def_block:
+    # if only preconditions and/or invariants are specified
+    | NEWLINE INDENT a=[x=STRING NEWLINE { x.string }] b=scenic_behavior_header DEDENT { (a, b, [ast.Pass()]) }
+    | NEWLINE INDENT a=[x=STRING NEWLINE { x.string }] b=[scenic_behavior_header] c=scenic_behavior_statements DEDENT { (a, b or [], c) }
+    | invalid_block
+
+scenic_behavior_statements[list]: a=scenic_behavior_statement+ { list(itertools.chain.from_iterable(a)) }
+
+# statements available inside behavior (normal statements + dynamic statements - precondition/invariant)
+scenic_behavior_statement[list]:
+    | scenic_invalid_behavior_statement
+    | a=statement { a }
+
+scenic_invalid_behavior_statement:
+    | a="invariant" ':' a=expression {
+        self.raise_syntax_error_known_location("invariant can only be set at the beginning of behavior definitions", a) 
+     }
+    | a="precondition" ':' a=expression {
+        self.raise_syntax_error_known_location("precondition can only be set at the beginning of behavior definitions", a) 
+     }
+
+scenic_behavior_header: a=(x=(scenic_precondition_stmt | scenic_invariant_stmt) NEWLINE { x })+ { a }
+
+scenic_precondition_stmt:
+    | "precondition" ':' a=expression { s.Precondition(value=a, LOCATIONS) }
+
+scenic_invariant_stmt:
+    | "invariant" ':' a=expression { s.Invariant(value=a, LOCATIONS) }
+
+
+# Monitor
+# -------
+
+scenic_monitor_def:
+    | "monitor" a=NAME &&':' b=scenic_monitor_def_block {
+        s.MonitorDef(
+            a.string,
+            b[0],
+            b[1],
+            LOCATIONS
+        )
+     }
+
+scenic_monitor_def_block:
+    | NEWLINE INDENT a=[x=STRING NEWLINE { x.string }] b=scenic_monitor_statements DEDENT { (a, b) }
+
+scenic_monitor_statements[list]: a=statement+ { list(itertools.chain.from_iterable(a)) }
+
 
 # Function definitions
 # --------------------

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -493,7 +493,7 @@ class TestCompiler:
                     kw_defaults=[],
                     defaults=[],
                 ),
-                docstring="DOCSTRING",
+                docstring="'''DOCSTRING'''",
                 header=[
                     Invariant(
                         value=Compare(
@@ -645,7 +645,7 @@ class TestCompiler:
         node, _ = compileScenicAST(
             MonitorDef(
                 name="M",
-                docstring="DOCSTRING",
+                docstring="'DOCSTRING'",
                 body=[
                     Assign(
                         targets=[Name(id="localvar", ctx=Store())],

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -482,6 +482,240 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_behavior(self):
+        node, _ = compileScenicAST(
+            BehaviorDef(
+                name="Foo",
+                args=arguments(
+                    posonlyargs=[],
+                    args=[arg("input")],
+                    kwonlyargs=[],
+                    kw_defaults=[],
+                    defaults=[],
+                ),
+                docstring="DOCSTRING",
+                header=[
+                    Invariant(
+                        value=Compare(
+                            left=Name(id="localvar", ctx=Load()),
+                            ops=[Gt()],
+                            comparators=[Name(id="input", ctx=Load())],
+                        ),
+                        lineno=2,
+                    ),
+                    Precondition(
+                        value=Compare(
+                            left=Name(id="localvar", ctx=Load()),
+                            ops=[Gt()],
+                            comparators=[Name(id="input", ctx=Load())],
+                        ),
+                        lineno=3,
+                    ),
+                ],
+                body=[
+                    Assign(
+                        targets=[Name(id="localvar", ctx=Store())],
+                        value=Constant(value=1),
+                    ),
+                    While(test=Constant(value=True), body=[Pass()], orelse=[]),
+                ],
+            )
+        )
+        match node:
+            case ClassDef(
+                name="Foo",
+                bases=[Name("Behavior")],
+                keywords=[],
+                body=[
+                    Expr(Constant("DOCSTRING")),  # preserved docstring
+                    FunctionDef(
+                        name="checkPreconditions",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                            args=[arg("input")],
+                        ),
+                        body=[
+                            If(
+                                test=UnaryOp(
+                                    op=Not(),
+                                    operand=Compare(
+                                        left=Attribute(
+                                            value=Name("_Scenic_current_behavior"),
+                                            attr="localvar",
+                                        ),
+                                        ops=[Gt()],
+                                        comparators=[Name("input")],
+                                    ),
+                                ),
+                                body=[
+                                    Raise(
+                                        exc=Call(
+                                            func=Name("PreconditionViolation"),
+                                            args=[
+                                                Name("_Scenic_current_behavior"),
+                                                Constant(3),
+                                            ],
+                                        )
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    FunctionDef(
+                        name="checkInvariants",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                            args=[arg("input")],
+                        ),
+                        body=[
+                            If(
+                                test=UnaryOp(
+                                    op=Not(),
+                                    operand=Compare(
+                                        left=Attribute(
+                                            value=Name("_Scenic_current_behavior"),
+                                            attr="localvar",
+                                        ),
+                                        ops=[Gt()],
+                                        comparators=[Name("input")],
+                                    ),
+                                ),
+                                body=[
+                                    Raise(
+                                        exc=Call(
+                                            func=Name("InvariantViolation"),
+                                            args=[
+                                                Name("_Scenic_current_behavior"),
+                                                Constant(2),
+                                            ],
+                                        )
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                    Assign(
+                        targets=[Name("_locals")],
+                        value=Constant(frozenset()),
+                    ),
+                    FunctionDef(
+                        name="makeGenerator",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                            args=[arg("input")],
+                        ),
+                        body=[
+                            Assign(
+                                targets=[
+                                    Attribute(
+                                        value=Name("_Scenic_current_behavior"),
+                                        attr="input",
+                                    )
+                                ],
+                                value=Name("input"),
+                            ),
+                            Assign(
+                                targets=[
+                                    Attribute(
+                                        value=Name("_Scenic_current_behavior"),
+                                        attr="localvar",
+                                    )
+                                ],
+                                value=Constant(1),
+                            ),
+                            While(test=Constant(True), body=[Pass()]),
+                        ],
+                    ),
+                ],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_monitor(self):
+        node, _ = compileScenicAST(
+            MonitorDef(
+                name="M",
+                docstring="DOCSTRING",
+                body=[
+                    Assign(
+                        targets=[Name(id="localvar", ctx=Store())],
+                        value=Constant(value=1),
+                    ),
+                    While(test=Constant(value=True), body=[Pass()], orelse=[]),
+                ],
+            )
+        )
+        match node:
+            case ClassDef(
+                name="M",
+                bases=[Name("Monitor")],
+                body=[
+                    Expr(Constant("DOCSTRING")),
+                    FunctionDef(
+                        name="checkPreconditions",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                        ),
+                        body=[Pass()],
+                    ),
+                    FunctionDef(
+                        name="checkInvariants",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                        ),
+                        body=[Pass()],
+                    ),
+                    Assign(
+                        targets=[Name("_locals")],
+                        value=Constant(value=frozenset()),
+                    ),
+                    FunctionDef(
+                        name="makeGenerator",
+                        args=arguments(
+                            posonlyargs=[
+                                arg("_Scenic_current_behavior"),
+                                arg("self"),
+                            ],
+                        ),
+                        body=[
+                            Assign(
+                                targets=[
+                                    Attribute(
+                                        value=Name("_Scenic_current_behavior"),
+                                        attr="localvar",
+                                        ctx=Store(),
+                                    )
+                                ],
+                                value=Constant(value=1),
+                            ),
+                            While(
+                                test=Constant(value=True),
+                                body=[Pass()],
+                            ),
+                        ],
+                    ),
+                ],
+            ):
+                assert True
+            case _:
+                assert False
+
     def test_abort(self):
         node, _ = compileScenicAST(Abort())
         match node:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -443,7 +443,7 @@ class TestBehaviorDef:
                 """
                 behavior test:
                     hello()
-                    precondition: True
+                    invariant: True
                 """
             )
 

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -297,6 +297,235 @@ class TestClass:
                 assert False
 
 
+class TestBehaviorDef:
+    def test_basic(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments([], [], None, [], [], None, []),
+                None,
+                [],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_empty_parenthesis(self):
+        mod = parse_string_helper(
+            """
+            behavior test():
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments([], [], None, [], [], None, []),
+                None,
+                [],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_parameter(self):
+        mod = parse_string_helper(
+            """
+            behavior test(x, y = "hello"):
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(args=[arg("x"), arg("y")], defaults=[Constant("hello")]),
+                None,
+                [],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_precondition(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                precondition: True
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(),
+                None,
+                [Precondition(Constant(True))],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_invariant(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                invariant: True
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(),
+                None,
+                [Invariant(Constant(True))],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_precondition_and_invariant(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                precondition: True
+                invariant: True
+                precondition: True
+                pass
+        """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(),
+                None,
+                [
+                    Precondition(Constant(True)),
+                    Invariant(Constant(True)),
+                    Precondition(Constant(True)),
+                ],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_invalid_precondition(self):
+        with pytest.raises(SyntaxError) as e:
+            parse_string_helper(
+                """
+                behavior test:
+                    hello()
+                    precondition: True
+                """
+            )
+
+    def test_invalid_invariant(self):
+        with pytest.raises(SyntaxError) as e:
+            parse_string_helper(
+                """
+                behavior test:
+                    hello()
+                    precondition: True
+                """
+            )
+
+    def test_empty_body(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                invariant: True
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(),
+                None,
+                [
+                    Invariant(Constant(True)),
+                ],
+                [Pass()],
+            ):
+                assert True
+            case _:
+                assert False
+
+    def test_docstring(self):
+        mod = parse_string_helper(
+            """
+            behavior test:
+                \"\"\"DOCSTRING\"\"\"
+                invariant: True
+                body()
+            """
+        )
+        get_docstring
+        stmt = mod.body[0]
+        match stmt:
+            case BehaviorDef(
+                "test",
+                arguments(),
+                '"""DOCSTRING"""',
+                [
+                    Invariant(Constant(True)),
+                ],
+                [Expr(Call(Name("body")))],
+            ):
+                assert True
+            case _:
+                assert False
+
+
+class TestMonitorDef:
+    def test_basic(self):
+        mod = parse_string_helper(
+            """
+            monitor Monitor:
+                pass
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case MonitorDef("Monitor", None, [Pass()]):
+                assert True
+            case _:
+                assert False
+
+    def test_docstring(self):
+        mod = parse_string_helper(
+            """
+            monitor Monitor:
+                \"\"\"DOCSTRING\"\"\"
+                pass
+            """
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case MonitorDef("Monitor", '"""DOCSTRING"""', [Pass()]):
+                assert True
+            case _:
+                assert False
+
+
 class TestModel:
     def test_basic(self):
         mod = parse_string_helper("model some_model")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -448,26 +448,13 @@ class TestBehaviorDef:
             )
 
     def test_empty_body(self):
-        mod = parse_string_helper(
-            """
-            behavior test:
-                invariant: True
-            """
-        )
-        stmt = mod.body[0]
-        match stmt:
-            case BehaviorDef(
-                "test",
-                arguments(),
-                None,
-                [
-                    Invariant(Constant(True)),
-                ],
-                [Pass()],
-            ):
-                assert True
-            case _:
-                assert False
+        with pytest.raises(SyntaxError):
+            mod = parse_string_helper(
+                """
+                behavior test:
+                    invariant: True
+                """
+            )
 
     def test_docstring(self):
         mod = parse_string_helper(


### PR DESCRIPTION
This PR adds `behavior` and `monitor` compound statements for defining behaviors and monitors.

## Changes

While our primary goal is to preserve compatibility, I've made a couple of changes from the current compiler. 

### Position of preconditions/invariants declaration

Scenic 2.0 allows arbitrary ordering of preconditions and invariant declarations. For example,

```python
behavior B:
    precondition: C1
    hello()
    invariant: C2
```

This is valid in the current version of the compiler. In the new parser, preconditions and invariants **must** be placed before any other statements. The example above is invalid because the invariant declaration comes after a normal function call `hello()`.

**TODO:** If this gets merged, add a TODO item to document ordering of `precondition` and `invariant` declarations.

### Invariants and preconditions on `monitor`

The current compiler allows the use of `precondition: ...` and `invariant: ...` inside monitors as well. However, the documentation does not mention the use of these declarations for monitors. In the new parser, preconditions and invariants can only be defined inside behaviors. The use of those syntax inside monitors will be a syntax error.

