### PR TITLE
Pruning Improvements and Voxel Regions + Bugfix & Cleanup

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1257,12 +1257,6 @@ class Object(OrientedPoint):
     def inradius(self):
         """A lower bound on the inradius of this object"""
 
-        # Define a helper function that computes the actual inradius
-        def inradiusActual(width, length, height, shape):
-            return MeshVolumeRegion(
-                mesh=shape.mesh, dimensions=(width, length, height)
-            ).inradius
-
         # Define a helper function that computes the support of the inradius,
         # given the sub supports.
         def inradiusSupport(width_s, length_s, height_s, shape_s):
@@ -1310,14 +1304,15 @@ class Object(OrientedPoint):
 
             return distance_range
 
-        # Return either the inradius or a FunctionDistribution using the above helpers
-        args = toDistribution((self.width, self.length, self.height, self.shape))
-        if not isLazy(args):
-            return inradiusActual(*args)
-        else:
-            return FunctionDistribution(
-                args=args, kwargs={}, func=inradiusActual, support=inradiusSupport
-            )
+        # Define a helper function that computes the actual inradius
+        @distributionFunction(support=inradiusSupport)
+        def inradiusActual(width, length, height, shape):
+            return MeshVolumeRegion(
+                mesh=shape.mesh, dimensions=(width, length, height)
+            ).inradius
+
+        # Return the inradius (possibly a distribution) with proper support information
+        return inradiusActual(self.width, self.length, self.height, self.shape)
 
     @cached_property
     def planarInradius(self):
@@ -1327,12 +1322,6 @@ class Object(OrientedPoint):
         of this object projected into the XY plane, assuming that pitch and
         roll are both 0.
         """
-
-        # Define a helper function that computes the actual planarInradius
-        def planarInradiusActual(width, length, shape):
-            return MeshVolumeRegion(
-                mesh=shape.mesh, dimensions=(width, length, 1)
-            ).boundingPolygon.inradius
 
         # Define a helper function that computes the support of the inradius,
         # given the sub supports.
@@ -1377,17 +1366,15 @@ class Object(OrientedPoint):
 
             return distance_range
 
-        # Return either the inradius or a FunctionDistribution using the above helpers
-        args = toDistribution((self.width, self.length, self.shape))
-        if not isLazy(args):
-            return planarInradiusActual(*args)
-        else:
-            return FunctionDistribution(
-                args=args,
-                kwargs={},
-                func=planarInradiusActual,
-                support=planarInradiusSupport,
-            )
+        # Define a helper function that computes the actual planarInradius
+        @distributionFunction(support=planarInradiusSupport)
+        def planarInradiusActual(width, length, shape):
+            return MeshVolumeRegion(
+                mesh=shape.mesh, dimensions=(width, length, 1)
+            ).boundingPolygon.inradius
+
+        # Return the planar inradius (possibly a distribution) with proper support information
+        return planarInradiusActual(self.width, self.length, self.shape)
 
     @cached_property
     def surface(self):

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1290,12 +1290,13 @@ class Object(OrientedPoint):
         # Extract a list of possible shapes
         if isinstance(shape, Shape):
             shapes = [shape]
-        elif isinstance(shape, MultiplexerDistribution):
-            if all(isinstance(opt, Shape) for opt in shape.options):
-                shapes = shape.options
-            else:
-                # Something we don't recognize, abort
-                return 0
+        elif isinstance(shape, MultiplexerDistribution) and all(
+            isinstance(opt, Shape) for opt in shape.options
+        ):
+            shapes = shape.options
+        else:
+            # Something we don't recognize, abort
+            return 0
 
         # Check that all possible shapes contain the origin
         if not all(shape.containsCenter for shape in shapes):

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1265,7 +1265,7 @@ class Object(OrientedPoint):
             )
             return shapeRegion.inradius
 
-        # If we havea uniform distribution over shapes and a supportInterval for each dimension,
+        # If we have a uniform distribution over shapes and a supportInterval for each dimension,
         # we can compute a supportInterval for this object's inradius
 
         # Define helper class

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1321,7 +1321,8 @@ class Object(OrientedPoint):
         """A lower bound on the planar inradius of this object.
 
         This is defined as the inradius of the polygon of the occupiedSpace
-        of this object projected into the XY plane.
+        of this object projected into the XY plane, assuming that pitch and
+        roll are both 0.
         """
         # First check if all needed variables are defined. If so, we can
         # compute the inradius exactly.

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -236,12 +236,10 @@ def pruneContainment(scenario, verbosity):
 
                 # Erode the voxel region. Erosion is done with a rank 3 structuring unit with
                 # connectivity 3 (a 3x3x3 cube of voxels). Each erosion pass can erode by at
-                # most math.hypot([1.5*pitch]*3). Therefore we can safely make at most
-                # floor(maxErosion/math.hypot([1.5*pitch]*3)) passes without eroding more
+                # most math.hypot([pitch]*3). Therefore we can safely make at most
+                # floor(maxErosion/math.hypot([pitch]*3)) passes without eroding more
                 # than maxErosion.
-                iterations = math.floor(
-                    maxErosion / math.hypot(*([1.5 * target_pitch] * 3))
-                )
+                iterations = math.floor(maxErosion / math.hypot(*([target_pitch] * 3)))
                 eroded_container = voxelized_container.erode(iterations=iterations)
 
                 # Now check if this erosion is useful, i.e. do we have less volume to sample from.

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -431,7 +431,7 @@ def pruneVisibility(scenario, verbosity):
             if (
                 base is not ego.visibleRegion
                 and not needsSampling(ego.visibleRegion)
-                and not checkCyclical(scenario, base, ego.visibleRegion)
+                and not checkCyclical(base, ego.visibleRegion)
             ):
                 if verbosity >= 1:
                     print(
@@ -446,7 +446,7 @@ def pruneVisibility(scenario, verbosity):
             if (
                 base is not obj._observingEntity.visibleRegion
                 and not needsSampling(obj._observingEntity.visibleRegion)
-                and not checkCyclical(scenario, base, obj._observingEntity.visibleRegion)
+                and not checkCyclical(base, obj._observingEntity.visibleRegion)
             ):
                 if verbosity >= 1:
                     print(
@@ -596,15 +596,11 @@ def percentagePruned(base, newBase):
     return None
 
 
-def checkCyclical(scenario, A, B):
+def checkCyclical(A, B):
     """Check for a potential circular dependency
 
     Returns True if the scenario would have a circular dependency
     if A depended on B.
