### PR TITLE
Run CI both with/without optional dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
+        extras: ["test", "test-full"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -91,7 +92,7 @@ jobs:
 
     - name: Install Scenic and dependencies
       run: |
-        python -m pip install -e ".[test-full]"
+        python -m pip install -e ".[${{ matrix.extras }}]"
 
     - name: Run pytest
       run: |

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -311,7 +311,9 @@ try:
     import dill
 except ModuleNotFoundError:
     dill = None
-dill_version = metadata.version("dill")
+    dill_version = None
+else:
+    dill_version = metadata.version("dill")
 pickle_test = pytest.mark.skipif(not dill, reason="dill required for pickling tests")
 
 


### PR DESCRIPTION
Also fixes a bug introduced in #165 which causes the test suite to fail when `dill` isn't installed.