### PR TITLE
[Parser] implement `terminate after` statements

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -349,6 +349,17 @@ class TerminateWhen(AST):
         self._fields = ["cond"]
 
 
+class TerminateAfter(AST):
+    __match_args__ = ("duration",)
+
+    def __init__(
+        self, duration: Union["Seconds", "Steps"], *args: any, **kwargs: any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.duration = duration
+        self._fields = ["duration"]
+
+
 class DoFor(AST):
     __match_args__ = ("elts", "duration")
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -856,15 +856,18 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_TerminateAfter(self, node: s.TerminateAfter):
-        return ast.Expr(
-            ast.Call(
-                func=ast.Name(id="terminate_after", ctx=loadCtx),
-                args=[
-                    self.visit(node.duration.value),
-                    ast.Constant(node.duration.unitStr),
-                ],
-                keywords=[],
-            )
+        return ast.copy_location(
+            ast.Expr(
+                ast.Call(
+                    func=ast.Name(id="terminate_after", ctx=loadCtx),
+                    args=[
+                        self.visit(node.duration.value),
+                        ast.Constant(node.duration.unitStr),
+                    ],
+                    keywords=[],
+                )
+            ),
+            node,
         )
 
     # Instance & Specifier

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -855,6 +855,16 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             )
         )
 
+    def visit_TerminateAfter(self, node: s.TerminateAfter):
+        return ast.Call(
+            func=ast.Name(id="terminate_after", ctx=loadCtx),
+            args=[
+                self.visit(node.duration.value),
+                ast.Constant(node.duration.unitStr),
+            ],
+            keywords=[],
+        )
+
     # Instance & Specifier
 
     def visit_New(self, node: s.New):

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -856,13 +856,15 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         )
 
     def visit_TerminateAfter(self, node: s.TerminateAfter):
