### PR TITLE
[Parser] implement `do choose` and `do shuffle`

### DIFF
--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -397,6 +397,24 @@ class DoUntil(AST):
         self._fields = ["value", "cond"]
 
 
+class DoChoose(AST):
+    __match_args__ = ("elts",)
+
+    def __init__(self, elts: list[ast.AST], *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.elts = elts
+        self._fields = ["elts"]
+
+
+class DoShuffle(AST):
+    __match_args__ = ("elts",)
+
+    def __init__(self, elts: list[ast.AST], *args: any, **kwargs: any) -> None:
+        super().__init__(*args, **kwargs)
+        self.elts = elts
+        self._fields = ["elts"]
+
+
 class Do(AST):
     __match_args__ = ("elts",)
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -551,6 +551,8 @@ scenic_stmt:
     | scenic_take_stmt
     | scenic_wait_stmt
     | scenic_terminate_stmt
+    | scenic_do_choose_stmt
+    | scenic_do_shuffle_stmt
     | scenic_do_for_stmt
     | scenic_do_until_stmt
     | scenic_do_stmt
@@ -1786,6 +1788,10 @@ scenic_terminate_simulation_when_stmt: "terminate" "simulation" "when" v=express
 scenic_terminate_when_stmt: "terminate" "when" v=expression { s.TerminateWhen(v, LOCATIONS) }
 
 scenic_terminate_stmt: "terminate" { s.Terminate(LOCATIONS) }
+
+scenic_do_choose_stmt: 'do' "choose" e=(','.expression+) { s.DoChoose(e, LOCATIONS) }
+
+scenic_do_shuffle_stmt: 'do' "shuffle" e=(','.expression+) { s.DoShuffle(e, LOCATIONS) }
 
 scenic_do_for_stmt: 'do' e=(','.expression+) 'for' u=scenic_dynamic_duration { s.DoFor(elts=e, duration=u, LOCATIONS) }
 scenic_dynamic_duration:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -907,6 +907,64 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_do_choose(self):
+        node, _ = compileScenicAST(DoChoose([Constant("foo"), Constant("bar")]))
+        match node:
+            case [
+                Expr(
+                    value=YieldFrom(
+                        value=Call(
+                            func=Attribute(
+                                value=Name(id="_Scenic_current_behavior", ctx=Load()),
+                                attr="_invokeSubBehavior",
+                                ctx=Load(),
+                            ),
+                            args=[
+                                Name(id="self", ctx=Load()),
+                                Tuple(
+                                    elts=[Constant("foo"), Constant("bar")],
+                                    ctx=Load(),
+                                ),
+                            ],
+                            keywords=[keyword("schedule", Constant("choose"))],
+                        )
+                    )
+                ),
+                checkInvariants,
+            ]:
+                self.assert_invocation_check_invariants(checkInvariants)
+            case _:
+                assert False
+
+    def test_do_choose(self):
+        node, _ = compileScenicAST(DoShuffle([Constant("foo"), Constant("bar")]))
+        match node:
+            case [
+                Expr(
+                    value=YieldFrom(
+                        value=Call(
+                            func=Attribute(
+                                value=Name(id="_Scenic_current_behavior", ctx=Load()),
+                                attr="_invokeSubBehavior",
+                                ctx=Load(),
+                            ),
+                            args=[
+                                Name(id="self", ctx=Load()),
+                                Tuple(
+                                    elts=[Constant("foo"), Constant("bar")],
+                                    ctx=Load(),
+                                ),
+                            ],
+                            keywords=[keyword("schedule", Constant("shuffle"))],
+                        )
+                    )
+                ),
+                checkInvariants,
+            ]:
+                self.assert_invocation_check_invariants(checkInvariants)
+            case _:
+                assert False
+
     def assert_invocation_check_invariants(self, node):
         match node:
             case Expr(

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -731,6 +731,24 @@ class TestDo:
             case _:
                 assert False
 
+    def test_do_choose(self):
+        mod = parse_string_helper("do choose foo, bar")
+        stmt = mod.body[0]
+        match stmt:
+            case DoChoose([Name("foo"), Name("bar")]):
+                assert True
+            case _:
+                assert False
+
+    def test_do_shuffle(self):
+        mod = parse_string_helper("do shuffle foo, bar")
+        stmt = mod.body[0]
+        match stmt:
+            case DoShuffle([Name("foo"), Name("bar")]):
+                assert True
+            case _:
+                assert False
+
 
 class TestParam:
     def test_basic(self):


### PR DESCRIPTION
This PR implements `do choose` and `do shuffle` statements.

- [As I previously mentioned](https://github.com/BerkeleyLearnVerify/Scenic/pull/78#discussion_r954438424), I refactored the duplicated code into the `makeDoLike` helper function.
  - We can probably improve the uses of the `Modifier`class, but we are holding that off for now

