### PR TITLE
[Parser] perform in-behavior check when compiling starred values

### DIFF
--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -619,7 +619,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         newArgs = []
         wrappedStar = False
         for arg in node.args:
-            if isinstance(arg, ast.Starred):  # TODO(shun): check not in behavior?
+            if isinstance(arg, ast.Starred) and not self.inBehavior:
                 wrappedStar = True
                 checkedVal = ast.Call(
                     ast.Name("wrapStarredValue", ast.Load()),


### PR DESCRIPTION
https://github.com/BerkeleyLearnVerify/Scenic/pull/69#pullrequestreview-1057886082

As suggested above, changed `visit_Call` not to transform starred values inside behaviors.