### PR TITLE
[Parser] implement requirement-like syntax

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -331,6 +331,24 @@ class Terminate(AST):
     pass
 
 
+class TerminateSimulationWhen(AST):
+    __match_args__ = ("cond",)
+
+    def __init__(self, cond=ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.cond = cond
+        self._fields = ["cond"]
+
+
+class TerminateWhen(AST):
+    __match_args__ = ("cond",)
+
+    def __init__(self, cond=ast.AST, *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.cond = cond
+        self._fields = ["cond"]
+
+
 class DoFor(AST):
     __match_args__ = ("elts", "duration")
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -261,6 +261,39 @@ class RequireEventually(AST):
         self._fields = ["cond", "name"]
 
 
+class Record(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
+class RecordInitial(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
+class RecordFinal(AST):
+    __match_args__ = ("value", "name")
+
+    def __init__(
+        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.value = value
+        self.name = name
+
+
 class Mutate(AST):
     __match_args__ = ("elts", "scale")
 

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -237,6 +237,30 @@ class Require(AST):
         self._fields = ["cond", "prob", "name"]
 
 
+class RequireAlways(AST):
+    __match_args__ = ("cond", "name")
+
+    def __init__(
+        self, cond: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.cond = cond
+        self.name = name
+        self._fields = ["cond", "name"]
+
+
+class RequireEventually(AST):
+    __match_args__ = ("cond", "name")
+
+    def __init__(
+        self, cond: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.cond = cond
+        self.name = name
+        self._fields = ["cond", "name"]
+
+
 class Mutate(AST):
     __match_args__ = ("elts", "scale")
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -820,7 +820,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         name: Optional[str] = None,
         prob: Optional[float] = None,
     ):
-        """Create a call to a function that implements requirement-like features, such as `record` and `terminate`.
+        """Create a call to a function that implements requirement-like features, such as `record` and `terminate when`.
 
         Args:
             functionName (str): Name of the requirement-like function to call. Its signature must be `(reqId: int, body: () -> bool, lineno: int, name: str | None)`

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -828,6 +828,63 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_Record(self, node: s.Record):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_RecordInitial(self, node: s.RecordInitial):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record_initial", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_RecordFinal(self, node: s.RecordFinal):
+        value = self.visit(node.value)
+        syntax_id = self._register_requirement_syntax(value)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="record_final", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=value,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -885,6 +885,38 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_TerminateWhen(self, node: s.TerminateWhen):
+        condition = self.visit(node.cond)
+        syntax_id = self._register_requirement_syntax(condition)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name("terminate_when", loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(args=noArgs, body=condition),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(None),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_TerminateSimulationWhen(self, node: s.TerminateSimulationWhen):
+        condition = self.visit(node.cond)
+        syntax_id = self._register_requirement_syntax(condition)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name("terminate_simulation_when", loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(args=noArgs, body=condition),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(None),
+                ],
+                keywords=[],
+            )
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -790,6 +790,44 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             checkInvariants,
         ]
 
+    def visit_RequireAlways(self, node: s.RequireAlways):
+        condition = self.visit(node.cond)
+        syntax_id = self._register_requirement_syntax(condition)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="require_always", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=condition,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
+    def visit_RequireEventually(self, node: s.RequireEventually):
+        condition = self.visit(node.cond)
+        syntax_id = self._register_requirement_syntax(condition)
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="require_eventually", ctx=loadCtx),
+                args=[
+                    ast.Constant(syntax_id),
+                    ast.Lambda(
+                        args=noArgs,
+                        body=condition,
+                    ),
+                    ast.Constant(value=node.lineno),
+                    ast.Constant(value=node.name),
+                ],
+                keywords=[],
+            )
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -676,24 +676,8 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     def visit_Require(self, node: s.Require):
         condition = self.visit(node.cond)
-        syntax_id = self._register_requirement_syntax(condition)
-
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="require", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=condition,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[ast.keyword(arg="prob", value=ast.Constant(node.prob))]
-                if node.prob is not None
-                else [],
-            )
+        return self.createRequirementLike(
+            "require", condition, node.lineno, node.name, node.prob
         )
 
     def visit_Abort(self, node: s.Abort):
@@ -792,128 +776,72 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     def visit_RequireAlways(self, node: s.RequireAlways):
         condition = self.visit(node.cond)
-        syntax_id = self._register_requirement_syntax(condition)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="require_always", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=condition,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[],
-            )
+        return self.createRequirementLike(
+            "require_always", condition, node.lineno, node.name
         )
 
     def visit_RequireEventually(self, node: s.RequireEventually):
         condition = self.visit(node.cond)
-        syntax_id = self._register_requirement_syntax(condition)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="require_eventually", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=condition,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[],
-            )
+        return self.createRequirementLike(
+            "require_eventually", condition, node.lineno, node.name
         )
 
     def visit_Record(self, node: s.Record):
         value = self.visit(node.value)
