### PR TITLE
Parse prefix temporal operators followed by `and` and `or`

### DIFF
--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1441,11 +1441,11 @@ scenic_implication (memo):
     | disjunction
 
 disjunction (memo):
-    | a=conjunction b=('or' c=conjunction { c })+ { ast.BoolOp(op=ast.Or(), values=[a] + b, LOCATIONS) }
+    | a=conjunction b=('or' c=(scenic_temporal_prefix | conjunction) { c })+ { ast.BoolOp(op=ast.Or(), values=[a] + b, LOCATIONS) }
     | conjunction
 
 conjunction (memo):
-    | a=inversion b=('and' c=inversion { c })+ { ast.BoolOp(op=ast.And(), values=[a] + b, LOCATIONS) }
+    | a=inversion b=('and' c=(scenic_temporal_prefix | inversion) { c })+ { ast.BoolOp(op=ast.And(), values=[a] + b, LOCATIONS) }
     | inversion
 
 inversion (memo):

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -2623,10 +2623,41 @@ class TestOperator:
         ],
     )
     def test_bool_temporal_prefix(self, boolop, boolopclass, tempop, tempopclass):
+        """Parse require statements of the form `require x {boolop} {tempop} y`.
+
+        It should be parsed as `require x {boolop} ({tempop} y)`"""
         mod = parse_string_helper(f"require x {boolop} {tempop} y")
         stmt = mod.body[0]
         match stmt:
             case Require(BoolOp(boolopclass(), [Name("x"), tempopclass(Name("y"))])):
+                assert True
+            case _:
+                assert False
+
+    @pytest.mark.parametrize(
+        "boolop,boolopclass,tempop,tempopclass",
+        [
+            bop + top
+            for bop in [("or", Or), ("and", And)]
+            for top in [("always", Always), ("eventually", Eventually), ("next", Next)]
+        ],
+    )
+    def test_bool_temporal_prefix_bool(self, boolop, boolopclass, tempop, tempopclass):
+        """Parse require statements of the form `require x {boolop} {tempop} y {boolop} z`.
+
+        It should be parsed as `require x {boolop} ({tempop} (y {boolop} z))`"""
+        mod = parse_string_helper(f"require x {boolop} {tempop} y {boolop} z")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(
+                BoolOp(
+                    boolopclass(),
+                    [
+                        Name("x"),
+                        tempopclass(BoolOp(boolopclass(), [Name("y"), Name("z")])),
+                    ],
+                )
+            ):
                 assert True
             case _:
                 assert False

--- a/tests/syntax/test_parser.py
+++ b/tests/syntax/test_parser.py
@@ -2614,6 +2614,23 @@ class TestOperator:
             case _:
                 assert False
 
+    @pytest.mark.parametrize(
+        "boolop,boolopclass,tempop,tempopclass",
+        [
+            bop + top
+            for bop in [("or", Or), ("and", And)]
+            for top in [("always", Always), ("eventually", Eventually), ("next", Next)]
+        ],
+    )
+    def test_bool_temporal_prefix(self, boolop, boolopclass, tempop, tempopclass):
+        mod = parse_string_helper(f"require x {boolop} {tempop} y")
+        stmt = mod.body[0]
+        match stmt:
+            case Require(BoolOp(boolopclass(), [Name("x"), tempopclass(Name("y"))])):
+                assert True
+            case _:
+                assert False
+
     def test_eventually(self):
         mod = parse_string_helper("require eventually x")
         stmt = mod.body[0]


### PR DESCRIPTION
The Python grammar (which we used as a base for Scenic grammar) is structured so it does not allow prefix operators after `and` or `or` without parenthesis. In Python, the only such prefix operator is `lambda`, and if you do 

```python
fn = False or lambda x: x
```

You might expect this to parse and assign the identity function to `fn`, but it just raises a syntax error.

This is problematic in Scenic because we have prefix temporal operators that we want to use together with `and` and `or`. For example, users might want to write

```scenic
require X or eventually Y
```

It failed to parse with the current grammar. This PR fixes the issue.

