### PR TITLE
Work around class attribute bug in dill 0.3.7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,7 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' && steps.windows-cache-deps.outputs.cache-hit != 'true' }}
       run: |
         New-Item -Path downloads -ItemType Directory -Force
-        Invoke-WebRequest https://files.openscad.org/OpenSCAD-2021.01-x86-64.zip -O downloads/openscad.zip
+        Invoke-WebRequest https://github.com/openscad/openscad/releases/download/openscad-2021.01/OpenSCAD-2021.01-x86-64.zip -O downloads/openscad.zip
         Invoke-WebRequest https://download.blender.org/release/Blender3.6/blender-3.6.0-windows-x64.zip -O downloads/blender.zip
 
     - name: Install non-Python dependencies (Windows)

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1621,7 +1621,11 @@ class OrientedPoint2D(Point2D, OrientedPoint):
             # Can get here when cls is unpickled (the transformed version was pickled)
             pass
         else:
-            cls._props_transformed = True
+            # Mark class as being transformed.
+            # To work around https://github.com/uqfoundation/dill/issues/612,
+            # use a different truthy value for each class.
+            cls._props_transformed = str(cls)
+
             props = cls._scenic_properties
             # Raise error if parentOrientation already defined
             if "parentOrientation" in props:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -326,7 +326,7 @@ def tryPickling(thing, checkEquivalence=True, pickler=dill):
     return unpickled
 
 
-def areEquivalent(a, b, cache=None, debug=True, ignoreCacheAttrs=False, extraIgnores=()):
+def areEquivalent(a, b, cache=None, debug=False, ignoreCacheAttrs=False, extraIgnores=()):
     """Whether two objects are equivalent, i.e. have the same properties.
 
     This is only used for debugging, e.g. to check that a Distribution is the


### PR DESCRIPTION
`dill` 0.3.7 doesn't completely preserve the `__dict__` or `__module__` of subclasses pickled by value: see https://github.com/uqfoundation/dill/issues/612. This broke our mechanism for detecting when subclasses of `OrientedPoint2D` have already been transformed, as well as the pickle tests asserting equivalence of Scenic objects and their unpickled versions. This PR fixes the former by working around the bug, and silences the latter by adding a special case to `areEquivalent` to ignore wrong `__module__` values when using `dill` 0.3.7 (hopefully this will be fixed in subsequent versions).

(I've also updated the URL used to download OpenSCAD: their website is having issues and they recommend getting the releases from GitHub in the mean time.)