### PR TITLE
Only recognize temporal operators inside requirements

### DIFF
--- a/docs/internals/compiler.rst
+++ b/docs/internals/compiler.rst
@@ -135,12 +135,12 @@ easily distinguish Scenic-specific rules from those in the original Python gramm
 .. code-block:: pegen
 
    scenic_implication (memo):
-       | invalid_scenic_implication  # special rule to explain invalid uses of 'implies'
-       | a=disjunction 'implies' b=disjunction { s.ImpliesOp(a, b, LOCATIONS) }
+       | invalid_scenic_implication  # special rule to explain invalid uses of "implies"
+       | a=disjunction "implies" b=disjunction { s.ImpliesOp(a, b, LOCATIONS) }
        | disjunction
 
 Our rule has three alternatives, which the parser considers in order.
-For the moment, let's consider the second alternative, which is the one defining the actual syntax of ``implies``: it matches any text matching the ``disjunction`` rule, followed by the keyword ``implies``, followed by any text matching the ``disjunction`` rule.
+For the moment, let's consider the second alternative, which is the one defining the actual syntax of ``implies``: it matches any text matching the ``disjunction`` rule, followed by the word ``implies``, followed by any text matching the ``disjunction`` rule.
 In the grammar, precedence and associativity of operators are defined by using
 separate rules for each precedence level.
 The ``disjunction`` rule matches any expression defined using ``or`` or an operator with higher precedence than ``or``.
@@ -167,7 +167,7 @@ rules: those rules can then generate errors when they match.
 .. code-block:: pegen
 
    invalid_scenic_implication[NoReturn]:
-       | a=disjunction 'implies' disjunction 'implies' b=disjunction {
+       | a=disjunction "implies" disjunction "implies" b=disjunction {
            self.raise_syntax_error_known_range(
                f"`implies` must take exactly two operands", a, b
            )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1743,28 +1743,3 @@ class ScenicToPythonTransformer(Transformer):
             ],
             keywords=[],
         )
-
-    def visit_Always(self, node: s.Always):
-        raise self.makeSyntaxError(
-            "`always` can only be used inside requirements", node
-        )
-
-    def visit_Eventually(self, node: s.Eventually):
-        raise self.makeSyntaxError(
-            "`always` can only be used inside requirements", node
-        )
-
-    def visit_Next(self, node: s.Next):
-        raise self.makeSyntaxError(
-            "`always` can only be used inside requirements", node
-        )
-
-    def visit_ImpliesOp(self, node: s.ImpliesOp):
-        raise self.makeSyntaxError(
-            "`always` can only be used inside requirements", node
-        )
-
-    def visit_UntilOp(self, node: s.UntilOp):
-        raise self.makeSyntaxError(
-            "`always` can only be used inside requirements", node
-        )

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -22,10 +22,7 @@ def compileScenicAST(
     inInterruptBlock: bool = False,
 ) -> Tuple[Union[ast.AST, List[ast.AST]], List[ast.AST]]:
     """Compiles Scenic AST to Python AST"""
-    compiler = ScenicToPythonTransformer()
-
-    # set filename
-    compiler.filename = filename
+    compiler = ScenicToPythonTransformer(filename)
 
     # set optional flags
     compiler.inBehavior = inBehavior
@@ -194,6 +191,25 @@ class LocalFinder(ast.NodeVisitor):
         self.generic_visit(node)
 
 
+class Transformer(ast.NodeTransformer):
+    """Subclass of `ast.NodeTransformer` with a method for raising syntax errors."""
+
+    def __init__(self, filename):
+        super().__init__()
+        self.filename = filename
+
+    def makeSyntaxError(self, msg, node: ast.AST) -> ScenicParseError:
+        e = SyntaxError(msg)
+        e.lineno = node.lineno
+        e.offset = node.col_offset
+        if node.end_lineno is not None:
+            e.end_lineno = node.end_lineno
+        if node.end_col_offset is not None:
+            e.end_offset = node.end_col_offset
+        e.filename = self.filename
+        raise ScenicParseError(e)
+
+
 # Proposition Constructors with Temporal Operators Support
 PROPOSITION_AND = "PropositionAnd"
 PROPOSITION_OR = "PropositionOr"
@@ -215,11 +231,15 @@ PROPOSITION_FACTORY = (
     UNTIL,
     IMPLIES,
 )
+TEMPORAL_PREFIX_OPS = {
+    'always',
+    'eventually',
+    'next',
+}
 
