### PR TITLE
Manual CI attempt 3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,4 +56,4 @@ jobs:
         python -m pip install -e ".[test]"
     - name: Run pytest
       run: |
-        pytest ${{ inputs.options }}
+        pytest ${{ inputs.options || '--no-graphics' }}


### PR DESCRIPTION
#140 broke automatic test runs; this should fix them.

(Unfortunately there is apparently no way to have default values for inputs get shared across `workflow_call/workflow_dispatch` and `push/pull_request` triggers.)