### PR TITLE
Work around bpo-37838

### DIFF
--- a/src/scenic/core/distributions.py
+++ b/src/scenic/core/distributions.py
@@ -13,7 +13,7 @@ import decorator
 
 from scenic.core.lazy_eval import (LazilyEvaluable,
     requiredProperties, needsLazyEvaluation, valueInContext, makeDelayedFunctionCall)
-from scenic.core.utils import DefaultIdentityDict, argsToString, cached, sqrt2
+from scenic.core.utils import DefaultIdentityDict, argsToString, cached, sqrt2, get_type_hints
 from scenic.core.errors import RuntimeParseError
 
 ## Misc
@@ -320,7 +320,7 @@ class FunctionDistribution(Distribution):
 		args = tuple(toDistribution(arg) for arg in args)
 		kwargs = { name: toDistribution(arg) for name, arg in kwargs.items() }
 		if valueType is None:
-			valueType = typing.get_type_hints(func).get('return')
+			valueType = get_type_hints(func).get('return')
 		super().__init__(*args, *kwargs.values(), valueType=valueType)
 		self.function = func
 		self.arguments = args
@@ -428,7 +428,7 @@ class MethodDistribution(Distribution):
 		args = tuple(toDistribution(arg) for arg in args)
 		kwargs = { name: toDistribution(arg) for name, arg in kwargs.items() }
 		if valueType is None:
-			valueType = typing.get_type_hints(method).get('return')
+			valueType = get_type_hints(method).get('return')
 		super().__init__(*args, *kwargs.values(), valueType=valueType)
 		self.method = method
 		self.object = obj
@@ -492,7 +492,7 @@ class AttributeDistribution(Distribution):
 		# If the object's type is known, see if we have an attribute type annotation.
 		ty = type_support.underlyingType(obj)
 		try:
-			hints = typing.get_type_hints(ty)
+			hints = get_type_hints(ty)
 			attrTy = hints.get(attribute)
 			if attrTy:
 				return attrTy
@@ -525,7 +525,7 @@ class AttributeDistribution(Distribution):
 			if func:
 				if isinstance(func, property):
 					func = func.fget
-				retTy = typing.get_type_hints(func).get('return')
+				retTy = get_type_hints(func).get('return')
 		return OperatorDistribution('__call__', self, args, valueType=retTy)
 
 	def __repr__(self):
@@ -549,7 +549,7 @@ class OperatorDistribution(Distribution):
 		ty = type_support.underlyingType(obj)
 		op = getattr(ty, operator, None)
 		if op:
-			retTy = typing.get_type_hints(op).get('return')
+			retTy = get_type_hints(op).get('return')
 			if retTy:
 				return retTy
 

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -114,7 +114,8 @@ def get_type_args(tp):
 
 # Patched version of typing.get_type_hints fixing bpo-37838
 
-if sys.version_info >= (3, 7, 6) and sys.version_info != (3, 8, 0):
+if (sys.version_info >= (3, 8, 1)
+    or (sys.version_info < (3, 8) and sys.version_info >= (3, 7, 6))):
     get_type_hints = typing.get_type_hints
 else:
     def get_type_hints(obj, globalns=None, localns=None):

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import math
 import signal
 import sys
+import types
 import typing
 
 import decorator
@@ -110,3 +111,16 @@ def get_type_args(tp):
             res = (list(res[:-1]), res[-1])
         return res
     return ()
+
+# Patched version of typing.get_type_hints fixing bpo-37838
+
+if sys.version_info >= (3, 7, 6) and sys.version_info != (3, 8, 0):
+    get_type_hints = typing.get_type_hints
+else:
+    def get_type_hints(obj, globalns=None, localns=None):
+        if not isinstance(obj, (type, types.ModuleType)) and globalns is None:
+            wrapped = obj
+            while hasattr(wrapped, '__wrapped__'):
+                wrapped = wrapped.__wrapped__
+            globalns = getattr(wrapped, '__globals__', {})
+        return typing.get_type_hints(obj, globalns, localns)


### PR DESCRIPTION
This should fix the issue in #132 on old versions of Python.

I tested this by unconditionally patching `typing.get_type_hints`, but the PR only does the patching when the version of Python is old enough to suffer from bpo-37838. @Eric-Vin since I can't install an old-enough version under macOS, and our CI probably doesn't use one either, can you please see if you can do it on your machine?