-
-class PropositionTransformer(ast.NodeTransformer):
-    def __init__(self) -> None:
-        super().__init__()
+class PropositionTransformer(Transformer):
+    def __init__(self, filename='<unknown>') -> None:
+        super().__init__(filename)
         self.nextSyntaxId = 0
 
     def transform(
@@ -339,6 +359,15 @@ class PropositionTransformer(ast.NodeTransformer):
         )
         return ast.copy_location(newNode, node)
 
+    def visit_Call(self, node: ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in TEMPORAL_PREFIX_OPS:
+            self.makeSyntaxError(
+                f'malformed use of the "{func.id}" temporal operator',
+                node
+            )
+        return self.generic_visit(node)
+
     def visit_Always(self, node: s.Always):
         value = self.visit(node.value)
         if not self.is_proposition_factory(value):
@@ -415,10 +444,9 @@ class Context(IntFlag):
     DYNAMIC = BEHAVIOR | MONITOR | COMPOSE
 
 
-class ScenicToPythonTransformer(ast.NodeTransformer):
-    def __init__(self) -> None:
-        super().__init__()
-        self.filename = None
+class ScenicToPythonTransformer(Transformer):
+    def __init__(self, filename) -> None:
+        super().__init__(filename)
 
         self.requirements = []
         self.nextSyntaxId = 0
@@ -440,17 +468,6 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
         self.inLoop = False
         self.usedBreak = False
         self.usedContinue = False
-
-    def makeSyntaxError(self, msg, node: ast.AST) -> ScenicParseError:
-        e = SyntaxError(msg)
-        e.lineno = node.lineno
-        e.offset = node.col_offset
-        if node.end_lineno is not None:
-            e.end_lineno = node.end_lineno
-        if node.end_col_offset is not None:
-            e.end_offset = node.end_col_offset
-        e.filename = self.filename
-        raise ScenicParseError(e)
 
     @property
     def topLevel(self):
@@ -1327,7 +1344,8 @@ class ScenicToPythonTransformer(ast.NodeTransformer):
             name (Optional[str], optional): Optional name for requirements. Defaults to None.
             prob (Optional[float], optional): Optional probability for requirements. Defaults to None.
         """
-        newBody, self.nextSyntaxId = PropositionTransformer().transform(
+        propTransformer = PropositionTransformer(self.filename)
+        newBody, self.nextSyntaxId = propTransformer.transform(
             body, self.nextSyntaxId
         )
         newBody = self.visit(newBody)

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1369,7 +1369,16 @@ expressions:
 expression (memo):
     | invalid_expression
     | invalid_legacy_expression
-    | a=scenic_until 'if' b=scenic_until 'else' c=expression {
+    | a=disjunction 'if' b=disjunction 'else' c=disjunction {
+        ast.IfExp(body=a, test=b, orelse=c, LOCATIONS)
+     }
+    | disjunction
+    | lambdef
+
+scenic_temporal_expression (memo):
+    | invalid_expression
+    | invalid_legacy_expression
+    | a=scenic_until 'if' b=scenic_until 'else' c=scenic_until {
         ast.IfExp(body=a, test=b, orelse=c, LOCATIONS)
      }
     | scenic_until
@@ -1437,21 +1446,47 @@ scenic_temporal_prefix (memo):
 scenic_implication (memo):
     | invalid_scenic_implication
     # exclude implication on RHS to disallow "A implies B implies C"
-    | a=disjunction "implies" b=(scenic_temporal_prefix | disjunction) { s.ImpliesOp(a, b, LOCATIONS) }
-    | disjunction
+    | a=scenic_temporal_disjunction "implies" b=(scenic_temporal_prefix | scenic_temporal_disjunction) { s.ImpliesOp(a, b, LOCATIONS) }
+    | scenic_temporal_disjunction
 
 disjunction (memo):
-    | a=conjunction b=('or' c=(scenic_temporal_prefix | conjunction) { c })+ { ast.BoolOp(op=ast.Or(), values=[a] + b, LOCATIONS) }
+    | a=conjunction b=('or' c=conjunction { c })+ { ast.BoolOp(op=ast.Or(), values=[a] + b, LOCATIONS) }
     | conjunction
 
+scenic_temporal_disjunction (memo):
+    | a=scenic_temporal_conjunction b=('or' c=(scenic_temporal_prefix | scenic_temporal_conjunction) { c })+ { ast.BoolOp(op=ast.Or(), values=[a] + b, LOCATIONS) }
+    | scenic_temporal_conjunction
+
 conjunction (memo):
-    | a=inversion b=('and' c=(scenic_temporal_prefix | inversion) { c })+ { ast.BoolOp(op=ast.And(), values=[a] + b, LOCATIONS) }
+    | a=inversion b=('and' c=inversion { c })+ { ast.BoolOp(op=ast.And(), values=[a] + b, LOCATIONS) }
     | inversion
+
+scenic_temporal_conjunction (memo):
+    | a=scenic_temporal_inversion b=('and' c=(scenic_temporal_prefix | scenic_temporal_inversion) { c })+ { ast.BoolOp(op=ast.And(), values=[a] + b, LOCATIONS) }
+    | scenic_temporal_inversion
 
 inversion (memo):
     # [SCENIC NOTE]: Fail `not visible <inversion>` to be handled later
     | 'not' !("visible" inversion) a=inversion { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
     | comparison
+
+scenic_temporal_inversion (memo):
+    # Fail `not visible <inversion>` to be handled later
+    | 'not' !("visible" scenic_temporal_inversion) a=(scenic_temporal_prefix | scenic_temporal_inversion) { ast.UnaryOp(op=ast.Not(), operand=a, LOCATIONS) }
+    | scenic_temporal_group
+    | comparison
+
+# Parsing temporal operators only inside "require" would require duplicating
+# the entire rule hierarchy for expressions, since for example "always(X)" is a
+# valid function call in ordinary Python but should be a temporal operator
+# inside require. Instead, we only duplicate the boolean operators (above) and
+# add the following rule which allows the introduction of parentheses without
+# traversing all the way down to `atom`; the rule looks ahead for a binary
+# temporal operator or the end of the parent expression in order to prevent
+# matching expressions like "(X) > 5", which should be parsed by `comparison`
+# instead. Invalid code like "(always(X)) > 5" is parsed as an ordinary
+# expression (with a call to the "always" function) and caught in the compiler.
+scenic_temporal_group: '(' a=scenic_temporal_expression ')' &('until' | 'or' | 'and' | ')' | ';' | NEWLINE) { a }
 
 # Scenic instance creation
 # ------------------------
@@ -1832,7 +1867,7 @@ scenic_require_stmt:
         s.RequireMonitor(monitor=e, name=n, LOCATIONS)
      }
     | invalid_scenic_require_prob
-    | 'require' p=['[' a=NUMBER ']' { float(a.string) }] e=expression n=['as' a=scenic_require_stmt_name { a }] {
+    | 'require' p=['[' a=NUMBER ']' { float(a.string) }] e=scenic_temporal_expression n=['as' a=scenic_require_stmt_name { a }] {
         s.Require(cond=e, prob=p, name=n, LOCATIONS)
      }
 scenic_require_stmt_name:
@@ -2206,7 +2241,7 @@ invalid_named_expression[NoReturn]:
      }
 
 invalid_scenic_until[NoReturn]:
-    | a=disjunction 'until' scenic_implication {
+    | a=scenic_temporal_disjunction 'until' scenic_implication {
         self.raise_syntax_error_known_location(
             f"`until` must take exactly two operands", a
         )
@@ -2220,7 +2255,7 @@ invalid_scenic_implication[NoReturn]:
      }
 
 invalid_scenic_require_prob[NoReturn]:
-    | 'require' '[' !(NUMBER ']') p=expression ']' expression ['as' scenic_require_stmt_name] {
+    | 'require' '[' !(NUMBER ']') p=expression ']' scenic_temporal_expression ['as' scenic_require_stmt_name] {
         self.raise_syntax_error_known_location(
             f"'require' probability must be a constant", p
         )

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -975,6 +975,10 @@ def test_require_always():
         actions = sampleEgoActions(scenario, maxSteps=2, maxIterations=50)
         assert tuple(actions) == (0, 0)
 
+def test_require_always_invalid():
+    with pytest.raises(ScenicSyntaxError):
+        compileScenic("require (always (x)) > 5")
+
 def test_require_eventually():
     scenario = compileScenic("""
         behavior Foo():
@@ -1034,6 +1038,10 @@ def test_require_next_2():
         require next next ego.blah == 2
     """)
     sampleEgoActions(scenario, maxSteps=5)
+
+def test_require_next_invalid():
+    with pytest.raises(ScenicSyntaxError):
+        compileScenic("require (next (x)) > 5")
 
 def test_require_until():
     scenario = compileScenic("""


### PR DESCRIPTION
Thereby allowing normal use of the built-in `next` function, for example (outside of requirements).

We didn't do this before because the straightforward implementation would require having two copies of all of the expression rules (for normal expressions, and expressions inside requirements allowing temporal operators). The implementation in this PR avoids that by using a slightly-hacky parsing rule which allows too much (specifically parsing the temporal operators as function calls in illegal code like `(always (X)) > 5`) plus a check in the compiler for the illegal cases. This approach is the least painful I could come up with using straight PEG syntax; if Pegen later adds predicates or other metaprogramming features we could switch to those.