### PR TITLE
Fix multiple compilation of driving scenario bug; minor improvements

### DIFF
--- a/examples/carla/pedestrian.scenic
+++ b/examples/carla/pedestrian.scenic
@@ -1,4 +1,5 @@
 param map = localPath('../../assets/maps/CARLA/Town03.xodr')
+param carla_map = 'Town03'
 model scenic.simulators.carla.model
 
 ego = new Car

--- a/src/scenic/simulators/carla/actions.py
+++ b/src/scenic/simulators/carla/actions.py
@@ -5,7 +5,6 @@ import math as _math
 import carla as _carla
 
 from scenic.domains.driving.actions import *
-import scenic.simulators.carla.model as _carlaModel
 import scenic.simulators.carla.utils.utils as _utils
 
 ################################################
@@ -43,9 +42,16 @@ class SetTransformAction(Action):  # TODO eliminate
 #############################################
 
 
+class _CarlaVehicle:
+    # Mixin identifying CARLA vehicles.
+    # Used to avoid importing the Vehicle class from the CARLA model, which is
+    # a Scenic module not importable from Python.
+    pass
+
+
 class VehicleAction(Action):
     def canBeTakenBy(self, agent):
-        return isinstance(agent, _carlaModel.Vehicle)
+        return isinstance(agent, _CarlaVehicle)
 
 
 class SetManualGearShiftAction(VehicleAction):
@@ -131,9 +137,14 @@ class SetVehicleLightStateAction(VehicleAction):
 #################################################
 
 
+class _CarlaPedestrian:
+    # Mixin identifying CARLA pedestrians. (see _CarlaVehicle)
+    pass
+
+
 class PedestrianAction(Action):
     def canBeTakenBy(self, agent):
-        return isinstance(agent, _carlaModel.Pedestrian)
+        return isinstance(agent, _CarlaPedestrian)
 
 
 class SetJumpAction(PedestrianAction):

--- a/src/scenic/simulators/carla/model.scenic
+++ b/src/scenic/simulators/carla/model.scenic
@@ -67,6 +67,9 @@ except ModuleNotFoundError:
         raise RuntimeError('the "carla" package is required to run simulations '
                            'from this scenario')
 
+    class _CarlaVehicle: pass
+    class _CarlaPedestrian: pass
+
 param carla_map = None
 param address = '127.0.0.1'
 param port = 2000

--- a/src/scenic/simulators/carla/model.scenic
+++ b/src/scenic/simulators/carla/model.scenic
@@ -49,6 +49,7 @@ from scenic.simulators.utils.colors import Color
 try:
     from scenic.simulators.carla.simulator import CarlaSimulator    # for use in scenarios
     from scenic.simulators.carla.actions import *
+    from scenic.simulators.carla.actions import _CarlaVehicle, _CarlaPedestrian
     import scenic.simulators.carla.utils.utils as _utils
 except ModuleNotFoundError:
     # for convenience when testing without the carla package
@@ -140,7 +141,7 @@ class CarlaActor(DrivingObject):
         else:
             self.carlaActor.set_velocity(cvel)
 
-class Vehicle(Vehicle, CarlaActor, Steers):
+class Vehicle(Vehicle, CarlaActor, Steers, _CarlaVehicle):
     """Abstract class for steerable vehicles."""
 
     def setThrottle(self, throttle):
@@ -194,7 +195,7 @@ class Truck(Vehicle):
     blueprint: Uniform(*blueprints.truckModels)
 
 
-class Pedestrian(Pedestrian, CarlaActor, Walks):
+class Pedestrian(Pedestrian, CarlaActor, Walks, _CarlaPedestrian):
     """A pedestrian.
 
     The default ``blueprint`` (see `CarlaActor`) is a uniform distribution over the

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -49,7 +49,7 @@ class CarlaSimulator(DrivingSimulator):
             except Exception as e:
                 raise RuntimeError(f"CARLA could not load world '{carla_map}'") from e
         else:
-            if map_path.endswith(".xodr"):
+            if str(map_path).endswith(".xodr"):
                 with open(map_path) as odr_file:
                     self.world = self.client.generate_opendrive_world(odr_file.read())
             else:

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -660,7 +660,12 @@ def ego(obj=None):
         if egoObject is None:
             raise InvalidScenarioError("referred to ego object not yet assigned")
     elif not isinstance(obj, Object):
-        raise TypeError("tried to make non-object the ego object")
+        if isinstance(obj, type) and issubclass(obj, Object):
+            suffix = " (perhaps you forgot 'new'?)"
+        else:
+            suffix = ""
+        ty = type(obj).__name__
+        raise TypeError(f"tried to make non-object (of type {ty}) the ego object{suffix}")
     else:
         currentScenario._ego = obj
         for scenario in runningScenarios:

--- a/tests/simulators/carla/test_carla.py
+++ b/tests/simulators/carla/test_carla.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.utils import pickle_test, sampleScene, tryPickling
+from tests.utils import compileScenic, pickle_test, sampleScene, tryPickling
 
 # Suppress potential warning about missing the carla package
 pytestmark = pytest.mark.filterwarnings(
@@ -16,6 +16,21 @@ def test_basic(loadLocalScenario):
 def test_simulator_import():
     pytest.importorskip("carla")
     from scenic.simulators.carla import CarlaSimulator
+
+
+def test_consistent_object_type(getAssetPath):
+    pytest.importorskip("carla")
+    mapPath = getAssetPath("maps/CARLA/Town01.xodr")
+    code = rf"""
+        param map = '{mapPath}'
+        param carla_map = 'Town01'
+        model scenic.simulators.carla.model
+        action = SetGearAction(0)
+        ego = new Car
+        assert action.canBeTakenBy(ego)
+    """
+    for _ in range(2):
+        compileScenic(code, mode2D=True)
 
 
 @pickle_test

--- a/tests/simulators/carla/test_carla.py
+++ b/tests/simulators/carla/test_carla.py
@@ -21,8 +21,8 @@ def test_simulator_import():
 def test_consistent_object_type(getAssetPath):
     pytest.importorskip("carla")
     mapPath = getAssetPath("maps/CARLA/Town01.xodr")
-    code = rf"""
-        param map = '{mapPath}'
+    code = f"""
+        param map = r'{mapPath}'
         param carla_map = 'Town01'
         model scenic.simulators.carla.model
         action = SetGearAction(0)


### PR DESCRIPTION
Fixes a variant of the issue in #123 which wasn't fixed by that PR and came up in #168. (Plus another couple minor things I improved along the way.)

This bug was enabled by the fact that it's still possible to import a Scenic module from a Python module if that Python module was imported during the compilation of a Scenic module. Completely banning imports of Scenic modules from Python seems to be nontrivial, so I'll save that for another PR.