### PR TITLE
[Parser] Fix `test_errors.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tox = {version = "^3.14.0", optional = true}
 sphinx_rtd_theme = {version = "^0.5.2", optional = true}
 astor = {version = "^0.8.1", optional = true}
 inflect = {version = "^5.5.2", optional = true}
-pegen = {version = "^0.1.0", optional = true}
+pegen = {git = "git@github.com:we-like-parsers/pegen.git", rev = "db7552d", optional = true}
 
 [tool.poetry.extras]
 guideways = ["pyproj"]

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -5,6 +5,8 @@ from typing import Optional, Union
 class AST(ast.AST):
     "Scenic AST base class"
 
+    _attributes = ("lineno", "col_offset", "end_lineno", "end_col_offset")
+
     def __init__(self, *args: any, **kwargs: any) -> None:
         super().__init__(*args, **kwargs)
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1,8 +1,6 @@
 import ast
 from enum import IntFlag, auto
-from functools import reduce
 import itertools
-import operator
 from typing import Callable, Literal, Optional, Tuple, List, Union
 
 import scenic.syntax.ast as s

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -879,12 +879,18 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     @context(Context.DYNAMIC)
     def visit_Do(self, node: s.Do):
-        # TODO(shun): Check node has no more than one element inside behavior/monitors
+        if (self.inBehavior or self.inMonitor) and len(node.elts) > 1:
+            raise SyntaxError(
+                f"`do` can only take one action inside a {'behavior' if self.inBehavior else 'monitor'}"
+            )
         return self.makeDoLike(node, node.elts)
 
     @context(Context.DYNAMIC)
     def visit_DoFor(self, node: s.DoFor):
-        # TODO(shun): Check node has no more than one element inside behavior/monitors
+        if (self.inBehavior or self.inMonitor) and len(node.elts) > 1:
+            raise SyntaxError(
+                f"`do` can only take one action inside a {'behavior' if self.inBehavior else 'monitor'}"
+            )
         return self.makeDoLike(
             node,
             node.elts,
@@ -901,7 +907,10 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     @context(Context.DYNAMIC)
     def visit_DoUntil(self, node: s.DoUntil):
-        # TODO(shun): Check node has no more than one element inside behavior/monitors
+        if (self.inBehavior or self.inMonitor) and len(node.elts) > 1:
+            raise SyntaxError(
+                f"`do` can only take one action inside a {'behavior' if self.inBehavior else 'monitor'}"
+            )
         return self.makeDoLike(
             node,
             node.elts,

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -354,7 +354,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     # Special Case
 
-    @context(Context.BEHAVIOR | Context.MONITOR | Context.COMPOSE)
+    @context(Context.DYNAMIC)
     def visit_TryInterrupt(self, node: s.TryInterrupt):
         statements = []
         oldInTryInterrupt = self.inTryInterrupt

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -519,7 +519,7 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         for propertyDef in propertyDefs:
             if propertyDef.property in propertyDict:
                 raise self.makeSyntaxError(
-                    f'duplicated property "{propertyDef.property}"', node
+                    f'duplicated property "{propertyDef.property}"', propertyDef
                 )
             propertyDict[propertyDef.property] = propertyDef
 

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -795,7 +795,6 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
 
     @context(Context.TOP_LEVEL)
     def visit_Model(self, node: s.Model):
-        # TODO(shun): Assert not in setup
         return ast.Expr(
             value=ast.Call(
                 func=ast.Name(id="model", ctx=loadCtx),

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -87,7 +87,8 @@ def parse_string(
     token_stream_factory: Optional[
         Callable[[Callable[[], str]], Iterator[tokenize.TokenInfo]]
     ] = None,
-    verbose:bool = False,
+    verbose: bool = False,
+    filename: str = "<unknown>",
 ) -> Any:
     """Parse a string."""
     tok_stream = (
@@ -96,7 +97,7 @@ def parse_string(
         tokenize.generate_tokens(io.StringIO(source).readline)
     )
     tokenizer = Tokenizer(tok_stream, verbose=verbose)
-    parser = ScenicParser(tokenizer, verbose=verbose, py_version=py_version)
+    parser = ScenicParser(tokenizer, verbose=verbose, py_version=py_version, filename=filename)
     return parser.parse(mode if mode == "eval" else "file")
 
 

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -91,6 +91,8 @@ def parse_string(
     filename: str = "<unknown>",
 ) -> Any:
     """Parse a string."""
+    # adding a newline at the end to properly handle errors on the last line
+    # TODO(shun): Find a better way to fix this
     tok_stream = (
         token_stream_factory(io.StringIO(source + "\\n").readline)
         if token_stream_factory else

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -92,9 +92,9 @@ def parse_string(
 ) -> Any:
     """Parse a string."""
     tok_stream = (
-        token_stream_factory(io.StringIO(source).readline)
+        token_stream_factory(io.StringIO(source + "\\n").readline)
         if token_stream_factory else
-        tokenize.generate_tokens(io.StringIO(source).readline)
+        tokenize.generate_tokens(io.StringIO(source + "\\n").readline)
     )
     tokenizer = Tokenizer(tok_stream, verbose=verbose)
     parser = ScenicParser(tokenizer, verbose=verbose, py_version=py_version, filename=filename)

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -91,12 +91,10 @@ def parse_string(
     filename: str = "<unknown>",
 ) -> Any:
     """Parse a string."""
-    # adding a newline at the end to properly handle errors on the last line
-    # TODO(shun): Find a better way to fix this
     tok_stream = (
-        token_stream_factory(io.StringIO(source + "\\n").readline)
+        token_stream_factory(io.StringIO(source).readline)
         if token_stream_factory else
-        tokenize.generate_tokens(io.StringIO(source + "\\n").readline)
+        tokenize.generate_tokens(io.StringIO(source).readline)
     )
     tokenizer = Tokenizer(tok_stream, verbose=verbose)
     parser = ScenicParser(tokenizer, verbose=verbose, py_version=py_version, filename=filename)

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -253,7 +253,7 @@ def compileStream(stream, namespace, params={}, model=None, filename='<stream>')
 			print(ast.dump(scenic_tree, include_attributes=False, indent=4))
 			print('### End Scenic AST')
 
-		tree, requirements = compileScenicAST(scenic_tree)
+		tree, requirements = compileScenicAST(scenic_tree, filename=filename)
 
 		if dumpFinalAST:
 			print(f'### Begin final AST of {filename}')

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -246,7 +246,7 @@ def compileStream(stream, namespace, params={}, model=None, filename='<stream>')
 
 		# Parse the translated source
 		source = stream.read().decode('utf-8')
-		scenic_tree = parse_string(source, "exec", None)
+		scenic_tree = parse_string(source, "exec", filename=filename)
 
 		if dumpScenicAST:
 			print(f'### Begin Scenic AST of {filename}')

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -380,6 +380,10 @@ class TestCompiler:
             case _:
                 assert False
 
+    def test_model_in_setup(self):
+        with pytest.raises(SyntaxError):
+            compileScenicAST(Model("model"), inSetup=True)
+
     def test_mutate_basic(self):
         node, _ = compileScenicAST(Mutate([Name("x", Load())]))
         match node:

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -756,12 +756,16 @@ class TestCompiler:
                 assert False
 
     def test_abort(self):
-        node, _ = compileScenicAST(Abort(), inTryInterrupt=True)
+        node, _ = compileScenicAST(Abort(), inInterruptBlock=True)
         match node:
             case Return(Attribute(Name("BlockConclusion"), "ABORT")):
                 assert True
             case _:
                 assert False
+
+    def test_abort_outside_interrupt(self):
+        with pytest.raises(SyntaxError):
+            compileScenicAST(Abort(), inInterruptBlock=False)
 
     def test_take(self):
         node, _ = compileScenicAST(

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -32,7 +32,8 @@ class TestCompiler:
                 ],
                 orelse=[],
                 finalbody=[],
-            )
+            ),
+            inBehavior=True,
         )
         match node:
             case Try(
@@ -755,7 +756,7 @@ class TestCompiler:
                 assert False
 
     def test_abort(self):
-        node, _ = compileScenicAST(Abort())
+        node, _ = compileScenicAST(Abort(), inTryInterrupt=True)
         match node:
             case Return(Attribute(Name("BlockConclusion"), "ABORT")):
                 assert True
@@ -763,7 +764,9 @@ class TestCompiler:
                 assert False
 
     def test_take(self):
-        node, _ = compileScenicAST(Take([Constant(1), Constant(2), Constant(3)]))
+        node, _ = compileScenicAST(
+            Take([Constant(1), Constant(2), Constant(3)]), inBehavior=True
+        )
         match node:
             case [
                 Expr(value=Yield(value=Tuple([Constant(1), Constant(2), Constant(3)]))),
@@ -774,7 +777,7 @@ class TestCompiler:
                 assert False
 
     def test_wait(self):
-        node, _ = compileScenicAST(Wait())
+        node, _ = compileScenicAST(Wait(), inMonitor=True)
         match node:
             case [
                 Expr(value=Yield(value=Constant(value=()))),
@@ -785,7 +788,7 @@ class TestCompiler:
                 assert False
 
     def test_terminate(self):
-        node, _ = compileScenicAST(Terminate(lineno=1))
+        node, _ = compileScenicAST(Terminate(lineno=1), inBehavior=True)
         match node:
             case [
                 Expr(
@@ -804,7 +807,7 @@ class TestCompiler:
                 assert False
 
     def test_do(self):
-        node, _ = compileScenicAST(Do([Constant(1)]))
+        node, _ = compileScenicAST(Do([Constant(1)]), inBehavior=True)
         match node:
             case [
                 Expr(
@@ -833,7 +836,9 @@ class TestCompiler:
                 assert False
 
     def test_do_for_seconds(self):
-        node, _ = compileScenicAST(DoFor([Constant("foo")], Seconds(Constant(1))))
+        node, _ = compileScenicAST(
+            DoFor([Constant("foo")], Seconds(Constant(1))), inBehavior=True
+        )
         match node:
             case [
                 Expr(
@@ -871,7 +876,9 @@ class TestCompiler:
                 assert False
 
     def test_do_for_steps(self):
-        node, _ = compileScenicAST(DoFor([Constant("foo")], Steps(Constant(3))))
+        node, _ = compileScenicAST(
+            DoFor([Constant("foo")], Steps(Constant(3))), inBehavior=True
+        )
         match node:
             case [
                 Expr(
@@ -909,7 +916,9 @@ class TestCompiler:
                 assert False
 
     def test_do_until(self):
-        node, _ = compileScenicAST(DoUntil([Constant("foo")], Name("condition")))
+        node, _ = compileScenicAST(
+            DoUntil([Constant("foo")], Name("condition")), inBehavior=True
+        )
         match node:
             case [
                 Expr(

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -67,9 +67,9 @@ def test_malformed_soft_requirement():
 
 def test_undefined_specifier():
     with pytest.raises(SyntaxError):
-        compileScenic('Object cattywampus')
+        compileScenic('new Object cattywampus')
     with pytest.raises(SyntaxError):
-        compileScenic('Object athwart 3')
+        compileScenic('new Object athwart 3')
 
 ## Illegal usages of keywords
 
@@ -141,20 +141,20 @@ def test_multiple_requirements():
 templates = [
 (1,     # on first line
 '''{bug}
-ego = Object'''
+ego = new Object'''
 ),
 (2,     # after ordinary statement
-'''ego = Object
+'''ego = new Object
 {bug}'''
 ),
 (3,     # after import
-'''ego = Object
+'''ego = new Object
 import time
 {bug}'''
 ),
 (8,     # after explicit line continuation (and in a function)
 '''from time import time
-ego = Object
+ego = new Object
 
 def qux(foo=None,
         bar=3):
@@ -166,7 +166,7 @@ qux()
 '''
 ),
 (4,     # after automatic line continuation by parentheses
-'''ego = Object
+'''ego = new Object
 x = (1 + 2
      + 3)
 {bug}
@@ -175,7 +175,7 @@ x = (1 + 2
 ]
 
 indentedSpecTemplate = '''\
-ego = Object facing 1, {continuation}
+ego = new Object facing 1, {continuation}
              at 10@10
 {{bug}}
 '''
@@ -190,7 +190,7 @@ dynamicTemplates = [
         take 5
     interrupt when ego.position.x > 4:
         take 10
-ego = Object with behavior foo
+ego = new Object with behavior foo
 '''
 ),
 (5,
@@ -200,7 +200,7 @@ ego = Object with behavior foo
     interrupt when simulation().currentTime > 0:
         {bug}
         take 10
-ego = Object with behavior foo
+ego = new Object with behavior foo
 '''
 ),
 ]
@@ -310,14 +310,14 @@ def runFile(path):
     'x = 3 << 2',                   # token translation
     '4 = 2',                        # Python parsing
     '3 relative to',                # Python parsing
-    'Point at x y',                 # Python parsing (with offset past end of original line)
+    'new Point at x y',                 # Python parsing (with offset past end of original line)
     'require',                      # AST surgery
     'terminate 4',                  # AST surgery (handled differently inside behaviors)
     'break',                        # Python compilation
     '4 at 0',                       # Python execution (Scenic parse error)
     'x = _flub__',                  # Python execution (Python runtime error)
     'raise Exception',              # Python execution (program exception)
-    'Object at Uniform(0@0, 4)'     # sampling
+    'new Object at Uniform(0@0, 4)'     # sampling
     'require 4 at 0',               # requirement evaluation (Scenic parse error)
     'require _flub__',              # requirement evaluation (Python runtime error)
 ))
@@ -345,7 +345,7 @@ def test_line_numbering_double(bug, template, tmpdir, pytestconfig):
 
 chainedTemplates = [
 ((5, 3),
-'''ego = Object
+'''ego = new Object
 try:
     raise TypeError
 except Exception as e:
@@ -353,7 +353,7 @@ except Exception as e:
 '''
 ),
 ((8, 6, 3),
-'''ego = Object
+'''ego = new Object
 try:
     raise TypeError
 except Exception as e:

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -263,7 +263,8 @@ def checkException(e, lines, program, bug, path, output, topLevel=True):
     if syntaxErrorLike:
         assert e.lineno == eLine, program
         assert e.text.strip() == bug
-        assert e.offset <= len(e.text)
+        # if text does not end with NEWLINE, it is okay to point to the next character after the last
+        assert e.offset <= len(e.text) if e.text[-1] == "\n" else len(e.text) + 1
 
     # If we skipped generating a textual backtrace in a subprocess, stop here.
     if output is None:

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -307,7 +307,6 @@ def runFile(path):
 
 @pytest.mark.parametrize('bug', (
     # BUGGY CODE                    ERROR CAUGHT DURING:
-    'x = 3 << 2',                   # token translation
     '4 = 2',                        # Python parsing
     '3 relative to',                # Python parsing
     'new Point at x y',                 # Python parsing (with offset past end of original line)

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -308,16 +308,16 @@ def runFile(path):
 
 @pytest.mark.parametrize('bug', (
     # BUGGY CODE                    ERROR CAUGHT DURING:
-    '4 = 2',                        # Python parsing
-    '3 relative to',                # Python parsing
-    'new Point at x y',                 # Python parsing (with offset past end of original line)
-    'require',                      # AST surgery
-    'terminate 4',                  # AST surgery (handled differently inside behaviors)
+    '4 = 2',                        # Scenic parsing
+    '3 relative to',                # Scenic parsing
+    'new Point at x y',             # Scenic parsing
+    'require',                      # Scenic parsing
+    'terminate 4',                  # Scenic compilation (handled differently inside behaviors)
     'break',                        # Python compilation
     '4 at 0',                       # Python execution (Scenic parse error)
     'x = _flub__',                  # Python execution (Python runtime error)
     'raise Exception',              # Python execution (program exception)
-    'new Object at Uniform(0@0, 4)'     # sampling
+    'new Object at Uniform(0@0, 4)' # sampling
     'require 4 at 0',               # requirement evaluation (Scenic parse error)
     'require _flub__',              # requirement evaluation (Python runtime error)
 ))


### PR DESCRIPTION
This PR includes a couple of changes to pass `test_errors.py`.

## `context` decorator

One of the things that are tested in `test_errors.py` is whether statements are allowed in the context.

[Full list of statements with restrictions](https://shun-notes.notion.site/Scenic-statements-with-context-restriction-15db4bd4ed754e58b6e29bfdcf2bcc82)

These are hard to catch in grammar as there's only one `statement` rule that's used across different blocks. 

I propose the `context` decorator to catch those errors at the compiler level. The decorator takes an enum flag `Context` and the decorated visitor raises a syntax error if it is called on an illegal context.