-        syntax_id = self._register_requirement_syntax(value)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="record", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=value,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[],
-            )
-        )
+        return self.createRequirementLike("record", value, node.lineno, node.name)
 
     def visit_RecordInitial(self, node: s.RecordInitial):
         value = self.visit(node.value)
-        syntax_id = self._register_requirement_syntax(value)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="record_initial", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=value,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[],
-            )
+        return self.createRequirementLike(
+            "record_initial", value, node.lineno, node.name
         )
 
     def visit_RecordFinal(self, node: s.RecordFinal):
         value = self.visit(node.value)
-        syntax_id = self._register_requirement_syntax(value)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name(id="record_final", ctx=loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(
-                        args=noArgs,
-                        body=value,
-                    ),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(value=node.name),
-                ],
-                keywords=[],
-            )
-        )
+        return self.createRequirementLike("record_final", value, node.lineno, node.name)
 
     def visit_TerminateWhen(self, node: s.TerminateWhen):
         condition = self.visit(node.cond)
-        syntax_id = self._register_requirement_syntax(condition)
-        return ast.Expr(
-            value=ast.Call(
-                func=ast.Name("terminate_when", loadCtx),
-                args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(args=noArgs, body=condition),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(None),
-                ],
-                keywords=[],
-            )
+        return self.createRequirementLike(
+            "terminate_when", condition, node.lineno, None
         )
 
     def visit_TerminateSimulationWhen(self, node: s.TerminateSimulationWhen):
         condition = self.visit(node.cond)
-        syntax_id = self._register_requirement_syntax(condition)
+        return self.createRequirementLike(
+            "terminate_simulation_when", condition, node.lineno
+        )
+
+    def createRequirementLike(
+        self,
+        functionName: str,
+        syntax: ast.AST,
+        lineno: int,
+        name: Optional[str] = None,
+        prob: Optional[float] = None,
+    ):
+        """Create a call to a function that implements requirement-like features, such as `record` and `terminate`.
+
+        Args:
+            functionName (str): Name of the requirement-like function to call. Its signature must be `(reqId: int, body: () -> bool, lineno: int, name: str | None)`
+            syntax (ast.AST): AST node to evaluate for checking the condition
+            lineno (int): Line number in the source code
+            name (Optional[str], optional): Optional name for requirements. Defaults to None.
+            prob (Optional[float], optional): Optional probability for requirements. Defaults to None.
+        """
+        syntax_id = self._register_requirement_syntax(syntax)
         return ast.Expr(
             value=ast.Call(
-                func=ast.Name("terminate_simulation_when", loadCtx),
+                func=ast.Name(functionName, loadCtx),
                 args=[
-                    ast.Constant(syntax_id),
-                    ast.Lambda(args=noArgs, body=condition),
-                    ast.Constant(value=node.lineno),
-                    ast.Constant(None),
+                    ast.Constant(syntax_id),  # requirement ID
+                    ast.Lambda(args=noArgs, body=syntax),  # body
+                    ast.Constant(lineno),  # line number
+                    ast.Constant(name),  # requirement name
                 ],
-                keywords=[],
+                keywords=[ast.keyword(arg="prob", value=ast.Constant(prob))]
+                if prob is not None
+                else [],
             )
         )
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -542,6 +542,9 @@ scenic_stmt:
     | scenic_require_always_stmt
     | scenic_require_eventually_stmt
     | scenic_require_stmt
