### PR TITLE
[Parser] migrate `core` tests to new syntax

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -232,7 +232,7 @@ class Constructible(Samplable):
 		return self._withProperties(props, constProps=constProps)
 
 	def dumpAsScenicCode(self, stream, skipConstProperties=True):
-		stream.write(self.__class__.__name__)
+		stream.write(f"new {self.__class__.__name__}")
 		first = True
 		for prop in sorted(self.properties):
 			if skipConstProperties and prop in self._constProps:

--- a/tests/core/test_pickle.py
+++ b/tests/core/test_pickle.py
@@ -51,7 +51,7 @@ def test_pickle_object():
     tryPickling(obj)
 
 def test_pickle_scenario():
-    scenario = compileScenic('ego = Object at Range(1, 2) @ 0')
+    scenario = compileScenic('ego = new Object at Range(1, 2) @ 0')
     sc1 = tryPickling(scenario)
     sc2 = tryPickling(scenario)
     e1, e2 = sampleEgo(sc1), sampleEgo(sc2)
@@ -60,7 +60,7 @@ def test_pickle_scenario():
     assert e1.position.x != e2.position.x
 
 def test_pickle_scene():
-    scene = sampleSceneFrom('ego = Object at Range(1, 2) @ 3')
+    scene = sampleSceneFrom('ego = new Object at Range(1, 2) @ 3')
     tryPickling(scene)
 
 def test_pickle_scenario_dynamic():
@@ -71,8 +71,8 @@ def test_pickle_scenario_dynamic():
                 wait
         behavior Bar(t):
             do Foo(Range(0, 1)) for t seconds
-        ego = Object with behavior Bar(Range(5, 10))
-        other = Object at 10 @ Range(20, 30)
+        ego = new Object with behavior Bar(Range(5, 10))
+        other = new Object at 10 @ Range(20, 30)
         require always other.position.x >= 0
         terminate when ego.position.x > 10
         record ego.position as egoPos

--- a/tests/core/test_scenarios.py
+++ b/tests/core/test_scenarios.py
@@ -6,22 +6,22 @@ from scenic.core.distributions import Range
 from tests.utils import compileScenic
 
 def test_nonexistent_scenario_local_1():
-    scenario = compileScenic('ego = Object')
+    scenario = compileScenic('ego = new Object')
     with pytest.raises(AttributeError):
         scenario.dynamicScenario.blah
 
 def test_nonexistent_scenario_local_2():
     scenario = compileScenic("""
         scenario Main():
-            ego = Object
+            ego = new Object
     """)
     with pytest.raises(AttributeError):
         scenario.dynamicScenario.blah
 
 def test_condition_scenario_objects():
     scenario = compileScenic("""
-        Object facing Range(0, 1)
-        ego = Object at 10@10, facing Range(0, 1)
+        new Object facing Range(0, 1)
+        ego = new Object at 10@10, facing Range(0, 1)
     """)
     sceneA, _ = scenario.generate(maxIterations=1)
     scenario.conditionOn(scene=sceneA, objects=(1,))
@@ -31,7 +31,7 @@ def test_condition_scenario_objects():
 
 def test_condition_scenario_params_1():
     scenario = compileScenic("""
-        ego = Object
+        ego = new Object
         param x = Range(0, 1)
     """)
     scenario.conditionOn(params={'x': 0.6})
@@ -40,7 +40,7 @@ def test_condition_scenario_params_1():
 
 def test_condition_scenario_params_2():
     scenario = compileScenic("""
-        ego = Object
+        ego = new Object
         param x = Range(0, 1)
     """)
     scenario.conditionOn(params={'x': Range(0.5, 0.51)})

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -13,8 +13,8 @@ from tests.utils import sampleSceneFrom
 class TestExportToScenicCode:
     def test_simple(self):
         scene1 = sampleSceneFrom("""
-            ego = Object at Range(3, 5) @ 2, with foo 42
-            Object at 10@10, facing toward ego, with foo 'zoggle'
+            ego = new Object at Range(3, 5) @ 2, with foo 42
+            new Object at 10@10, facing toward ego, with foo 'zoggle'
             param qux = ego.position
         """)
         stream = io.StringIO()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ paramPattern = re.compile(r'\s*Parameter "p": (.*)$')
 def runAndGetP(tmpdir, program, options=[], addEgo=True):
     program = inspect.cleandoc(program)
     if addEgo:
-        program += '\nego = Object'
+        program += '\nego = new Object'
     path = os.path.join(tmpdir, 'test.sc')
     with open(path, 'w') as f:
         f.write(program)


### PR DESCRIPTION
This PR migrates tests under `tests/core` and fixes the issue found through the migration.