### PR TITLE
[Parser] generate parser before running tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
 test = [	# minimum dependencies for running tests (used for tox virtualenvs)
 	"pytest-randomly",
 	"pytest",
+	"pegen",
 ]
 
 [tool.poetry.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,8 +50,6 @@ def pytest_configure(config):
         parser = syntaxDir / "parser.py"
         result = subprocess.run(
             [
-                "poetry",
-                "run",
                 "python",
                 "-m",
                 "pegen",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def pytest_addoption(parser):
     # option to skip very slow tests
     parser.addoption('--fast', action='store_true', help='skip very slow tests')
     # option to skip parser generation
-    parser.addoption('--skip-pegen', action='store_true', help='generate the parser before running tests')
+    parser.addoption('--skip-pegen', action='store_true', help='skip generating the parser before running tests')
 
 class ParserGenerationException(BaseException):
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,12 +44,22 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'slow: mark test as very slow')
 
     if not config.getoption("skip_pegen"):
+        projectRootDir = Path(__file__).parent.parent
+        syntaxDir = projectRootDir / "src" / "scenic" / "syntax"
+        grammar = syntaxDir / "scenic.gram"
+        parser = syntaxDir / "parser.py"
         result = subprocess.run(
             [
-                "make",
-                "--always-make",
+                "poetry",
+                "run",
+                "python",
+                "-m",
+                "pegen",
+                grammar,
+                "-o",
+                parser,
             ],
-            cwd=Path(__file__).parent.parent,
+            cwd=projectRootDir,
             capture_output=True,
             text=True,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,9 +37,6 @@ def pytest_addoption(parser):
     # option to skip parser generation
     parser.addoption('--skip-pegen', action='store_true', help='skip generating the parser before running tests')
 
-class ParserGenerationException(BaseException):
-    pass
-
 def pytest_configure(config):
     config.addinivalue_line('markers', 'slow: mark test as very slow')
 
@@ -62,7 +59,7 @@ def pytest_configure(config):
             text=True,
         )
         if result.returncode != 0:
-            raise ParserGenerationException(f"Failed to generate the parser: {result.stderr}")
+            pytest.exit(f"Failed to generate the parser: {result.stderr}")
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption('--fast'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def pytest_configure(config):
             text=True,
         )
         if result.returncode != 0:
-            pytest.exit(f"Failed to generate the parser: {result.stderr}")
+            pytest.exit(f"Failed to generate the parser: {result.stderr}", result.returncode)
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption('--fast'):


### PR DESCRIPTION
## Overview

This PR hooks `pytest_configure` to generate the parser before running tests. This ensures that the grammar is valid when running the test suite and test cases are executed with the updated parser.

The parser will be generated by default. Use the newly added option `--skip-pegen` to skip the process.

## Discussion Points

### Default behavior

In this PR, pytest generates the parser by default and we provide an option to skip it. We can choose to not generate the parser by default and add an option to turn it on.

Since the parser generation is pretty fast (around 500ms on my computer), I believe we can leave this on by default, but one might argue that the default should be off as the grammar might not change so often.

### What to execute

~Since Pegen does not expose APIs, we must use its CLI interface. We can directly call `pegen` (`python -m pegen`) or use `Makefile` in the project root.~

~In this PR, I chose to call `make` so I don't have to copy arguments to `conftest.py`. However, this requires `make` to run the test suite, which might not be available in some environments (especially on Windows).~

~Possible alternatives includes:~

- ~write the same command in both `Makefile` and `conftest.py`~
- ~create a separate Python script for generating the parser (by calling pegen internally) and use that from `conftest.py` (call the exposed function) and `Makefile` (call the script).~

### Update (9/9)

I tried to place a Python script that calls `pegen` in `src/scenic/syntax` but I realized that this approach doesn't work because `scenic.syntax` is invalid without the parser file and importing the build script raises an error.

I also realized that the options are not that long, so I decided to just write the build script one more time in `conftest.py`.