+    | scenic_record_initial_stmt
+    | scenic_record_final_stmt
+    | scenic_record_stmt
     | scenic_mutate_stmt
     | scenic_take_stmt
     | scenic_wait_stmt
@@ -1747,6 +1750,21 @@ scenic_require_always_stmt:
 scenic_require_eventually_stmt:
     | 'require' 'eventually' e=expression n=['as' a=scenic_require_stmt_name { a }] {
         s.RequireEventually(cond=e, name=n, LOCATIONS)
+     }
+
+scenic_record_stmt:
+    | "record" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.Record(value=e, name=n, LOCATIONS)
+     }
+
+scenic_record_initial_stmt:
+    | "record" "initial" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RecordInitial(value=e, name=n, LOCATIONS)
+     }
+
+scenic_record_final_stmt:
+    | "record" "final" e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RecordFinal(value=e, name=n, LOCATIONS)
      }
 
 scenic_mutate_stmt:

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -539,6 +539,8 @@ scenic_stmt:
     | scenic_model_stmt
     | scenic_tracked_assignment
     | scenic_param_stmt
+    | scenic_require_always_stmt
+    | scenic_require_eventually_stmt
     | scenic_require_stmt
     | scenic_mutate_stmt
     | scenic_take_stmt
@@ -1736,6 +1738,16 @@ scenic_require_stmt:
 scenic_require_stmt_name:
     | a=(NAME | NUMBER) { a.string }
     | a=STRING { a.string[1:-1] }
