### PR TITLE
[Parser] Pass `test_dynamics.py`

### DIFF
--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -7,7 +7,9 @@ import scenic.syntax.ast as s
 # exposed functions
 
 
-def compileScenicAST(scenicAST: ast.AST) -> Tuple[Union[ast.AST, list[ast.AST]], List[ast.AST]]:
+def compileScenicAST(
+    scenicAST: ast.AST,
+) -> Tuple[Union[ast.AST, list[ast.AST]], List[ast.AST]]:
     """Compiles Scenic AST to Python AST"""
     compiler = ScenicToPythonTransformer()
     tree = compiler.visit(scenicAST)
@@ -460,7 +462,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         return self.makeBehaviorLikeDef(
             baseClassName="Monitor",
             name=node.name,
-            args=noArgs,
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
             docstring=node.docstring,
             header=[],
             body=node.body,

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -677,7 +677,7 @@ def test_interrupt_define_local():
             interrupt when False:
                 pass
             take i
-        ego = Object with behavior Foo
+        ego = new Object with behavior Foo
     """)
     actions = sampleEgoActions(scenario, maxSteps=1)
     assert tuple(actions) == (1,)
@@ -691,7 +691,7 @@ def test_interrupt_define_local_2():
                 i = 1
                 abort
             take i
-        ego = Object with behavior Foo
+        ego = new Object with behavior Foo
     """)
     actions = sampleEgoActions(scenario, maxSteps=1)
     assert tuple(actions) == (1,)


### PR DESCRIPTION
This PR includes two changes that were necessary to pass `test_dynamics.py`. 

## 1: Missing `new` keywords

I rebased `2022-parser` to `main` and that added two tests in the old syntax. This PR adds `new` keywords to those new cases.

## 2: Side effects

My implementation of `monitor` had side effects that would break the compiler. 

https://github.com/BerkeleyLearnVerify/Scenic/blob/8d7e8f56a0e43a42d69b03148994ba8548ef08a4/src/scenic/syntax/compiler.py#L463

When compiling a `monitor`, I used `noArgs` and passed that to `makeBehaviorLikeDef`. 

https://github.com/BerkeleyLearnVerify/Scenic/blob/8d7e8f56a0e43a42d69b03148994ba8548ef08a4/src/scenic/syntax/compiler.py#L463

In `makeBehaviorLikeDef`, this node is visited and assigned to `newArgs`. 

https://github.com/BerkeleyLearnVerify/Scenic/blob/8d7e8f56a0e43a42d69b03148994ba8548ef08a4/src/scenic/syntax/compiler.py#L563

After that, `newArgs` is modified to accept additional arguments for monitors. 

Because `newArgs` has a reference to the shared `noArgs`, this mutates the shared instance and adds arguments to it. I copied the content of `noArgs` to `visit_MonitorDef` so it creates a new instance. 

I could've made `noArgs` to be a function that returns a new instance and replaced all references to `noArgs` with calls to that function, but since most visitors are not mutating, I chose to just write the empty arguments inside `visit_MonitorDef`.