### PR TITLE
2to3 converter maps "offset by X" to "at ego offset by X"

### DIFF
--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -1194,6 +1194,8 @@ class TokenTranslator:
 					elif twoWords in allowedPrefixOps:	# 2-word prefix operator
 						callFunction(allowedPrefixOps[twoWords])
 						advance()	# consume second word
+						if dumpScenic3 and inConstructorContext:
+							dumpScenic3.recordSpecifier(token, nextToken)
 					elif not startOfStatement and twoWords in allowedInfixOps:	# 2-word infix operator
 						injectToken(allowedInfixOps[twoWords])
 						advance()	# consume second word
@@ -1227,6 +1229,8 @@ class TokenTranslator:
 					elif inConstructorContext and tstring == 'with':	# special case for 'with' specifier
 						callFunction('With', argument=(STRING, f'"{nextString}"'))
 						advance()	# consume property name
+						if dumpScenic3:
+							dumpScenic3.recordSpecifier(token, nextToken)
 					elif startOfStatement and tstring == requireStatement and nextString == '[':
 						# special case for require[p]
 						next(tokens)	# consume '['
@@ -1258,6 +1262,8 @@ class TokenTranslator:
 					oneWord = (tstring,)
 					if oneWord in allowedPrefixOps:		# 1-word prefix operator
 						callFunction(allowedPrefixOps[oneWord])
+						if dumpScenic3 and inConstructorContext:
+							dumpScenic3.recordSpecifier(token)
 					elif not startOfStatement and oneWord in allowedInfixOps:	# 1-word infix operator
 						injectToken(allowedInfixOps[oneWord])
 						skip = True

--- a/tests/syntax/test_2to3.py
+++ b/tests/syntax/test_2to3.py
@@ -46,6 +46,18 @@ def test_custom_object_creation(check):
 def test_class_noncreation(check, code):
     check(code, code)
 
+def test_offset_by_specifier(check):
+    check('ego=Object\nObject offset by (4, 5)',
+          'ego=new Object\nnew Object at ego offset by (4, 5)')
+    check('ego=Object\nObject offset by (4, 5), facing 30 deg',
+          'ego=new Object\nnew Object at ego offset by (4, 5), facing 30 deg')
+    check('ego=Object\nObject facing 30 deg, offset by 1 @ 2',
+          'ego=new Object\nnew Object facing 30 deg, at ego offset by 1 @ 2')
+
+def test_offset_by_operator(check):
+    check('ego = Object at (1, 2) offset by (3, 4)',
+          'ego = new Object at (1, 2) offset by (3, 4)')
+
 def test_monitor(check):
     check("""
         monitor MyMon:


### PR DESCRIPTION
This is needed to preserve the semantics, since the `offset by` specifier will optionally specify `parentOrientation` in Scenic 3 (whereas it did not specify `heading` in Scenic 2).