+
+scenic_require_always_stmt:
+    | 'require' 'always' e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RequireAlways(cond=e, name=n, LOCATIONS)
+     }
+
+scenic_require_eventually_stmt:
+    | 'require' 'eventually' e=expression n=['as' a=scenic_require_stmt_name { a }] {
+        s.RequireEventually(cond=e, name=n, LOCATIONS)
+     }
 
 scenic_mutate_stmt:
     | 'mutate' elts=[(','.scenic_mutate_stmt_id+)] scale=['by' x=expression {x}] {

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -546,6 +546,8 @@ scenic_stmt:
     | scenic_record_final_stmt
     | scenic_record_stmt
     | scenic_mutate_stmt
+    | scenic_terminate_simulation_when_stmt
+    | scenic_terminate_when_stmt
     | scenic_take_stmt
     | scenic_wait_stmt
     | scenic_terminate_stmt
@@ -1778,6 +1780,10 @@ scenic_abort_stmt: "abort" { s.Abort(LOCATIONS) }
 scenic_take_stmt: 'take' elts=(','.expression+) { s.Take(elts=elts, LOCATIONS) }
 
 scenic_wait_stmt: 'wait' { s.Wait(LOCATIONS) }
+
+scenic_terminate_simulation_when_stmt: "terminate" "simulation" "when" v=expression { s.TerminateSimulationWhen(v, LOCATIONS) }
+
+scenic_terminate_when_stmt: "terminate" "when" v=expression { s.TerminateWhen(v, LOCATIONS) }
 
 scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
 

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -951,6 +951,52 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_require_always(self):
+        node, requirements = compileScenicAST(RequireAlways(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("require_always"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # requirement
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_require_eventually(self):
+        node, requirements = compileScenicAST(RequireEventually(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("require_eventually"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # requirement
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1066,6 +1066,58 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_terminate_when(self):
+        node, requirements = compileScenicAST(TerminateWhen(Name("C"), lineno=2))
+
+        match node:
+            case Expr(
+                Call(
+                    Name("terminate_when"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # requirement
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_terminate_simulation_when(self):
+        node, requirements = compileScenicAST(
+            TerminateSimulationWhen(Name("C"), lineno=2)
+        )
+
+        match node:
+            case Expr(
+                Call(
+                    Name("terminate_simulation_when"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # requirement
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -997,6 +997,75 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_record(self):
+        node, requirements = compileScenicAST(Record(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial(self):
+        node, requirements = compileScenicAST(RecordInitial(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record_initial"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
+    def test_record_final(self):
+        node, requirements = compileScenicAST(RecordFinal(Name("C"), lineno=2))
+        match node:
+            case Expr(
+                Call(
+                    Name("record_final"),
+                    [
+                        Constant(0),  # reqId
+                        Lambda(body=Name("C")),  # record value
+                        Constant(2),  # lineno
+                        Constant(None),  # name
+                    ],
+                )
+            ):
+                assert True
+            case _:
+                assert False
+        match requirements:
+            case [Name("C")]:
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -863,6 +863,62 @@ class TestRequire:
                 assert False
 
 
+class TestRecord:
+    def test_record(self):
+        mod = parse_string_helper("record x")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_named(self):
+        mod = parse_string_helper("record x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case Record(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial(self):
+        mod = parse_string_helper("record initial x")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_initial_named(self):
+        mod = parse_string_helper("record initial x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordInitial(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final(self):
+        mod = parse_string_helper("record final x")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_record_final_named(self):
+        mod = parse_string_helper("record final x as name")
+        stmt = mod.body[0]
+        match stmt:
+            case RecordFinal(Name("x"), "name"):
+                assert True
+            case _:
+                assert False
+
+
 class TestNew:
     def test_basic(self):
         mod = parse_string_helper("new Object")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -919,6 +919,26 @@ class TestRecord:
                 assert False
 
 
+class TestTerminateWhen:
+    def test_terminate_when(self):
+        mod = parse_string_helper("terminate when x")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateWhen(Name("x")):
+                assert True
+            case _:
+                assert False
+
+    def test_terminate_simulation_when(self):
+        mod = parse_string_helper("terminate simulation when x")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateSimulationWhen(Name("x")):
+                assert True
+            case _:
+                assert False
+
+
 class TestNew:
     def test_basic(self):
         mod = parse_string_helper("new Object")

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -826,6 +826,42 @@ class TestRequire:
             case _:
                 assert False
 
+    def test_require_always(self):
+        mod = parse_string_helper("require always X")
+        stmt = mod.body[0]
+        match stmt:
+            case RequireAlways(Name("X"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_require_always_with_name(self):
+        mod = parse_string_helper("require always X as safety")
+        stmt = mod.body[0]
+        match stmt:
+            case RequireAlways(Name("X"), "safety"):
+                assert True
+            case _:
+                assert False
+
+    def test_require_eventually(self):
+        mod = parse_string_helper("require eventually X")
+        stmt = mod.body[0]
+        match stmt:
+            case RequireEventually(Name("X"), None):
+                assert True
+            case _:
+                assert False
+
+    def test_require_eventually_with_name(self):
+        mod = parse_string_helper("require eventually X as liveness")
+        stmt = mod.body[0]
+        match stmt:
+            case RequireEventually(Name("X"), "liveness"):
+                assert True
+            case _:
+                assert False
+
 
 class TestNew:
     def test_basic(self):


### PR DESCRIPTION
This PR implements Scenic constructs with the requirement-like syntax:

- `require always`
- `require eventually`
- `record`
- `record initial`
- `record final`
- `terminate when`
- `terminate simulation when`

These features need to preserve the syntax of the "body" of the call to be evaluated later, and the corresponding functions in veneer have similar signatures: `(reqId: int, body: () -> bool, lineno: int, name: str | None)`, with optional probability for plain requirements.

This PR adds grammar for the statements listed above to be able to parse them. When compiling these statements, visitors call the `createRequirementLike` helper function. It creates the call to the function while registering the syntax of the value to be evaluated later.