### PR TITLE
Upgrade Shapely to 2.x for Scenic 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 	'pygame ~= 2.1.3.dev8; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
 	"scipy ~= 1.7",
-	"shapely ~= 1.7",
+	"shapely ~= 2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Upgrade Shapely to 2.0.

It l;ooks like all compatibiulity issues have been solved already.