-
-    This function runs DFS on the scenario, with the dependency edges
-    reversed for convenience (this should not affect whether or not a
-    cycle exists).
     """
     state = collections.defaultdict(lambda: 0)
 
@@ -621,10 +617,10 @@ def checkCyclical(scenario, A, B):
         # Recurse on children
         deps = conditionedDeps(target)
 
-        if target is A:
-            deps.append(B)
-
         for child in deps:
+            if child is A:
+                return True
+
             if dfs(child):
                 return True
 
@@ -633,7 +629,7 @@ def checkCyclical(scenario, A, B):
 
         return False
 
-    return dfs(scenario)
+    return dfs(B)
 
 
 def conditionedDeps(samp):

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -146,6 +146,8 @@ def matchPolygonalField(heading, position):
 
 
 ### Pruning procedures
+
+
 def prune(scenario, verbosity=1):
     """Prune a `Scenario`, removing infeasible parts of the space.
 

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -216,15 +216,13 @@ def pruneContainment(scenario, verbosity):
             # For most regions, use full object inradius.
             minRadius, _ = supportInterval(obj.inradius)
 
-        # Erode the container region if possible.
-        if (
-            hasattr(container, "buffer")
-            and maxDistance is not None
-            and minRadius is not None
-        ):
-            maxErosion = minRadius - maxDistance
-            if maxErosion > 0:
-                container = container.buffer(-maxErosion)
+        # Erode the container if possible
+        if maxDistance is not None and minRadius is not None:
+            if hasattr(container, "buffer"):
+                # We can do an exact erosion
+                maxErosion = minRadius - maxDistance
+                if maxErosion > 0:
+                    container = container.buffer(-maxErosion)
 
         # Restrict the base region to the container, unless
         # they're the same in which case we're done
@@ -242,23 +240,24 @@ def pruneContainment(scenario, verbosity):
         if isinstance(newBase, EmptyRegion):
             raise InvalidScenarioError(f"Object {obj} does not fit in container")
 
-        if verbosity >= 1:
-            if (
-                base.dimensionality is None
-                or newBase.dimensionality is None
-                or base.dimensionality != newBase.dimensionality
-            ):
+        if (
+            base.dimensionality is None
+            or newBase.dimensionality is None
+            or base.dimensionality != newBase.dimensionality
+        ):
+            if verbosity >= 1:
                 print(
                     f"    Region containment constraint pruning attempted but could not compute percentage for {base} and {newBase}."
                 )
-            elif base.dimensionality == newBase.dimensionality:
-                ratio = newBase.size / base.size
-                percent = max(0, 100 * (1.0 - ratio))
+        elif base.dimensionality == newBase.dimensionality:
+            ratio = newBase.size / base.size
+            percent = max(0, 100 * (1.0 - ratio))
 
-                if percent <= 0.001:
-                    # We didn't really prune anything, don't bother setting new position
-                    continue
+            if percent <= 0.001:
+                # We didn't really prune anything, don't bother setting new position
+                continue
 
+            if verbosity >= 1:
                 print(
                     f"    Region containment constraint pruned {percent:.1f}% of space."
                 )

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -160,7 +160,7 @@ def prune(scenario, verbosity=1):
 
     pruneContainment(scenario, verbosity)
     pruneRelativeHeading(scenario, verbosity)
-    pruneVisibility(scenario, verbosity)
+    # pruneVisibility(scenario, verbosity)
 
     if verbosity >= 1:
         totalTime = time.time() - startTime

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -410,8 +410,11 @@ def pruneVisibility(scenario, verbosity):
 
         if obj._observingEntity:
             # We can restrict the base region to the visible region
