### PR TITLE
Fix grammar for `implies`

### DIFF
--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1427,7 +1427,7 @@ scenic_until (memo):
 
 scenic_implication (memo):
     | invalid_scenic_implication
-    | a=disjunction 'implies' b=disjunction { s.ImpliesOp(a, b, LOCATIONS) }
+    | a=scenic_next 'implies' b=scenic_next { s.ImpliesOp(a, b, LOCATIONS) }
     | scenic_next
 
 scenic_next (memo):

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -1791,6 +1791,15 @@ class TestOperator:
             parse_string_helper("x implies y implies z")
         assert "must take exactly two operands" in e.value.msg
 
+    def test_always_implies(self):
+        mod = parse_string_helper("x implies next y")
+        stmt = mod.body[0]
+        match stmt:
+            case Expr(ImpliesOp(Name("x"), Next(Name("y")))):
+                assert True
+            case _:
+                assert False
+
     def test_until_basic(self):
         mod = parse_string_helper("x until y")
         stmt = mod.body[0]


### PR DESCRIPTION
There was an issue where `next`, `eventually`, `always` could not be used inside `implies`. This PR fixes the bug.