### PR TITLE
[Parser] fix typo in `test_basic.py`

### DIFF
--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -82,7 +82,7 @@ def test_mutate():
 
 def test_mutate_object():
     scenario = compileScenic("""
-        ego = new Object at 3@1, facing 0
+        ego = new Object at 30@1, facing 0
         other = new Object
         mutate other
     """)


### PR DESCRIPTION
1cde868fbbbf8f97e92ac655f7eef9b886cb3fca

I made a typo in the commit above that broke `test_basic.py`. This PR fixes the typo and the new parser can pass all cases in the file.