### PR TITLE
Fix various Windows issues; add Windows to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,13 +8,12 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/src/scenic/core/errors.py
+++ b/src/scenic/core/errors.py
@@ -290,6 +290,6 @@ def getText(filename, lineno, line='', offset=0, end_offset=None):
             end_offset = adj_end_offset
         else:
             offset = min(offset, len(line))
-    except FileNotFoundError:
+    except OSError:
         pass
     return line, offset, end_offset

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -41,19 +41,16 @@ def argsToString(args, kwargs={}):
 
 @contextmanager
 def alarm(seconds, handler=None, noNesting=False):
-    if seconds <= 0:
+    if seconds <= 0 or not hasattr(signal, 'SIGALRM'):  # SIGALRM not supported on Windows
         yield
         return
     if handler is None:
         handler = signal.SIG_IGN
-    try:
-        signal.signal(signal.SIGALRM, handler)
-        if noNesting:
-            assert oldHandler is signal.SIG_DFL, 'SIGALRM handler already installed'
-    except ValueError:
-        yield      # SIGALRM not supported on Windows
-        return
-    previous = signal.alarm(seconds)
+    signal.signal(signal.SIGALRM, handler)
+    if noNesting:
+        assert oldHandler is signal.SIG_DFL, 'SIGALRM handler already installed'
+    length = int(math.ceil(seconds))
+    previous = signal.alarm(length)
     if noNesting:
         assert previous == 0, 'nested call to "alarm"'
     try:

--- a/tests/domains/driving/conftest.py
+++ b/tests/domains/driving/conftest.py
@@ -1,16 +1,18 @@
 
 import glob
 import os
+from pathlib import Path
 import shutil
 
 import pytest
 
 from scenic.domains.driving.roads import Network
 
-maps = glob.glob('tests/formats/opendrive/maps/**/*.xodr')
+mapFolder = Path('tests')/'formats'/'opendrive'/'maps'
+maps = glob.glob(str(mapFolder/'**'/'*.xodr'))
 
 # TODO fix handling of this problematic map
-badmap = 'tests/formats/opendrive/maps/opendrive.org/sample1.1.xodr'
+badmap = str(mapFolder/'opendrive.org'/'sample1.1.xodr')
 map_params = []
 for path in maps:
     if path == badmap:
@@ -33,5 +35,5 @@ def cached_maps(tmpdir_factory):
 
 @pytest.fixture(scope='session')
 def network(cached_maps):
-    path = cached_maps['tests/formats/opendrive/maps/CARLA/Town03.xodr']
+    path = cached_maps[str(mapFolder/'CARLA'/'Town03.xodr')]
     return Network.fromFile(path)

--- a/tests/domains/driving/test_network.py
+++ b/tests/domains/driving/test_network.py
@@ -1,8 +1,12 @@
 
+from pathlib import Path
+
 import pytest
 
 from scenic.core.distributions import RejectionException
 from scenic.domains.driving.roads import Network, Intersection
+
+from tests.domains.driving.conftest import mapFolder
 
 # Suppress all warnings from OpenDRIVE parser
 pytestmark = pytest.mark.filterwarnings("ignore::scenic.formats.opendrive.OpenDriveWarning")
@@ -21,7 +25,7 @@ def test_show(network):
     plt.close()
 
 def test_element_tolerance(cached_maps, pytestconfig):
-    path = cached_maps['tests/formats/opendrive/maps/CARLA/Town01.xodr']
+    path = cached_maps[str(mapFolder/'CARLA'/'Town01.xodr')]
     tol = 0.05
     network = Network.fromFile(path, tolerance=tol)
     drivable = network.drivableRegion

--- a/tests/formats/opendrive/test_opendrive.py
+++ b/tests/formats/opendrive/test_opendrive.py
@@ -1,6 +1,7 @@
 
 import os
 import glob
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
@@ -9,8 +10,9 @@ from scenic.formats.opendrive import OpenDriveWorkspace
 from scenic.core.geometry import TriangulationError
 
 oldDir = os.getcwd()
-os.chdir('tests/formats/opendrive')
-maps = glob.glob('maps/**/*.xodr')
+os.chdir(Path('tests') / 'formats' / 'opendrive')
+mapPath = Path('maps') / '**' / '*.xodr'
+maps = glob.glob(str(mapPath))
 os.chdir(oldDir)
 
 @pytest.mark.slow

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -1,8 +1,10 @@
 
+import signal
 import sys
 
 import pytest
 
+import scenic.core.dynamics as dynamics
 from scenic.core.errors import RuntimeParseError, ScenicSyntaxError
 from scenic.core.simulators import TerminationType
 
@@ -115,6 +117,20 @@ def test_behavior_no_actions():
                 Foo()   # forgot to use 'do'
             ego = Object with behavior Bar
         """)
+
+@pytest.mark.skipif(not hasattr(signal, 'SIGALRM'), reason='need SIGALRM')
+@pytest.mark.slow
+def test_behavior_stuck(monkeypatch):
+    scenario = compileScenic("""
+        import time
+        behavior Foo():
+            time.sleep(1.5)
+            wait
+        ego = Object with behavior Foo
+    """)
+    monkeypatch.setattr(dynamics, 'stuckBehaviorWarningTimeout', 1)
+    with pytest.warns(dynamics.StuckBehaviorWarning):
+        sampleResultOnce(scenario)
 
 def test_behavior_create_object():
     with pytest.raises(ScenicSyntaxError):

--- a/tests/syntax/test_errors.py
+++ b/tests/syntax/test_errors.py
@@ -263,7 +263,7 @@ def checkBug(bug, template, tmpdir, pytestconfig):
             # test the formatting of the resulting backtrace
             command = (
                 'from tests.syntax.test_errors import runFile;'
-                f'runFile("{path}")'
+                f'runFile(r"{path}")'
             )
             args = [sys.executable, '-c', command]
             result = subprocess.run(args, capture_output=True, text=True)


### PR DESCRIPTION
The `signal` module doesn't have a `SIGALRM` attribute on Windows, causing `utils.alarm` to fail as in #112. This patch makes the context manager a no-op on platforms lacking `SIGALRM`, as originally intended. There were also several places in the code which assumed POSIX paths; these now use `pathlib` and raw strings as needed to avoid backslashes being interpreted as escape sequences.

There was no test for stuck behavior detection (which uses `utils.alarm`), so I added one.

Finally, this PR causes our CI setup to run the test suite on Windows as well as Ubuntu.