-            # of the observing entity.
-            if base is not obj._observingEntity.visibleRegion:
+            # of the observing entity. Only do this if the visible
+            # region is fixed, to avoid creating it at every timestep.
+            if base is not obj._observingEntity.visibleRegion and not needsSampling(
+                obj._observingEntity.visibleRegion
+            ):
                 if verbosity >= 1:
                     print(
                         f"    Pruning restricted base region of {obj} to visible region of {obj._observingEntity}."
@@ -420,12 +423,14 @@ def pruneVisibility(scenario, verbosity):
 
         if obj._nonObservingEntity:
             # We can subtract the visible region of the observing entity
-            # from the base region.
-            if verbosity >= 1:
-                print(
-                    f"    Pruning subtracted visible region of {obj._nonObservingEntity} from base region of {obj}."
-                )
-            newBase = newBase.difference(obj._nonObservingEntity.visibleRegion)
+            # from the base region. Only do this if the visible region
+            # is fixed, to avoid creating it at every timestep.
+            if not needsSampling(obj._nonObservingEntity.visibleRegion):
+                if verbosity >= 1:
+                    print(
+                        f"    Pruning subtracted visible region of {obj._nonObservingEntity} from base region of {obj}."
+                    )
+                newBase = newBase.difference(obj._nonObservingEntity.visibleRegion)
 
         # Check newBase properties
         if isinstance(newBase, EmptyRegion):

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -197,9 +197,8 @@ def pruneContainment(scenario, verbosity):
             raise InvalidScenarioError(f"Object {obj} contained in empty region")
 
         # Compute the maximum distance the object can be from the sampled point
-        # TODO: Proper vector supportInterval calculations. Right now this gives us None
-        # if value is not exact
         if offset is not None:
+            # TODO: Support interval doesn't really work here for random values.
             if isinstance(base, PolygonalRegion):
                 # Special handling for 2D regions that ignores vertical component of offset
                 offset_2d = Vector(offset.x, offset.y, 0)

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -47,11 +47,11 @@ from scenic.core.vectors import (
 from scenic.core.workspaces import Workspace
 from scenic.syntax.relations import DistanceRelation, RelativeHeadingRelation
 
-### Utilities
-
+### Constants
 PRUNING_PITCH = 0.01
 
 
+### Utilities
 def currentPropValue(obj, prop):
     """Get the current value of an object's property, taking into account prior pruning."""
     value = getattr(obj, prop)

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -212,8 +212,13 @@ def pruneContainment(scenario, verbosity):
 
         # Compute the minimum radius of the object, with respect to the
         # bounded dimensions of the container.
-        if isinstance(base, PolygonalRegion):
-            # Special handling for 2D regions, using planar inradius instead.
+        if (
+            isinstance(base, PolygonalRegion)
+            and supportInterval(obj.pitch) == (0, 0)
+            and supportInterval(obj.roll) == (0, 0)
+        ):
+            # Special handling for 2D regions with no pitch or roll,
+            # using planar inradius instead.
             minRadius, _ = supportInterval(obj.planarInradius)
         else:
             # For most regions, use full object inradius.

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -160,7 +160,7 @@ def prune(scenario, verbosity=1):
 
     pruneContainment(scenario, verbosity)
     pruneRelativeHeading(scenario, verbosity)
-    # pruneVisibility(scenario, verbosity)
+    pruneVisibility(scenario, verbosity)
 
     if verbosity >= 1:
         totalTime = time.time() - startTime
@@ -389,7 +389,8 @@ def pruneVisibility(scenario, verbosity):
 
     for obj in scenario.objects:
         # Extract the base region if it exists
-        base, offset = matchInRegion(obj.position)
+        position = currentPropValue(obj, "position")
+        base, offset = matchInRegion(position)
 
         if base is None or needsSampling(base):
             continue

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -9,7 +9,6 @@ import math
 import time
 
 import numpy
-import scipy
 import shapely.geometry
 import shapely.geos
 from trimesh.transformations import translation_matrix
@@ -220,49 +219,35 @@ def pruneContainment(scenario, verbosity):
             # For most regions, use full object inradius.
             minRadius, _ = supportInterval(obj.inradius)
 
-        # Compute the maximum safe erosion
-        maxErosion = minRadius - maxDistance
-
         # Erode the container if possible and productive
-        if maxDistance is not None and minRadius is not None and maxErosion > 0:
+        if (
+            maxDistance is not None
+            and minRadius is not None
+            and (maxErosion := minRadius - maxDistance) > 0
+        ):
             if hasattr(container, "buffer"):
                 # We can do an exact erosion
                 container = container.buffer(-maxErosion)
             elif isinstance(container, MeshVolumeRegion):
                 # We can attempt to erode a voxel approximation of the MeshVolumeRegion.
                 # Compute a voxel overapproximation of the mesh.
-                container_mesh = container.mesh
-                target_pitch = 0.005 * max(container_mesh.extents)
-                container_voxels = container_mesh.voxelized(target_pitch).fill()
-                voxelized_container = VoxelRegion(voxelGrid=container_voxels)
+                target_pitch = 0.005 * max(container.mesh.extents)
+                voxelized_container = container.voxelized(target_pitch)
 
                 # Erode the voxel region. Erosion is done with a rank 3 structuring unit with
                 # connectivity 3 (a 3x3x3 cube of voxels). Each erosion pass can erode by at
                 # most math.hypot([1.5*pitch]*3). Therefore we can safely make at most
                 # floor(maxErosion/math.hypot([1.5*pitch]*3)) passes without eroding more
                 # than maxErosion.
-                structure = scipy.ndimage.generate_binary_structure(3, 3)
                 iterations = math.floor(
                     maxErosion / math.hypot(*([1.5 * target_pitch] * 3))
                 )
-                eroded_voxelized_container = voxelized_container.erode(
-                    structure=structure, iterations=iterations
-                )
-
-                print("Original Volume:", container_mesh.volume)
-                print("Voxelized Volume:", voxelized_container.volume)
-                print("Eroded Volume:", eroded_voxelized_container.volume)
+                eroded_container = voxelized_container.erode(iterations=iterations)
 
                 # Now check if this erosion is useful, i.e. do we have less volume to sample from.
                 # If so, replace the original container.
-                if eroded_container.volume < container.volume:
-                    container = eroded_voxelized_container
-
-                # import trimesh
-                # render_scene = trimesh.scene.Scene()
-                # render_scene.add_geometry(eroded_voxelized_container.voxelGrid.as_boxes())
-                # render_scene.add_geometry(container_mesh)
-                # render_scene.show()
+                if eroded_container.size < container.size:
+                    container = eroded_container
 
         # Restrict the base region to the possibly eroded container, unless
         # they're the same in which case we're done

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -49,6 +49,8 @@ from scenic.syntax.relations import DistanceRelation, RelativeHeadingRelation
 
 ### Utilities
 
+PRUNING_PITCH = 0.01
+
 
 def currentPropValue(obj, prop):
     """Get the current value of an object's property, taking into account prior pruning."""
@@ -237,8 +239,8 @@ def pruneContainment(scenario, verbosity):
                 # an overapproximation, but one dilation with a rank 3 structuring unit
                 # with connectivity 3 is. To simplify, we just erode one less time than
                 # needed.
-                target_pitch = 0.005 * max(container.mesh.extents)
-                voxelized_container = container.voxelized(target_pitch)
+                target_pitch = PRUNING_PITCH * max(container.mesh.extents)
+                voxelized_container = container.voxelized(target_pitch, lazy=True)
 
                 # Erode the voxel region. Erosion is done with a rank 3 structuring unit with
                 # connectivity 3 (a 3x3x3 cube of voxels). Each erosion pass can erode by at
@@ -407,8 +409,8 @@ def pruneVisibility(scenario, verbosity):
             # Compute a voxel overapproximation of the mesh. Technically this is not
             # an overapproximation, but one dilation with a rank 3 structuring unit
             # with connectivity 3 is. To simplify, we just dilate one additional time.
-            target_pitch = 0.005 * max(viewRegion.mesh.extents)
-            voxelized_vr = viewRegion.voxelized(target_pitch)
+            target_pitch = PRUNING_PITCH * max(viewRegion.mesh.extents)
+            voxelized_vr = viewRegion.voxelized(target_pitch, lazy=True)
 
             # Dilate the voxel region. Dilation is done with a rank 3 structuring unit with
             # connectivity 3 (a 3x3x3 cube of voxels). Each dilation pass must dilate by at

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2144,6 +2144,9 @@ class VoxelRegion(Region):
         return Vector(*offset_pt)
 
     def erode(self, iterations, structure=None):
+        if iterations == 0:
+            return self
+
         if structure == None:
             structure = scipy.ndimage.generate_binary_structure(3, 3)
 

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1737,6 +1737,7 @@ class MeshVolumeRegion(MeshRegion):
         return abs(dist)
 
     @cached_property
+    @distributionFunction
     def inradius(self):
         center_point = self.mesh.bounding_box.center_mass
 
@@ -2808,6 +2809,7 @@ class PolygonalRegion(Region):
         return math.hypot(dist2D, point[2] - self.z)
 
     @cached_property
+    @distributionFunction
     def inradius(self):
         minx, miny, maxx, maxy = self.polygons.bounds
         center = makeShapelyPoint(((minx + maxx) / 2, (maxy + miny) / 2))

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2080,63 +2080,20 @@ class VoxelRegion(Region):
 
     def __init__(
         self,
-        encoding=None,
-        dimensions=None,
-        position=None,
-        transform=None,
-        rotation=None,
-        voxelGrid=None,
+        voxelGrid,
         orientation=None,
         name=None,
     ):
-        # Copy parameters
-        self.encoding = encoding
-        self.dimensions = None if dimensions is None else toVector(dimensions)
-        self.position = None if position is None else toVector(position)
-        self.orientation = None if orientation is None else toDistribution(orientation)
-
-        # Initialize superclass with samplables
-        super().__init__(
-            name, self.encoding, self.dimensions, self.position, orientation=orientation
-        )
+        # Initialize superclass
+        super().__init__(name, orientation=orientation)
 
         # If our region isn't fixed yet, then compute other values later
         if isLazy(self):
             return
 
-        if voxelGrid is not None:
-            self._voxelGrid = voxelGrid
-        else:
-            # Ensure encoding is a numpy array
-            if not isinstance(self.encoding, numpy.ndarray):
-                raise ValueError("The 'encoding' parameter must be a numpy array.")
-
-            self._voxelGrid = trimesh.voxel.VoxelGrid(self.encoding)
-
-            # Center voxel grid
-
-            centering_matrix = translation_matrix(
-                (self._voxelGrid.scale - self._voxelGrid.extents) / 2
-            )
-            self._voxelGrid.apply_transform(centering_matrix)
-
-            # If dimensions are provided, scale mesh to those dimension
-            if self.dimensions is not None:
-                scale = self._voxelGrid.extents / numpy.array(self.dimensions)
-
-                scale_matrix = numpy.eye(4)
-                scale_matrix[:3, :3] /= scale
-
-                self._voxelGrid.apply_transform(scale_matrix)
-
-            # If position is provided, translate mesh to that position.
-            if self.position is not None:
-                position_matrix = translation_matrix(self.position)
-                self._voxelGrid.apply_transform(position_matrix)
-
         # Work around Trimesh caching bug
         self._voxelGrid = trimesh.voxel.VoxelGrid(
-            self._voxelGrid.encoding, transform=self._voxelGrid.transform.copy()
+            voxelGrid.encoding, transform=voxelGrid.transform.copy()
         )
 
         # Check that the encoding isn't empty. In that case, raise an error.

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2680,6 +2680,18 @@ class PolygonalRegion(Region):
         dist2D = shapely.distance(self.polygons, makeShapelyPoint(point))
         return math.hypot(dist2D, point[2] - self.z)
 
+    @cached_property
+    def inradius(self):
+        minx, miny, maxx, maxy = self.polygons.bounds
+        center = makeShapelyPoint(((minx + maxx) / 2, (maxy + miny) / 2))
+
+        # Check if center is contained
+        if not self.polygons.contains(center):
+            return 0
+
+        # Return the distance to the nearest boundary
+        return shapely.distance(self.polygons.boundary, center)
+
     def projectVector(self, point, onDirection):
         raise NotImplementedError(
             f'{type(self).__name__} does not yet support projection using "on"'

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2088,10 +2088,6 @@ class VoxelRegion(Region):
         self.voxel_points = self.voxelGrid.points
         self.scale = self.voxelGrid.scale
 
-        # Initialize KD-Tree for containment checking if not lazy
-        if not lazy:
-            self.kdTree
-
     @cached_property
     def kdTree(self):
         return scipy.spatial.KDTree(self.voxel_points)

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1757,6 +1757,10 @@ class MeshVolumeRegion(MeshRegion):
         return self.mesh.mass / self.mesh.density
 
     ## Utility Methods ##
+    def voxelized(self, pitch):
+        """Returns a VoxelRegion representing a filled voxelization of this mesh"""
+        return VoxelRegion(voxelGrid=self.mesh.voxelized(pitch).fill())
+
     @cached_method
     def getSurfaceRegion(self):
         """Return a region equivalent to this one, except as a MeshSurfaceRegion"""
@@ -2182,7 +2186,10 @@ class VoxelRegion(Region):
         # Then pick a random voxel point and add the base point to that point.
         return Vector(*offset_pt)
 
-    def erode(self, structure, iterations):
+    def erode(self, iterations, structure=None):
+        if structure == None:
+            structure = scipy.ndimage.generate_binary_structure(3, 3)
+
         # Compute an eroded encoding
         eroded_encoding = trimesh.voxel.encoding.DenseEncoding(
             scipy.ndimage.binary_erosion(
@@ -2211,7 +2218,7 @@ class VoxelRegion(Region):
         )
 
     @property
-    def volume(self):
+    def size(self):
         return self.voxelGrid.volume
 
     @property

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2173,6 +2173,14 @@ class VoxelRegion(Region):
         raw_aabb = (np_pos - self.dimensions[0] / 2, np_pos + self.dimensions[0] / 2)
         return tuple((raw_aabb[0][i], raw_aabb[1][i]) for i in range(3))
 
+    @property
+    def volume(self):
+        return self.voxelGrid.volume
+
+    @property
+    def dimensionality(self):
+        return 3
+
 
 class PolygonalFootprintRegion(Region):
     """Region that contains all points in a polygonal footprint, regardless of their z value.

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1739,7 +1739,7 @@ class MeshVolumeRegion(MeshRegion):
         center_point = self.mesh.bounding_box.center_mass
 
         pq = trimesh.proximity.ProximityQuery(self.mesh)
-        region_distance = abs(pq.signed_distance([center_point])[0])
+        region_distance = pq.signed_distance([center_point])[0]
 
         if region_distance < 0:
             return 0

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2087,10 +2087,6 @@ class VoxelRegion(Region):
         # Initialize superclass
         super().__init__(name, orientation=orientation)
 
-        # If our region isn't fixed yet, then compute other values later
-        if isLazy(self):
-            return
-
         # Work around Trimesh caching bug
         self._voxelGrid = trimesh.voxel.VoxelGrid(
             voxelGrid.encoding, transform=voxelGrid.transform.copy()

--- a/src/scenic/core/scenarios.py
+++ b/src/scenic/core/scenarios.py
@@ -469,6 +469,7 @@ class Scenario(_ScenarioPickleMixin):
             numpy.random.set_state(np_state)
 
             if rejection is not None:
+                # breakpoint()
                 optionallyDebugRejection()
 
         # obtained a valid sample; assemble a scene from it

--- a/src/scenic/core/scenarios.py
+++ b/src/scenic/core/scenarios.py
@@ -469,7 +469,6 @@ class Scenario(_ScenarioPickleMixin):
             numpy.random.set_state(np_state)
 
             if rejection is not None:
-                # breakpoint()
                 optionallyDebugRejection()
 
         # obtained a valid sample; assemble a scene from it

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -588,7 +588,7 @@ def test_mesh_voxelization(getAssetPath):
 def test_empty_erosion():
     box_region = BoxRegion(position=(0, 0, 0), dimensions=(1, 1, 1))
     vr = box_region.voxelized(pitch=0.1)
-    erosion = vr.erode(iterations=6)
+    erosion = vr.dilation(iterations=-6)
     assert isinstance(erosion, EmptyRegion)
 
 

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -548,7 +548,7 @@ def test_voxel_region():
         encoding=numpy.asarray(encoding), dimensions=(5, 5, 5), position=(4, 5, 6)
     )
 
-    assert vr2.volume == pytest.approx(7 * (5 / 3) ** 3)
+    assert vr2.size == pytest.approx(7 * (5 / 3) ** 3)
     assert vr2.dimensionality == 3
 
 
@@ -563,6 +563,13 @@ def test_mesh_voxelization(getAssetPath):
     for _ in range(100):
         sampled_pt = vr.uniformPointInner()
         assert vr.containsPoint(sampled_pt)
+
+
+def test_empty_erosion():
+    box_region = BoxRegion(position=(0, 0, 0), dimensions=(1, 1, 1))
+    vr = box_region.voxelized(pitch=0.1)
+    erosion = vr.erode(iterations=6)
+    assert isinstance(erosion, EmptyRegion)
 
 
 # ViewRegion tests

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -552,6 +552,19 @@ def test_voxel_region():
     assert vr2.dimensionality == 3
 
 
+def test_mesh_voxelization(getAssetPath):
+    plane_region = MeshVolumeRegion.fromFile(getAssetPath("meshes/classic_plane.obj.bz2"))
+    voxel_grid = plane_region.mesh.voxelized(max(plane_region.mesh.extents) / 100).fill()
+    vr = VoxelRegion(voxelGrid=voxel_grid)
+
+    for sampled_pt in trimesh.sample.volume_mesh(plane_region.mesh, 100):
+        assert vr.containsPoint(sampled_pt)
+
+    for _ in range(100):
+        sampled_pt = vr.uniformPointInner()
+        assert vr.containsPoint(sampled_pt)
+
+
 # ViewRegion tests
 H_ANGLES = [0.1, 45, 90, 135, 179.9, 180, 180.1, 225, 270, 315, 359.9, 360]
 

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -521,6 +521,30 @@ def test_pointset_region():
     assert ps.AABB == ((1, 5), (2, 6), (0, 5))
 
 
+def test_voxel_region():
+    encoding = [
+        [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+        [[0, 1, 1], [0, 1, 0], [1, 1, 0]],
+        [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
+    ]
+    vr = VoxelRegion(
+        encoding=numpy.asarray(encoding), dimensions=(3, 3, 3), position=(4, 5, 6)
+    )
+
+    assert vr.containsPoint((4, 5, 6))
+    assert vr.containsPoint((4, 6, 5))
+    assert vr.containsPoint((4, 4, 7))
+    assert not vr.containsPoint((4, 6, 7))
+    assert not vr.containsPoint((4, 4, 5))
+    assert not vr.containsPoint((100, 100, 100))
+
+    for _ in range(100):
+        sampled_pt = vr.uniformPointInner()
+        assert vr.containsPoint(sampled_pt)
+
+    assert vr.AABB == ((2.5, 5.5), (3.5, 6.5), (4.5, 7.5))
+
+
 # ViewRegion tests
 H_ANGLES = [0.1, 45, 90, 135, 179.9, 180, 180.1, 225, 270, 315, 359.9, 360]
 

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -574,8 +574,7 @@ def test_voxel_region():
 
 def test_mesh_voxelization(getAssetPath):
     plane_region = MeshVolumeRegion.fromFile(getAssetPath("meshes/classic_plane.obj.bz2"))
-    voxel_grid = plane_region.mesh.voxelized(max(plane_region.mesh.extents) / 100).fill()
-    vr = VoxelRegion(voxelGrid=voxel_grid)
+    vr = plane_region.voxelized(max(plane_region.mesh.extents) / 100)
 
     for sampled_pt in trimesh.sample.volume_mesh(plane_region.mesh, 100):
         assert vr.containsPoint(sampled_pt)

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -527,22 +527,29 @@ def test_voxel_region():
         [[0, 1, 1], [0, 1, 0], [1, 1, 0]],
         [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
     ]
-    vr = VoxelRegion(
+    vr1 = VoxelRegion(
         encoding=numpy.asarray(encoding), dimensions=(3, 3, 3), position=(4, 5, 6)
     )
 
-    assert vr.containsPoint((4, 5, 6))
-    assert vr.containsPoint((4, 6, 5))
-    assert vr.containsPoint((4, 4, 7))
-    assert not vr.containsPoint((4, 6, 7))
-    assert not vr.containsPoint((4, 4, 5))
-    assert not vr.containsPoint((100, 100, 100))
+    assert vr1.containsPoint((4, 5, 6))
+    assert vr1.containsPoint((4, 6, 5))
+    assert vr1.containsPoint((4, 4, 7))
+    assert not vr1.containsPoint((4, 6, 7))
+    assert not vr1.containsPoint((4, 4, 5))
+    assert not vr1.containsPoint((100, 100, 100))
 
     for _ in range(100):
-        sampled_pt = vr.uniformPointInner()
-        assert vr.containsPoint(sampled_pt)
+        sampled_pt = vr1.uniformPointInner()
+        assert vr1.containsPoint(sampled_pt)
 
-    assert vr.AABB == ((2.5, 5.5), (3.5, 6.5), (4.5, 7.5))
+    assert vr1.AABB == ((2.5, 5.5), (3.5, 6.5), (4.5, 7.5))
+
+    vr2 = VoxelRegion(
+        encoding=numpy.asarray(encoding), dimensions=(5, 5, 5), position=(4, 5, 6)
+    )
+
+    assert vr2.volume == pytest.approx(7 * (5 / 3) ** 3)
+    assert vr2.dimensionality == 3
 
 
 # ViewRegion tests

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -527,9 +527,21 @@ def test_voxel_region():
         [[0, 1, 1], [0, 1, 0], [1, 1, 0]],
         [[0, 0, 0], [0, 1, 0], [0, 0, 0]],
     ]
-    vr1 = VoxelRegion(
-        encoding=numpy.asarray(encoding), dimensions=(3, 3, 3), position=(4, 5, 6)
-    )
+
+    vg1 = trimesh.voxel.VoxelGrid(encoding=numpy.asarray(encoding))
+
+    centering_matrix = translation_matrix((vg1.scale - vg1.extents) / 2)
+    vg1.apply_transform(centering_matrix)
+
+    scale = vg1.extents / numpy.array((3, 3, 3))
+    scale_matrix = numpy.eye(4)
+    scale_matrix[:3, :3] /= scale
+    vg1.apply_transform(scale_matrix)
+
+    position_matrix = translation_matrix((4, 5, 6))
+    vg1.apply_transform(position_matrix)
+
+    vr1 = VoxelRegion(vg1)
 
     assert vr1.containsPoint((4, 5, 6))
     assert vr1.containsPoint((4, 6, 5))
@@ -544,11 +556,19 @@ def test_voxel_region():
 
     assert vr1.AABB == ((2.5, 5.5), (3.5, 6.5), (4.5, 7.5))
 
-    vr2 = VoxelRegion(
-        encoding=numpy.asarray(encoding), dimensions=(5, 5, 5), position=(4, 5, 6)
-    )
+    vg2 = trimesh.voxel.VoxelGrid(encoding=numpy.asarray(encoding))
 
-    assert vr2.size == pytest.approx(7 * (5 / 3) ** 3)
+    centering_matrix = translation_matrix((vg2.scale - vg2.extents) / 2)
+    vg2.apply_transform(centering_matrix)
+
+    scale = vg2.extents / numpy.array((5, 5, 3))
+    scale_matrix = numpy.eye(4)
+    scale_matrix[:3, :3] /= scale
+    vg2.apply_transform(scale_matrix)
+
+    vr2 = VoxelRegion(vg2)
+
+    assert vr2.size == pytest.approx((7 / 27) * 5 * 5 * 3)
     assert vr2.dimensionality == 3
 
 

--- a/tests/syntax/test_properties.py
+++ b/tests/syntax/test_properties.py
@@ -159,8 +159,8 @@ def test_object_inradius():
     scenario = compileScenic(
         """
         import trimesh
-        hollow_mesh = trimesh.creation.icosphere().difference(
-            trimesh.creation.icosphere(radius=0.5))
+        hollow_mesh = trimesh.creation.box((1,1,1)).difference(
+            trimesh.creation.box((0.5,0.5,0.5)))
         ego = new Object with width 3, with length 3, with height 3,
             facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
             with shape MeshShape(hollow_mesh)
@@ -174,8 +174,8 @@ def test_object_inradius():
     scenario = compileScenic(
         """
         import trimesh
-        hollow_mesh = trimesh.creation.icosphere().difference(
-            trimesh.creation.icosphere(radius=0.5))
+        hollow_mesh = trimesh.creation.box((1,1,1)).difference(
+            trimesh.creation.box((0.5,0.5,0.5)))
         ego = new Object with width Range(1, 3),
             with length Range(1, 3), with height Range(1, 3),
             facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
@@ -185,3 +185,63 @@ def test_object_inradius():
     ego = sampleEgo(scenario)
     assert supportInterval(scenario.objects[0].inradius) == (0, 0)
     assert ego.inradius == 0
+
+
+def test_object_planarInradius():
+    # Statically Sized Cube Example
+    scenario = compileScenic(
+        """
+        ego = new Object with width 3, with length 3, with height 0.5,
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert supportInterval(scenario.objects[0].planarInradius) == (1.5, 1.5)
+    assert ego.planarInradius == 1.5
+
+    # Randomly Sized Cube Example
+    scenario = compileScenic(
+        """
+        ego = new Object with width Range(1, 3),
+            with length Range(1, 3), with height Range(0.25, 0.5),
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert supportInterval(scenario.objects[0].planarInradius) == (0.5, 1.5)
+    assert ego.planarInradius == pytest.approx(min(ego.width, ego.length) / 2)
+
+    # Hollow Static Object Example
+    scenario = compileScenic(
+        """
+        import trimesh
+        hollow_mesh = trimesh.creation.box((1,1,1)).difference(
+            trimesh.creation.box((0.5,0.5,0.5)))
+        ego = new Object with width 3, with length 3, with height 0.5,
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
+            with shape MeshShape(hollow_mesh)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert supportInterval(scenario.objects[0].planarInradius) == pytest.approx(
+        (1.5, 1.5)
+    )
+    assert ego.planarInradius == pytest.approx(1.5)
+
+    # Hollow Random Object Example
+    scenario = compileScenic(
+        """
+        import trimesh
+        hollow_mesh = trimesh.creation.box((1,1,1)).difference(
+            trimesh.creation.box((0.5,0.5,0.5)))
+        ego = new Object with width Range(1, 3),
+            with length Range(1, 3), with height Range(0.25, 0.5),
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
+            with shape MeshShape(hollow_mesh)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert supportInterval(scenario.objects[0].planarInradius) == pytest.approx(
+        (0.5, 1.5)
+    )
+    assert ego.planarInradius == pytest.approx(min(ego.width, ego.length) / 2)

--- a/tests/syntax/test_properties.py
+++ b/tests/syntax/test_properties.py
@@ -186,7 +186,6 @@ def test_object_inradius():
         """
     )
     ego = sampleEgo(scenario)
-    assert isinstance(scenario.objects[0].inradius, Distribution)
     assert supportInterval(scenario.objects[0].inradius) == (0, 0)
     assert ego.inradius == 0
 

--- a/tests/syntax/test_properties.py
+++ b/tests/syntax/test_properties.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from scenic.core.distributions import supportInterval
+from scenic.core.distributions import Distribution, supportInterval
 from scenic.core.errors import SpecifierError
 from tests.utils import compileScenic, sampleEgo, sampleEgoFrom
 
@@ -140,6 +140,7 @@ def test_object_inradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert scenario.objects[0].inradius == 1.5
     assert supportInterval(scenario.objects[0].inradius) == (1.5, 1.5)
     assert ego.inradius == 1.5
 
@@ -152,6 +153,7 @@ def test_object_inradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].inradius, Distribution)
     assert supportInterval(scenario.objects[0].inradius) == (0.5, 1.5)
     assert ego.inradius == pytest.approx(min(ego.width, ego.length, ego.height) / 2)
 
@@ -167,6 +169,7 @@ def test_object_inradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert scenario.objects[0].inradius == 0
     assert supportInterval(scenario.objects[0].inradius) == (0, 0)
     assert ego.inradius == 0
 
@@ -183,8 +186,24 @@ def test_object_inradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].inradius, Distribution)
     assert supportInterval(scenario.objects[0].inradius) == (0, 0)
     assert ego.inradius == 0
+
+    # Random Shape Example
+    scenario = compileScenic(
+        """
+        import trimesh
+        annulus_shape = MeshShape(trimesh.creation.annulus(0.5,1,1))
+        ego = new Object with width Range(1, 3),
+            with length Range(1, 3), with height Range(1, 3),
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
+            with shape Uniform(BoxShape(), annulus_shape)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].inradius, Distribution)
+    assert supportInterval(scenario.objects[0].inradius) == (0, 1.5)
 
 
 def test_object_planarInradius():
@@ -196,6 +215,7 @@ def test_object_planarInradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert scenario.objects[0].planarInradius == 1.5
     assert supportInterval(scenario.objects[0].planarInradius) == (1.5, 1.5)
     assert ego.planarInradius == 1.5
 
@@ -208,6 +228,7 @@ def test_object_planarInradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].planarInradius, Distribution)
     assert supportInterval(scenario.objects[0].planarInradius) == (0.5, 1.5)
     assert ego.planarInradius == pytest.approx(min(ego.width, ego.length) / 2)
 
@@ -223,6 +244,7 @@ def test_object_planarInradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert scenario.objects[0].planarInradius == pytest.approx(1.5)
     assert supportInterval(scenario.objects[0].planarInradius) == pytest.approx(
         (1.5, 1.5)
     )
@@ -241,7 +263,23 @@ def test_object_planarInradius():
         """
     )
     ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].planarInradius, Distribution)
     assert supportInterval(scenario.objects[0].planarInradius) == pytest.approx(
         (0.5, 1.5)
     )
     assert ego.planarInradius == pytest.approx(min(ego.width, ego.length) / 2)
