### PR TITLE
[Parser] invoke dynamic actions

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -257,6 +257,80 @@ class Abort(AST):
     pass
 
 
+class Take(AST):
+    __match_args__ = ("elts",)
+
+    def __init__(self, elts: list[ast.AST], *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.elts = elts
+        self._fields = ["elts"]
+
+
+class Wait(AST):
+    pass
+
+
+class Terminate(AST):
+    pass
+
+
+class DoFor(AST):
+    __match_args__ = ("value", "duration")
+
+    def __init__(
+        self,
+        value: ast.AST,
+        duration: Union["Seconds", "Steps"],
+        *args: any,
+        **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.duration = duration
+        self._fields = ["value", "duration"]
+
+
+class Seconds(AST):
+    __match_args__ = ("value",)
+    unitStr = "seconds"
+
+    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self._fields = ["value"]
+
+
+class Steps(AST):
+    __match_args__ = ("value",)
+    unitStr = "steps"
+
+    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self._fields = ["value"]
+
+
+class DoUntil(AST):
+    __match_args__ = ("value", "cond")
+
+    def __init__(
+        self, value: ast.AST, cond: ast.AST, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.cond = cond
+        self._fields = ["value", "cond"]
+
+
+class Do(AST):
+    __match_args__ = ("value",)
+
+    def __init__(self, value: list[ast.AST], *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self._fields = ["value"]
+
+
 # Instance Creation
 
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -275,19 +275,19 @@ class Terminate(AST):
 
 
 class DoFor(AST):
-    __match_args__ = ("value", "duration")
+    __match_args__ = ("elts", "duration")
 
     def __init__(
         self,
-        value: ast.AST,
+        elts: list[ast.AST],
         duration: Union["Seconds", "Steps"],
         *args: any,
         **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.value = value
+        self.elts = elts
         self.duration = duration
-        self._fields = ["value", "duration"]
+        self._fields = ["elts", "duration"]
 
 
 class Seconds(AST):
@@ -311,24 +311,24 @@ class Steps(AST):
 
 
 class DoUntil(AST):
-    __match_args__ = ("value", "cond")
+    __match_args__ = ("elts", "cond")
 
     def __init__(
-        self, value: ast.AST, cond: ast.AST, *args: any, **kwargs: any
+        self, elts: list[ast.AST], cond: ast.AST, *args: any, **kwargs: any
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.value = value
+        self.elts = elts
         self.cond = cond
         self._fields = ["value", "cond"]
 
 
 class Do(AST):
-    __match_args__ = ("value",)
+    __match_args__ = ("elts",)
 
-    def __init__(self, value: list[ast.AST], *args: any, **kwargs: any) -> None:
+    def __init__(self, elts: list[ast.AST], *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+        self.elts = elts
+        self._fields = ["elts"]
 
 
 # Instance Creation

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -719,9 +719,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         subHandler = ast.Attribute(
             ast.Name(behaviorArgName, loadCtx), "_invokeSubBehavior", loadCtx
         )
+        # TODO(shun): Check node has no more than one element inside behavior/monitors
         subArgs = [
             ast.Name("self", loadCtx),
-            ast.Tuple([self.visit(node.value)], loadCtx),
+            ast.Tuple([self.visit(e) for e in node.elts], loadCtx),
         ]
         subRunner = ast.Call(subHandler, subArgs, [])
         return self.generateInvocation(node, subRunner, ast.YieldFrom)
@@ -730,9 +731,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         subHandler = ast.Attribute(
             ast.Name(behaviorArgName, loadCtx), "_invokeSubBehavior", loadCtx
         )
+        # TODO(shun): Check node has no more than one element inside behavior/monitors
         subArgs = [
             ast.Name("self", loadCtx),
-            ast.Tuple([self.visit(node.value)], loadCtx),
+            ast.Tuple([self.visit(e) for e in node.elts], loadCtx),
             ast.Call(
                 func=ast.Name("Modifier", loadCtx),
                 args=[
@@ -750,9 +752,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         subHandler = ast.Attribute(
             ast.Name(behaviorArgName, loadCtx), "_invokeSubBehavior", loadCtx
         )
+        # TODO(shun): Check node has no more than one element inside behavior/monitors
         subArgs = [
             ast.Name("self", loadCtx),
-            ast.Tuple([self.visit(node.value)], loadCtx),
+            ast.Tuple([self.visit(e) for e in node.elts], loadCtx),
             ast.Call(
                 func=ast.Name("Modifier", loadCtx),
                 args=[

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1751,14 +1751,14 @@ scenic_wait_stmt: 'wait' { s.Wait(LOCATIONS) }
 
 scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
 
-scenic_do_for_stmt: 'do' v=expression 'for' u=scenic_dynamic_duration { s.DoFor(value=v, duration=u, LOCATIONS) }
+scenic_do_for_stmt: 'do' e=(','.expression+) 'for' u=scenic_dynamic_duration { s.DoFor(elts=e, duration=u, LOCATIONS) }
 scenic_dynamic_duration:
     | v=expression 'seconds' { s.Seconds(v, LOCATIONS) }
     | v=expression 'steps' { s.Steps(v, LOCATIONS) }
 
-scenic_do_until_stmt: 'do' v=expression 'until' cond=expression { s.DoUntil(value=v, cond=cond, LOCATIONS) }
+scenic_do_until_stmt: 'do' e=(','.expression+) 'until' cond=expression { s.DoUntil(elts=e, cond=cond, LOCATIONS) }
 
-scenic_do_stmt: 'do' v=expression { s.Do(value=v, LOCATIONS) }
+scenic_do_stmt: 'do' e=(','.expression+) { s.Do(elts=e, LOCATIONS) }
 
 
 # LITERALS

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -541,6 +541,12 @@ scenic_stmt:
     | scenic_param_stmt
     | scenic_require_stmt
     | scenic_mutate_stmt
+    | scenic_take_stmt
+    | scenic_wait_stmt
+    | scenic_terminate_stmt
+    | scenic_do_for_stmt
+    | scenic_do_until_stmt
+    | scenic_do_stmt
     | scenic_abort_stmt
 
 scenic_compound_stmt:
@@ -1738,6 +1744,22 @@ scenic_mutate_stmt:
 scenic_mutate_stmt_id: a=NAME { ast.Name(id=a.string, ctx=Load, LOCATIONS) }
 
 scenic_abort_stmt: "abort" { s.Abort(LOCATIONS) }
+
+scenic_take_stmt: 'take' elts=(','.expression+) { s.Take(elts=elts, LOCATIONS) }
+
+scenic_wait_stmt: 'wait' { s.Wait(LOCATIONS) }
+
+scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
+
+scenic_do_for_stmt: 'do' v=expression 'for' u=scenic_dynamic_duration { s.DoFor(value=v, duration=u, LOCATIONS) }
+scenic_dynamic_duration:
+    | v=expression 'seconds' { s.Seconds(v, LOCATIONS) }
+    | v=expression 'steps' { s.Steps(v, LOCATIONS) }
+
+scenic_do_until_stmt: 'do' v=expression 'until' cond=expression { s.DoUntil(value=v, cond=cond, LOCATIONS) }
+
+scenic_do_stmt: 'do' v=expression { s.Do(value=v, LOCATIONS) }
+
 
 # LITERALS
 # ========

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -766,7 +766,7 @@ class TestCompiler:
                 assert False
 
     def test_do(self):
-        node, _ = compileScenicAST(Do(Constant(1)))
+        node, _ = compileScenicAST(Do([Constant(1)]))
         match node:
             case [
                 Expr(
@@ -795,7 +795,7 @@ class TestCompiler:
                 assert False
 
     def test_do_for_seconds(self):
-        node, _ = compileScenicAST(DoFor(Constant("foo"), Seconds(Constant(1))))
+        node, _ = compileScenicAST(DoFor([Constant("foo")], Seconds(Constant(1))))
         match node:
             case [
                 Expr(
@@ -833,7 +833,7 @@ class TestCompiler:
                 assert False
 
     def test_do_for_steps(self):
-        node, _ = compileScenicAST(DoFor(Constant("foo"), Steps(Constant(3))))
+        node, _ = compileScenicAST(DoFor([Constant("foo")], Steps(Constant(3))))
         match node:
             case [
                 Expr(
@@ -871,7 +871,7 @@ class TestCompiler:
                 assert False
 
     def test_do_until(self):
-        node, _ = compileScenicAST(DoUntil(Constant("foo"), Name("condition")))
+        node, _ = compileScenicAST(DoUntil([Constant("foo")], Name("condition")))
         match node:
             case [
                 Expr(

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -416,7 +416,7 @@ def test_behavior_invoke_mistyped():
         sampleActions(scenario)
 
 def test_behavior_invoke_multiple():
-    with pytest.raises(ScenicSyntaxError):
+    with pytest.raises(SyntaxError):
         compileScenic("""
             behavior Foo():
                 take 5

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -609,6 +609,102 @@ class TestAbort:
                 assert False
 
 
+class TestTake:
+    def test_single(self):
+        mod = parse_string_helper("take 1")
+        stmt = mod.body[0]
+        match stmt:
+            case Take([Constant(1)]):
+                assert True
+            case _:
+                assert False
+
+    def test_multiple(self):
+        mod = parse_string_helper(
+            "take SetThrottleAction(throttle), SetSteerAction(steering)"
+        )
+        stmt = mod.body[0]
+        match stmt:
+            case Take(
+                [
+                    Call(Name("SetThrottleAction"), [Name("throttle")]),
+                    Call(Name("SetSteerAction"), [Name("steering")]),
+                ]
+            ):
+                assert True
+            case _:
+                assert False
+
+
+class TestWait:
+    def test_wait(self):
+        mod = parse_string_helper("wait")
+        stmt = mod.body[0]
+        match stmt:
+            case Wait():
+                assert True
+            case _:
+                assert False
+
+
+class TestTerminate:
+    def test_basic(self):
+        mod = parse_string_helper("terminate")
+        stmt = mod.body[0]
+        match stmt:
+            case Terminate():
+                assert True
+            case _:
+                assert False
+
+
+class TestDo:
+    def test_basic(self):
+        mod = parse_string_helper("do foo")
+        stmt = mod.body[0]
+        match stmt:
+            case Do(Name("foo")):
+                assert True
+            case _:
+                assert False
+
+    def test_do_for_seconds(self):
+        mod = parse_string_helper("do foo for 3 seconds")
+        stmt = mod.body[0]
+        match stmt:
+            case DoFor(Name("foo"), Seconds(Constant(3))):
+                assert True
+            case _:
+                assert False
+
+    def test_do_for_steps(self):
+        mod = parse_string_helper("do foo for 3 steps")
+        stmt = mod.body[0]
+        match stmt:
+            case DoFor(Name("foo"), Steps(Constant(3))):
+                assert True
+            case _:
+                assert False
+
+    def test_do_for_expression(self):
+        mod = parse_string_helper("do foo for 3 + 3 steps")
+        stmt = mod.body[0]
+        match stmt:
+            case DoFor(Name("foo"), Steps(BinOp(Constant(3), Add(), Constant(3)))):
+                assert True
+            case _:
+                assert False
+
+    def test_do_until(self):
+        mod = parse_string_helper("do foo until condition")
+        stmt = mod.body[0]
+        match stmt:
+            case DoUntil(Name("foo"), Name("condition")):
+                assert True
+            case _:
+                assert False
+
+
 class TestParam:
     def test_basic(self):
         mod = parse_string_helper("param i = v")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -659,11 +659,20 @@ class TestTerminate:
 
 
 class TestDo:
-    def test_basic(self):
+    def test_do(self):
         mod = parse_string_helper("do foo")
         stmt = mod.body[0]
         match stmt:
-            case Do(Name("foo")):
+            case Do([Name("foo")]):
+                assert True
+            case _:
+                assert False
+
+    def test_do_multiple(self):
+        mod = parse_string_helper("do foo, bar")
+        stmt = mod.body[0]
+        match stmt:
+            case Do([Name("foo"), Name("bar")]):
                 assert True
             case _:
                 assert False
@@ -672,7 +681,7 @@ class TestDo:
         mod = parse_string_helper("do foo for 3 seconds")
         stmt = mod.body[0]
         match stmt:
-            case DoFor(Name("foo"), Seconds(Constant(3))):
+            case DoFor([Name("foo")], Seconds(Constant(3))):
                 assert True
             case _:
                 assert False
@@ -681,7 +690,7 @@ class TestDo:
         mod = parse_string_helper("do foo for 3 steps")
         stmt = mod.body[0]
         match stmt:
-            case DoFor(Name("foo"), Steps(Constant(3))):
+            case DoFor([Name("foo")], Steps(Constant(3))):
                 assert True
             case _:
                 assert False
@@ -690,7 +699,16 @@ class TestDo:
         mod = parse_string_helper("do foo for 3 + 3 steps")
         stmt = mod.body[0]
         match stmt:
-            case DoFor(Name("foo"), Steps(BinOp(Constant(3), Add(), Constant(3)))):
+            case DoFor([Name("foo")], Steps(BinOp(Constant(3), Add(), Constant(3)))):
+                assert True
+            case _:
+                assert False
+
+    def test_do_for_multiple(self):
+        mod = parse_string_helper("do foo, bar for 5 steps")
+        stmt = mod.body[0]
+        match stmt:
+            case DoFor([Name("foo"), Name("bar")], Steps(Constant(5))):
                 assert True
             case _:
                 assert False
@@ -699,7 +717,16 @@ class TestDo:
         mod = parse_string_helper("do foo until condition")
         stmt = mod.body[0]
         match stmt:
-            case DoUntil(Name("foo"), Name("condition")):
+            case DoUntil([Name("foo")], Name("condition")):
+                assert True
+            case _:
+                assert False
+
+    def test_do_until_multiple(self):
+        mod = parse_string_helper("do foo, bar until condition")
+        stmt = mod.body[0]
+        match stmt:
+            case DoUntil([Name("foo"), Name("bar")], Name("condition")):
                 assert True
             case _:
                 assert False


### PR DESCRIPTION
This PR implements six statements that invoke dynamic actions, namely

- take
- wait
- terminate
- do for
- do until
- do

## Discussion Points

### How many operands do `do` statements take?

~The documentation says the `do` statement can take more than one behaviors/actions. However, the implementation only allows one behavior/action at a time. There also is a test case that asserts an error is raised when more than one operands are specified.~

https://github.com/BerkeleyLearnVerify/Scenic/blob/f1c42f1559e555ec50073e30ee4a1f4a50fdadf2/tests/syntax/test_dynamics.py#L424

~In this PR, I chose to keep the current behavior and the statement can only take one operand. However, I believe it makes sense to add support for invoking more than one behaviors/scenarios.~

`do` can take multiple actions inside modular scenarios but not in behaviors and monitors. At the parser level, we allow multiple operands to be passed to do statements. At the compiler level, we throw an error if more than one operands are given inside behaviors/monitors.

