### PR TITLE
Fix leak across multiple compilations of driving scenarios

### DIFF
--- a/src/scenic/domains/driving/actions.py
+++ b/src/scenic/domains/driving/actions.py
@@ -17,7 +17,39 @@ import math
 
 from scenic.core.vectors import Vector
 from scenic.core.simulators import Action
-import scenic.domains.driving.model as _model
+
+## Mixin classes indicating support for various types of actions.
+
+class Steers:
+    """Mixin protocol for agents which can steer.
+
+    Specifically, agents must support throttling, braking, steering, setting the hand
+    brake, and going into reverse.
+    """
+    def setThrottle(self, throttle): raise NotImplementedError
+
+    def setSteering(self, steering): raise NotImplementedError
+
+    def setBraking(self, braking): raise NotImplementedError
+
+    def setHandbrake(self, handbrake): raise NotImplementedError
+
+    def setReverse(self, reverse): raise NotImplementedError
+
+class Walks:
+    """Mixin protocol for agents which can walk with a given direction and speed.
+
+    We provide a simplistic implementation which directly sets the velocity of the agent.
+    This implementation needs to be explicitly opted-into, since simulators may provide a
+    more sophisticated API that properly animates pedestrians.
+    """
+    def setWalkingDirection(self, heading):
+        velocity = Vector(0, self.speed).rotatedBy(heading)
+        self.setVelocity(velocity)
+
+    def setWalkingSpeed(self, speed):
+        velocity = speed * self.velocity.normalized()
+        self.setVelocity(velocity)
 
 ## Actions available to all agents
 
@@ -63,7 +95,7 @@ class SteeringAction(Action):
 	Such agents must implement the `Steers` protocol.
 	"""
 	def canBeTakenBy(self, agent):
-		return isinstance(agent, _model.Steers)
+		return isinstance(agent, Steers)
 
 class SetThrottleAction(SteeringAction):
 	"""Set the throttle.
@@ -186,7 +218,7 @@ class WalkingAction(Action):
 	Such agents must implement the `Walks` protocol.
 	"""
 	def canBeTakenBy(self, agent):
-		return isinstance(agent, _model.Walks)
+		return isinstance(agent, Walks)
 
 class SetWalkingDirectionAction(WalkingAction):
 	"""Set the walking direction."""

--- a/src/scenic/domains/driving/model.scenic
+++ b/src/scenic/domains/driving/model.scenic
@@ -301,39 +301,6 @@ class Pedestrian(DrivingObject):
     length: 0.75
     color: [0, 0.5, 1]
 
-# Mixin classes indicating support for various types of actions
-
-class Steers:
-    """Mixin protocol for agents which can steer.
-
-    Specifically, agents must support throttling, braking, steering, setting the hand
-    brake, and going into reverse.
-    """
-    def setThrottle(self, throttle): raise NotImplementedError
-
-    def setSteering(self, steering): raise NotImplementedError
-
-    def setBraking(self, braking): raise NotImplementedError
-
-    def setHandbrake(self, handbrake): raise NotImplementedError
-
-    def setReverse(self, reverse): raise NotImplementedError
-
-class Walks:
-    """Mixin protocol for agents which can walk with a given direction and speed.
-
-    We provide a simplistic implementation which directly sets the velocity of the agent.
-    This implementation needs to be explicitly opted-into, since simulators may provide a
-    more sophisticated API that properly animates pedestrians.
-    """
-    def setWalkingDirection(self, heading):
-        velocity = Vector(0, self.speed).rotatedBy(heading)
-        self.setVelocity(velocity)
-
-    def setWalkingSpeed(self, speed):
-        velocity = speed * self.velocity.normalized()
-        self.setVelocity(velocity)
-
 ## Utility functions
 
 def withinDistanceToAnyCars(car, thresholdDistance):

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -1,7 +1,6 @@
 """Behaviors for dynamic agents in CARLA scenarios."""
 
 from scenic.domains.driving.behaviors import *	# use common driving behaviors
-import scenic.domains.driving.model as _model
 
 try:
     from scenic.simulators.carla.actions import *
@@ -54,12 +53,12 @@ behavior CrossingBehavior(reference_actor, min_speed=1, threshold=10, final_spee
         if actor_speed < min_speed:
             actor_speed = min_speed
 
-        if isinstance(self, _model.Walks):
+        if isinstance(self, Walks):
             do WalkForwardBehavior(actor_speed)
-        elif isinstance(self, _model.Steers):
+        elif isinstance(self, Steers):
             take SetSpeedAction(actor_speed)
 
-    if isinstance(self, _model.Walks):
+    if isinstance(self, Walks):
         do WalkForwardBehavior(final_speed)
-    elif isinstance(self, _model.Steers):
+    elif isinstance(self, Steers):
         take SetSpeedAction(final_speed)

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -133,9 +133,6 @@ class NewtonianSimulation(DrivingSimulation):
     def createObjectInSimulator(self, obj):
         pass
 
-    def actionsAreCompatible(self, agent, actions):
-        return True
-
     def isOnScreen(self, x, y):
         return self.min_x <= x <= self.max_x and self.min_y <= y <= self.max_y
 

--- a/tests/simulators/newtonian/test_newtonian.py
+++ b/tests/simulators/newtonian/test_newtonian.py
@@ -20,10 +20,14 @@ def test_render(loadLocalScenario):
     simulator.simulate(scene, maxSteps=3)
 
 def test_driving(loadLocalScenario):
-    scenario = loadLocalScenario('driving.scenic')
-    scene, _ = scenario.generate(maxIterations=1000)
-    simulator = scenario.getSimulator()
-    simulation = simulator.simulate(scene, maxSteps=3)
+    def check():
+        scenario = loadLocalScenario('driving.scenic')
+        scene, _ = scenario.generate(maxIterations=1000)
+        simulator = scenario.getSimulator()
+        simulation = simulator.simulate(scene, maxSteps=3)
+    # Run this twice to catch leaks between successive compilations.
+    check()
+    check()  # If we fail here, something is leaking.
 
 @pickle_test
 def test_pickle(loadLocalScenario):


### PR DESCRIPTION
Fixes the second issue raised in #120: compiling a scenario using the driving model two times and then trying to run a simulation failed with an error claiming an ordinary steering action was incompatible with a car.

This issue was caused by the `scenic.domains.driving.actions` module keeping a reference to the Scenic module `scenic.domains.driving.model` in order to access the `Steers` mixin: the latter module gets purged at the end of compilation, so the second compilation imports it again and gets a different copy of `Steers`. But the former module is not purged since it's an ordinary Python module, so the actions used in the scenario use a different version of `Steers` than the objects, causing the `isinstance` check used in `SteeringAction.canBeTakenBy` to fail.