+
+    # Random Shape Example
+    scenario = compileScenic(
+        """
+        import trimesh
+        annulus_shape = MeshShape(trimesh.creation.annulus(0.5,1,1))
+        ego = new Object with width Range(1, 3),
+            with length Range(1, 3), with height Range(1, 3),
+            facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg),
+            with shape Uniform(BoxShape(), annulus_shape)
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert isinstance(scenario.objects[0].planarInradius, Distribution)
+    assert supportInterval(scenario.objects[0].planarInradius) == (0, 1.5)

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -57,22 +57,19 @@ def test_containment_2d_region():
     # that should be accounted for and the height is random.
     scenario = compileScenic(
         """
+        class TestObject:
+            baseOffset: (0.1, 0, self.height/2)
+
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
-        ego = new Object in workspace, with height Range(0.1,0.5),
-                with baseOffset (0.1,0,self.height/2)
+        ego = new Object in workspace, with height Range(0.1,0.5)
     """
     )
     # Sampling should fail ~30.56% of the time, so
     # 34 rejections are allowed to get the failure probability
-    # to ~1e-18. We want to see at least one sample with
-    # an x value in the range (0.4, 0.5), since that indicates
-    # that Scenic has not pruned too much by ignoring the entire
-    # baseOffset. The chance of a sample not being in this range
-    # is 90%, so we need 375 samples to get this probability
-    # down to ~1e-18.
-    xs = [sampleEgo(scenario, maxIterations=34).position.x for i in range(375)]
-    assert all(0.4 <= x <= 1.4 for x in xs)
-    assert any(0.4 <= x <= 0.5 for x in xs)
+    # to ~1e-18.
+    xs = [sampleEgo(scenario, maxIterations=34).position.x for i in range(60)]
+    assert all(0.5 <= x <= 1.5 for x in xs)
+    assert any(0.5 <= x <= 0.7 or 1.3 <= x <= 1.5 for x in xs)
 
 
 def test_containment_in_polyline():

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -4,6 +4,7 @@ import random
 import pytest
 
 from scenic.core.errors import InconsistentScenarioError
+from scenic.core.pruning import checkCyclical
 from scenic.core.vectors import Vector
 from tests.utils import compileScenic, sampleEgo, sampleParamP
 
@@ -209,7 +210,10 @@ def test_visibility_pruning():
 
 
 def test_visibility_pruning_cyclical():
-    """A case where a cyclical dependency could be introduced if pruning is not done carefully."""
+    """A case where a cyclical dependency could be introduced if pruning is not done carefully.
+
+    NOTE: We don't currently prune this case so this test is a sentinel for future behavior.
+    """
     scenario = compileScenic(
         """
         workspace = Workspace(PolygonalRegion([0@0, 100@0, 100@100, 0@100]))
@@ -217,4 +221,26 @@ def test_visibility_pruning_cyclical():
         ego = new Object visible from foo, in workspace
     """
     )
+
     sampleEgo(scenario, maxIterations=100)
+
+
+def test_checkCyclical():
+    scenario = compileScenic(
+        """
+        workspace = Workspace(PolygonalRegion([0@0, 100@0, 100@100, 0@100]))
+        foo = new Object in workspace
+        ego = new Object in workspace
+    """
+    )
+    assert not checkCyclical(scenario.objects[1].position, scenario.objects[0].position)
+
+    scenario = compileScenic(
+        """
+        workspace = Workspace(PolygonalRegion([0@0, 100@0, 100@100, 0@100]))
+        foo = new Object with requireVisible True, in workspace
+        ego = new Object visible from foo
+    """
+    )
+
+    assert checkCyclical(scenario.objects[1].position, scenario.objects[0].visibleRegion)

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -62,7 +62,7 @@ def test_containment_2d_region():
             baseOffset: (0.1, 0, self.height/2)
 
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
-        ego = new Object in workspace, with height Range(0.1,0.5)
+        ego = new TestObject on workspace, with height Range(0.1,0.5)
     """
     )
     # Sampling should fail ~30.56% of the time, so
