### PR TITLE
Add tolerance to vector fields from polygonal unions

### DIFF
--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -850,7 +850,7 @@ class PolygonalRegion(Region):
 		if not poly:
 			return super().union(other, triedReversed)
 		union = polygonUnion((self.polygons, poly), buf=buf)
-		orientation = VectorField.forUnionOf((self, other))
+		orientation = VectorField.forUnionOf((self, other), tolerance=buf)
 		return PolygonalRegion(polygon=union, orientation=orientation)
 
 	@staticmethod
@@ -865,7 +865,7 @@ class PolygonalRegion(Region):
 		if any(not poly for poly in polys):
 			raise TypeError(f'cannot take union of regions {regions}')
 		union = polygonUnion(polys, buf=buf)
-		orientation = VectorField.forUnionOf(regs)
+		orientation = VectorField.forUnionOf(regs, tolerance=buf)
 		return PolygonalRegion(polygon=union, orientation=orientation)
 
 	@property

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -899,7 +899,7 @@ class Network:
 
         :meta private:
         """
-        return 20
+        return 21
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""


### PR DESCRIPTION
Backport of 4c057e79ee28caedb2404a65e2eb1ca242901e8a to `main`. Should fix the "evaluated PiecewiseVectorField at undefined point" issue causing random test failures in #123 and #125.