### PR TITLE
[Parser] pass `test_distributions.py`

### DIFF
--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1799,8 +1799,8 @@ scenic_do_shuffle_stmt: 'do' "shuffle" e=(','.expression+) { s.DoShuffle(e, LOCA
 
 scenic_do_for_stmt: 'do' e=(','.expression+) 'for' u=scenic_dynamic_duration { s.DoFor(elts=e, duration=u, LOCATIONS) }
 scenic_dynamic_duration:
-    | v=expression 'seconds' { s.Seconds(v, LOCATIONS) }
-    | v=expression 'steps' { s.Steps(v, LOCATIONS) }
+    | v=expression "seconds" { s.Seconds(v, LOCATIONS) }
+    | v=expression "steps" { s.Steps(v, LOCATIONS) }
 
 scenic_do_until_stmt: 'do' e=(','.expression+) 'until' cond=expression { s.DoUntil(elts=e, cond=cond, LOCATIONS) }
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -2084,7 +2084,7 @@ invalid_legacy_expression:
 invalid_expression[NoReturn]:
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
-    | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
+    | !(NAME STRING | SOFT_KEYWORD) a=disjunction !SOFT_KEYWORD b=expression_without_invalid {
         (
             self.raise_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)
             if not isinstance(a, ast.Name) or a.id not in ("print", "exec")

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -2084,6 +2084,7 @@ invalid_legacy_expression:
 invalid_expression[NoReturn]:
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
+    # Soft keywords can follow a disjunction to support expressions like `3 steps`
     | !(NAME STRING | SOFT_KEYWORD) a=disjunction !SOFT_KEYWORD b=expression_without_invalid {
         (
             self.raise_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)

--- a/tests/syntax/test_distributions.py
+++ b/tests/syntax/test_distributions.py
@@ -174,7 +174,7 @@ def test_operator_lazy():
     assert any(h == pytest.approx(1) for h in hs)
 
 def test_callable():
-    scenario = compileScenic('ego = Object at 0 @ Uniform(sin, cos)(0)')
+    scenario = compileScenic('ego = new Object at 0 @ Uniform(sin, cos)(0)')
     ys = [sampleEgo(scenario).position.y for i in range(60)]
     assert all(y == 0 or y == 1 for y in ys)
     assert any(y == 0 for y in ys)
@@ -274,11 +274,11 @@ def test_tuple():
 
 def test_tuple_iteration():
     ego = sampleEgoFrom("""
-        other = Object with foo (1, Uniform(2, 3))
+        other = new Object with foo (1, Uniform(2, 3))
         data = [len(other.foo), other.foo[1], other.foo[0]]
         for item in other.foo:
             data.append(item)
-        ego = Object at 2@2, with foo data
+        ego = new Object at 2@2, with foo data
         require other.foo[1] == 3
     """, maxIterations=60)
     assert type(ego.foo) is list
@@ -309,11 +309,11 @@ def test_namedtuple():
 
 def test_comparison():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object with foo (Range(0, 1) > 0.5)')
+        compileScenic('ego = new Object with foo (Range(0, 1) > 0.5)')
 
 def test_len():
     with pytest.raises(RuntimeParseError):
-        compileScenic('ego = Object with foo len(Uniform([0], [1, 2]))')
+        compileScenic('ego = new Object with foo len(Uniform([0], [1, 2]))')
 
 def test_iter():
     with pytest.raises(RuntimeParseError):


### PR DESCRIPTION
This PR implements changes needed to pass test cases in `test_distributions.py`.

First, I added `new` keywords to some of the test cases that were using the old syntax.

`test_vector_method_lazy` uses `steps` as a keyword argument, and since I initially implemented `steps` and `seconds` as hard keywords, these cases were failing.

I changed `steps` and `seconds` to soft keywords, but then it introduced another problem. There is a rule `invalid_expression` for catching malformed expressions for better error reporting, and one of the forms is `<disjunction> <expression>`. Because `steps` and `seconds` can be an expression, valid expressions like `3 steps` are caught as invalid.

I modified the `invalid_expression` rule to ignore `disjunction followed by soft keyword` case. At this moment, it is sufficient to ignore `seconds` and `steps`, but I believe we can just ignore soft keywords.