-        return ast.Call(
-            func=ast.Name(id="terminate_after", ctx=loadCtx),
-            args=[
-                self.visit(node.duration.value),
-                ast.Constant(node.duration.unitStr),
-            ],
-            keywords=[],
+        return ast.Expr(
+            ast.Call(
+                func=ast.Name(id="terminate_after", ctx=loadCtx),
+                args=[
+                    self.visit(node.duration.value),
+                    ast.Constant(node.duration.unitStr),
+                ],
+                keywords=[],
+            )
         )
 
     # Instance & Specifier

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1786,7 +1786,7 @@ scenic_terminate_simulation_when_stmt: "terminate" "simulation" "when" v=express
 
 scenic_terminate_when_stmt: "terminate" "when" v=expression { s.TerminateWhen(v, LOCATIONS) }
 
-scenic_terminate_after_stmt: "terminate" "after" v=(scenic_dynamic_duration | v=expression { s.Steps(v, LOCATIONS) }) { s.TerminateAfter(v, LOCATIONS) }
+scenic_terminate_after_stmt: "terminate" "after" v=scenic_dynamic_duration { s.TerminateAfter(v, LOCATIONS) }
 
 scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -548,6 +548,7 @@ scenic_stmt:
     | scenic_mutate_stmt
     | scenic_terminate_simulation_when_stmt
     | scenic_terminate_when_stmt
+    | scenic_terminate_after_stmt
     | scenic_take_stmt
     | scenic_wait_stmt
     | scenic_terminate_stmt
@@ -1784,6 +1785,8 @@ scenic_wait_stmt: 'wait' { s.Wait(LOCATIONS) }
 scenic_terminate_simulation_when_stmt: "terminate" "simulation" "when" v=expression { s.TerminateSimulationWhen(v, LOCATIONS) }
 
 scenic_terminate_when_stmt: "terminate" "when" v=expression { s.TerminateWhen(v, LOCATIONS) }
+
+scenic_terminate_after_stmt: "terminate" "after" v=(scenic_dynamic_duration | v=expression { s.Steps(v, LOCATIONS) }) { s.TerminateAfter(v, LOCATIONS) }
 
 scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
 

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1121,7 +1121,7 @@ class TestCompiler:
     def test_terminate_after_seconds(self):
         node, _ = compileScenicAST(TerminateAfter(Seconds(Constant(10))))
         match node:
-            case Call(Name("terminate_after"), [Constant(10), Constant("seconds")], []):
+            case Expr(Call(Name("terminate_after"), [Constant(10), Constant("seconds")], [])):
                 assert True
             case _:
                 assert False
@@ -1129,7 +1129,7 @@ class TestCompiler:
     def test_terminate_after_steps(self):
         node, _ = compileScenicAST(TerminateAfter(Steps(Constant(20))))
         match node:
-            case Call(Name("terminate_after"), [Constant(20), Constant("steps")], []):
+            case Expr(Call(Name("terminate_after"), [Constant(20), Constant("steps")], [])):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1121,7 +1121,9 @@ class TestCompiler:
     def test_terminate_after_seconds(self):
         node, _ = compileScenicAST(TerminateAfter(Seconds(Constant(10))))
         match node:
-            case Expr(Call(Name("terminate_after"), [Constant(10), Constant("seconds")], [])):
+            case Expr(
+                Call(Name("terminate_after"), [Constant(10), Constant("seconds")], [])
+            ):
                 assert True
             case _:
                 assert False
@@ -1129,7 +1131,9 @@ class TestCompiler:
     def test_terminate_after_steps(self):
         node, _ = compileScenicAST(TerminateAfter(Steps(Constant(20))))
         match node:
-            case Expr(Call(Name("terminate_after"), [Constant(20), Constant("steps")], [])):
+            case Expr(
+                Call(Name("terminate_after"), [Constant(20), Constant("steps")], [])
+            ):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1118,6 +1118,22 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_terminate_after_seconds(self):
+        node, _ = compileScenicAST(TerminateAfter(Seconds(Constant(10))))
+        match node:
+            case Call(Name("terminate_after"), [Constant(10), Constant("seconds")], []):
+                assert True
+            case _:
+                assert False
+
+    def test_terminate_after_steps(self):
+        node, _ = compileScenicAST(TerminateAfter(Steps(Constant(20))))
+        match node:
+            case Call(Name("terminate_after"), [Constant(20), Constant("steps")], []):
+                assert True
+            case _:
+                assert False
+
     # Instance & Specifiers
     def test_new_no_specifiers(self):
         node, _ = compileScenicAST(New("Object", []))

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -959,22 +959,9 @@ class TestTerminateAfter:
                 assert False
 
     def test_omit_unit(self):
-        mod = parse_string_helper("terminate after 20")
-        stmt = mod.body[0]
-        match stmt:
-            case TerminateAfter(Steps(Constant(20))):
-                assert True
-            case _:
-                assert False
-
-    def test_expression(self):
-        mod = parse_string_helper("terminate after 3 + 5")
-        stmt = mod.body[0]
-        match stmt:
-            case TerminateAfter(Steps(BinOp(Constant(3), Add(), Constant(5)))):
-                assert True
-            case _:
-                assert False
+        # `seconds` or `steps` is required
+        with pytest.raises(SyntaxError):
+            parse_string_helper("terminate after 20")
 
 
 class TestNew:

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -939,6 +939,44 @@ class TestTerminateWhen:
                 assert False
 
 
+class TestTerminateAfter:
+    def test_steps(self):
+        mod = parse_string_helper("terminate after 3 steps")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateAfter(Steps(Constant(3))):
+                assert True
+            case _:
+                assert False
+
+    def test_seconds(self):
+        mod = parse_string_helper("terminate after 5 seconds")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateAfter(Seconds(Constant(5))):
+                assert True
+            case _:
+                assert False
+
+    def test_omit_unit(self):
+        mod = parse_string_helper("terminate after 20")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateAfter(Steps(Constant(20))):
+                assert True
+            case _:
+                assert False
+
+    def test_expression(self):
+        mod = parse_string_helper("terminate after 3 + 5")
+        stmt = mod.body[0]
+        match stmt:
+            case TerminateAfter(Steps(BinOp(Constant(3), Add(), Constant(5)))):
+                assert True
+            case _:
+                assert False
+
+
 class TestNew:
     def test_basic(self):
         mod = parse_string_helper("new Object")


### PR DESCRIPTION
This PR implements `terminate after` statements.

In this implementation, the unit (`seconds` or `steps`) is required. This is consistent with the paper and the documentation, while in the current implementation, omitting the unit was allowed and `seconds` was used implicitly.