### PR TITLE
Serialization Fixes for 3D

### DIFF
--- a/src/scenic/core/type_support.py
+++ b/src/scenic/core/type_support.py
@@ -259,6 +259,8 @@ class TypecheckedDistribution(Distribution):
     `Point` will be converted to a `Vector` in a context which expects the latter).
     """
 
+    _deterministic = True
+
     def __init__(self, dist, ty, errorMessage, coercer=None):
         super().__init__(dist, valueType=ty)
         self._dist = dist

--- a/src/scenic/core/vectors.py
+++ b/src/scenic/core/vectors.py
@@ -390,7 +390,11 @@ class Orientation:
 
     @classmethod
     def decodeFrom(cls, stream):
-        return cls.fromQuaternion(struct.unpack("<dddd", stream.read(32)))
+        # Quaternion constructor does not roundtrip so we manually
+        # construct a rotation and pass that in.
+        quaternion = struct.unpack("<dddd", stream.read(32))
+        rotation = Rotation(quaternion, normalize=False)
+        return cls(rotation)
 
 
 globalOrientation = Orientation.fromEuler(0, 0, 0)

--- a/src/scenic/core/vectors.py
+++ b/src/scenic/core/vectors.py
@@ -384,6 +384,14 @@ class Orientation:
             return NotImplemented
         return abs(numpy.dot(self.q, other.q)) > 1 - tol
 
+    @classmethod
+    def encodeTo(cls, orientation, stream):
+        stream.write(struct.pack("<dddd", *orientation.q))
+
+    @classmethod
+    def decodeFrom(cls, stream):
+        return cls.fromQuaternion(struct.unpack("<dddd", stream.read(32)))
+
 
 globalOrientation = Orientation.fromEuler(0, 0, 0)
 

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -38,6 +38,12 @@ simpleScenario = """
     param baz = ({'a', 'b', 'c', 'd'}, frozenset({'e', 'f', 'g', 'h'}))
 """
 
+randomScenario = """
+    box = BoxRegion(dimensions=(5,5,5))
+    new Object in box, facing (Range(0,360) deg, Range(0,360) deg, Range(0,360) deg)
+    new Object on box.getSurfaceRegion()
+"""
+
 
 def skeleton(scene):
     # Simple picklable representation of the main parameters of the scene
@@ -196,6 +202,14 @@ class TestExportToBytes:
 
     def test_simple_scene(self):
         scenario = compileScenic(simpleScenario)
+        scene1 = sampleScene(scenario)
+        data = scenario.sceneToBytes(scene1)
+        scene2 = scenario.sceneFromBytes(data)
+        assert scenario.sceneToBytes(scene2) == data
+        assertSceneEquivalence(scene1, scene2)
+
+    def test_random_scene(self):
+        scenario = compileScenic(randomScenario)
         scene1 = sampleScene(scenario)
         data = scenario.sceneToBytes(scene1)
         scene2 = scenario.sceneFromBytes(data)

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -5,6 +5,7 @@ For pickling, see ``test_pickle.py`` and many other tests marked with
 """
 
 import io
+import math
 import random
 import subprocess
 import sys
@@ -36,12 +37,6 @@ simpleScenario = """
         with name "otherObject"
     param qux = ego.position
     param baz = ({'a', 'b', 'c', 'd'}, frozenset({'e', 'f', 'g', 'h'}))
-"""
-
-randomScenario = """
-    box = BoxRegion(dimensions=(5,5,5))
-    new Object in box, facing (Range(0,360) deg, Range(0,360) deg, Range(0,360) deg)
-    new Object on box.getSurfaceRegion()
 """
 
 
@@ -177,9 +172,12 @@ class TestExportToBytes:
         from scenic.simulators.utils.colors import Color
 
         checkValueEncoding(Color(0.5, 1.0, 0.2), Color)
-        from scenic.core.vectors import Vector
+        from scenic.core.vectors import Orientation, Vector
 
         checkValueEncoding(Vector(-7.5, 42), Vector)
+        checkValueEncoding(
+            Orientation.fromEuler(0.2 * math.pi, 0.6 * math.pi, 0), Orientation
+        )
 
         class Foo:
             def __init__(self, x):
@@ -208,8 +206,13 @@ class TestExportToBytes:
         assert scenario.sceneToBytes(scene2) == data
         assertSceneEquivalence(scene1, scene2)
 
-    def test_random_scene(self):
-        scenario = compileScenic(randomScenario)
+    def test_scene_random_orientation(self):
+        program = """
+            box = BoxRegion(dimensions=(5,5,5))
+            new Object in box, facing (Range(0,360) deg, Range(0,360) deg, Range(0,360) deg)
+            new Object on box.getSurfaceRegion()
+        """
+        scenario = compileScenic(program)
         scene1 = sampleScene(scenario, maxIterations=10)
         data = scenario.sceneToBytes(scene1)
         scene2 = scenario.sceneFromBytes(data)

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -210,7 +210,7 @@ class TestExportToBytes:
 
     def test_random_scene(self):
         scenario = compileScenic(randomScenario)
-        scene1 = sampleScene(scenario)
+        scene1 = sampleScene(scenario, maxIterations=10)
         data = scenario.sceneToBytes(scene1)
         scene2 = scenario.sceneFromBytes(data)
         assert scenario.sceneToBytes(scene2) == data


### PR DESCRIPTION
It looks like some behavior isn't accounted for by our serialization library, specifically orientations from vector fields. I've added a test that reproduces that behavior and serialization functionality for `Orientation` objects.