### PR TITLE
Work around division by zero in colorsys

### DIFF
--- a/src/scenic/simulators/utils/colors.py
+++ b/src/scenic/simulators/utils/colors.py
@@ -87,7 +87,10 @@ class NoisyColorDistribution(Distribution):
 
     @staticmethod
     def addNoiseTo(color, hueNoise, lightNoise, satNoise):
-        hue, lightness, saturation = colorsys.rgb_to_hls(*color)
+        try:
+            hue, lightness, saturation = colorsys.rgb_to_hls(*color)
+        except ZeroDivisionError:
+            hue, lightness, saturation = 0.0, 1.0, 0.0
         hue = max(0, min(1, hue + hueNoise))
         lightness = max(0, min(1, lightness + lightNoise))
         saturation = max(0, min(1, saturation + satNoise))

--- a/tests/simulators/utils/test_colors.py
+++ b/tests/simulators/utils/test_colors.py
@@ -1,0 +1,10 @@
+import pytest
+
+from scenic.simulators.utils.colors import NoisyColorDistribution
+
+
+def test_add_noise():
+    ant = NoisyColorDistribution.addNoiseTo
+    for r in (0, 1, 0.9999999999999999):
+        color = (r, 1, 1)
+        assert ant(color, 0, 0, 0) == pytest.approx(color)

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
 extras =
 	test
 commands =
-	pytest --basetemp={envtmpdir} {posargs} tests/
+	pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
`colorsys.rgb_to_hls` divides by zero when given a color which is very nearly but not exactly white. Surprisingly, this doesn't seem to have been noticed before (at least I can't find anything online), so I'll file a bug. But in the mean time I'm adding this workaround, since the bug caused one of our tests to randomly fail.