### PR TITLE
[Parser] Fix builtin names compilation

### DIFF
--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -227,6 +227,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         if node.id in builtinNames:
             if not isinstance(node.ctx, ast.Load):
                 raise SyntaxError(f'unexpected keyword "f{node.id}"')
+            node = ast.copy_location(ast.Call(ast.Name(node.id, loadCtx), [], []), node)
         elif node.id in trackedNames:
             if not isinstance(node.ctx, ast.Load):
                 raise SyntaxError(f'only simple assignments to "{node.id}" are allowed')

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -159,9 +159,17 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_builtin_name(self):
+    def test_builtin_name_assign(self):
         with pytest.raises(SyntaxError):
             compileScenicAST(Assign([Name("globalParameters", Store())], Constant(1)))
+
+    def test_builtin_name_reference(self):
+        node, _ = compileScenicAST(Name("globalParameters", Load()))
+        match node:
+            case Call(Name("globalParameters")):
+                assert True
+            case _:
+                assert False
 
     def test_tracked_name_assign(self):
         # simple assign will be converted to `TrackedAssign` by the parser,


### PR DESCRIPTION
There was a bug in `visit_Name` and `globalParameters` was not turned into a function call. This PR fixes the bug and compiles `globalParameters` into `globalParameters()`.