@@ -166,9 +166,9 @@ def test_visibility_pruning():
     The following scenarios are equivalent except for how they specify that foo
     must be visible from ego. The size of the workspace and the visibleDistance
     of ego are chosen such that without pruning the chance of sampling a valid
-    scene over 100 tries is 1-(1-Decimal(3.14)/Decimal(10000000000**2))**100 = ~1e-18.
+    scene over 100 tries is 1-(1-Decimal(3.14)/Decimal(1e10**2))**100 = ~1e-18.
     Assuming the approximately buffered volume of the viewRegion has a 50% chance of
-    ejecting (i.e. it is twice as large as the true buffered viewRegion, which testing
+    rejecting (i.e. it is twice as large as the true buffered viewRegion, which testing
     indicates in this case has about a 10% increase in volume for this case), the chance
     of not finding a sample in 100 iterations is 1e-31.
 
@@ -176,13 +176,13 @@ def test_visibility_pruning():
     in the viewRegion instead of at any point where the object intersects the view region.
     Because of this, we want to see at least one sample where the position is outside
     the viewRegion but the object intersects the viewRegion. The chance of this happening
-    is 1-((4/3)*math.pi*(1)**3)/((4/3)*math.pi*(1.1)**3) = ~25%, so by repeating the process
-    30 times we have a 1e-19 chance of not gettin a single point in this zone.
+    per sample is 1 - (1 / 1.1)**3 = ~25%, so by repeating the process 30 times we have
+    a 1e-19 chance of not getting a single point in this zone.
     """
     # requireVisible
     scenario = compileScenic(
         """
-        workspace = Workspace(RectangularRegion(0@0, 0, 10000000000, 10000000000))
+        workspace = Workspace(RectangularRegion(0@0, 0, 1e10, 1e10))
         ego = new Object at (0,0,0), with visibleDistance 1
         foo = new Object in workspace, with requireVisible True,
             with shape SpheroidShape(dimensions=(0.2,0.2,0.2))
@@ -196,7 +196,7 @@ def test_visibility_pruning():
     # visible
     scenario = compileScenic(
         """
-        workspace = Workspace(RectangularRegion(0@0, 0, 10000000000, 10000000000))
+        workspace = Workspace(RectangularRegion(0@0, 0, 1e10, 1e10))
         ego = new Object at (0,0,0), with visibleDistance 1
         foo = new Object in workspace, visible,
             with shape SpheroidShape(dimensions=(0.2,0.2,0.2))

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -21,6 +21,25 @@ def test_containment_in():
     assert any(0.5 <= x <= 0.7 or 1.3 <= x <= 1.5 for x in xs)
 
 
+def test_containment_2d_region():
+    """Test pruning based on object containment in a 2D region.
+
+    Specifically tests that vertical portions of baseOffset are not added
+    to maxDistance, and that if objects are known to be flat in the plane,
+    their height is not considered as part of the minRadius.
+    """
+    scenario = compileScenic(
+        """
+        workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
+        ego = new Object in workspace, with height 100
+    """
+    )
+    # Sampling should only require 1 iteration after pruning
+    xs = [sampleEgo(scenario).position.x for i in range(60)]
+    assert all(0.5 <= x <= 1.5 for x in xs)
+    assert any(0.5 <= x <= 0.7 or 1.3 <= x <= 1.5 for x in xs)
+
+
 def test_containment_in_polyline():
     """As above, but when the object is placed on a polyline."""
     scenario = compileScenic(

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -28,16 +28,51 @@ def test_containment_2d_region():
     to maxDistance, and that if objects are known to be flat in the plane,
     their height is not considered as part of the minRadius.
     """
+    # Tests the effect of the vertical portion of baseOffset in a 2D region.
     scenario = compileScenic(
         """
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
-        ego = new Object in workspace, with height 100
+        ego = new Object on workspace
     """
     )
     # Sampling should only require 1 iteration after pruning
     xs = [sampleEgo(scenario).position.x for i in range(60)]
     assert all(0.5 <= x <= 1.5 for x in xs)
     assert any(0.5 <= x <= 0.7 or 1.3 <= x <= 1.5 for x in xs)
+
+    # Test height's effect in a 2D region.
+    scenario = compileScenic(
+        """
+        workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
+        ego = new Object in workspace, with height 0.1
+    """
+    )
+    # Sampling should only require 1 iteration after pruning
+    xs = [sampleEgo(scenario).position.x for i in range(60)]
+    assert all(0.5 <= x <= 1.5 for x in xs)
+    assert any(0.5 <= x <= 0.7 or 1.3 <= x <= 1.5 for x in xs)
+
+    # Test both combined, in a slightly more complicated case.
+    # Specifically, there is a non vertical component to baseOffset
+    # that should be accounted for and the height is random.
+    scenario = compileScenic(
+        """
+        workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
+        ego = new Object in workspace, with height Range(0.1,0.5),
+                with baseOffset (0.1,0,self.height/2)
+    """
+    )
+    # Sampling should fail ~30.56% of the time, so
+    # 34 rejections are allowed to get the failure probability
+    # to ~1e-18. We want to see at least one sample with
+    # an x value in the range (0.4, 0.5), since that indicates
+    # that Scenic has not pruned too much by ignoring the entire
+    # baseOffset. The chance of a sample not being in this range
+    # is 90%, so we need 375 samples to get this probability
+    # down to ~1e-18.
+    xs = [sampleEgo(scenario, maxIterations=34).position.x for i in range(375)]
+    assert all(0.4 <= x <= 1.4 for x in xs)
+    assert any(0.4 <= x <= 0.5 for x in xs)
 
 
 def test_containment_in_polyline():


### PR DESCRIPTION
This PR adds various pruning improvements, including:

- New type of inradius for objects projected into the plane.
- Improvements to containment pruning, which allows for pruning efficiency equal to what was present in Scenic 2.0 for 2D scenes, even without 3D mode.
- Added a VoxelRegion class, and the ability to approximately erode a mesh. This enables pruning for objects contained in meshes, though not optimally. Better pruning comes at a higher compile time cost, enabled by increasing `PRUNING_PITCH` in `pruning.py`.
- Added a limited version of pruning based on visibility. This can be expanded in a future PR, but currently only prunes when an object must be visible from a fixed object.

**Performance Note**: This appears to add only minor compile time slowdowns to our current examples, so I think it's unlikely to cause a performance regression. Any performance loss would only be at compile time, and would be offset by greater sampling efficiency. In my tests, voxelization during pruning is the only added expensive operation and it takes roughly one second (per voxelization) with the current pitch.