### PR TITLE
Avoid copying objects each time step

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -114,6 +114,21 @@ class Constructible(Samplable):
             # transformed by __init_subclass__, so we skip it now.
             return
 
+        # Identify cached properties/methods which will need to be cleared
+        # each time step during dynamic simulations.
+        clearers = {}
+        for attr, value in cls.__dict__.items():
+            if isinstance(value, property):
+                value = value.fget
+            if clearer := getattr(value, "_scenic_cache_clearer", None):
+                clearers[attr] = clearer
+        for sc in cls.__mro__:
+            if sclearers := getattr(sc, "_cache_clearers", None):
+                for attr, clearer in sclearers.items():
+                    if attr not in clearers:
+                        clearers[attr] = clearer
+        cls._cache_clearers = clearers
+
         # Find all defaults provided by the class or its superclasses
         allDefs = collections.defaultdict(list)
 
@@ -126,29 +141,37 @@ class Constructible(Samplable):
         resolvedDefs = {}
         dyns = []
         finals = []
+        dynFinals = []
         for prop, defs in allDefs.items():
             primary, rest = defs[0], defs[1:]
             spec = primary.resolveFor(prop, rest)
             resolvedDefs[prop] = spec
 
-            if any(defn.isDynamic for defn in defs):
+            if isDynamic := any(defn.isDynamic for defn in defs):
                 dyns.append(prop)
             if primary.isFinal:
                 finals.append(prop)
+                if isDynamic:
+                    dynFinals.append(prop)
         cls._defaults = resolvedDefs
-        cls._finalProperties = tuple(finals)
+        cls._finalProperties = frozenset(finals)
 
         # Determine types of dynamic properties
         dynTypes = {}
-        inst = None
+        defaultValues = None  # compute only if necessary
         for prop in dyns:
             ty = super(cls, cls)._dynamicProperties.get(prop)
             if not ty:
-                # First time this property has been defined; create a dummy object to
-                # run specifier resolution and determine the property's default value
-                if not inst:
-                    inst = cls._withSpecifiers((), register=False)
-                ty = underlyingType(getattr(inst, prop))
+                # First time this property has been defined; get the type of
+                # its default value.
+                if not defaultValues:
+                    # N.B. Here we evaluate the default value expressions, which is
+                    # risky since global state like the workspace may not have been set
+                    # up yet. For this reason we only compute default values when they
+                    # are actually needed; a better solution would be to have syntax for
+                    # annotating the types of dynamic properties.
+                    defaultValues, _ = cls._resolveSpecifiers(())
+                ty = underlyingType(defaultValues[prop])
             dynTypes[prop] = ty
         cls._dynamicProperties = dynTypes
         cls._simulatorProvidedProperties = {
@@ -156,6 +179,18 @@ class Constructible(Samplable):
             for prop, val in cls._dynamicProperties.items()
             if prop not in cls._finalProperties
         }
+
+        # Extract order in which to recompute dynamic final properties each time step
+        if defaultValues:
+            dynFinals = set(dynFinals)
+            order = []
+            for prop in defaultValues:  # order is that from specifier resolution
+                if prop in dynFinals:
+                    order.append(prop)
+            cls._dynamicFinalProperties = tuple(order)
+        else:
+            # No new dynamic properties: just inherit the order from the superclass
+            pass
 
     def __new__(cls, *args, _internal=False, **kwargs):
         if not _internal:
@@ -408,6 +443,20 @@ class Constructible(Samplable):
         )
         return properties, constProps
 
+    def _recomputeDynamicFinals(self):
+        # Evaluate default value expression for each dynamic final property
+        defaults = self._defaults
+        context = LazilyEvaluable.makeContext(**self._allProperties())
+        for prop in self._dynamicFinalProperties:
+            values = defaults[prop].getValuesFor(context)
+            assert len(values) == 1, (prop, values)
+            value = values[prop]  # no need for toDistribution since we're mid-simulation
+            self._specify(context, prop, value)
+        properties = LazilyEvaluable.getContextValues(context)
+
+        # Apply the obtained values
+        self.__dict__.update(properties)
+
     @classmethod
     def _specify(cls, context, prop, value):
         # Normalize types of some built-in properties
@@ -504,11 +553,15 @@ class Constructible(Samplable):
         props = {
             prop: val
             for prop, val in self._allProperties().items()
-            if prop not in set(self._finalProperties)
+            if prop not in self._finalProperties
         }
         props.update(overrides)
         constProps = self._constProps.difference(overrides)
         return self._withProperties(props, constProps=constProps)
+
+    def _clearCaches(self):
+        for clearer in self._cache_clearers.values():
+            clearer(self)
 
     def dumpAsScenicCode(self, stream, skipConstProperties=True):
         stream.write(f"new {self.__class__.__name__}")

--- a/src/scenic/core/specifiers.py
+++ b/src/scenic/core/specifiers.py
@@ -102,6 +102,8 @@ class PropertyDefault:
         self.isFinal = enabled("final", False)
         for attr in attributes:
             raise RuntimeError(f'unknown property attribute "{attr}"')
+        if self.isAdditive and self.isDynamic:
+            raise InvalidScenarioError("additive properties cannot be dynamic")
 
     @staticmethod
     def forValue(value):

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -45,6 +45,14 @@ def cached(oldMethod):
             setattr(self, storageName, value)
             return value
 
+    def clearer(self):
+        try:
+            delattr(self, storageName)
+        except AttributeError:
+            pass
+
+    wrapper._scenic_cache_clearer = clearer
+
     return wrapper
 
 
@@ -68,6 +76,14 @@ def cached_method(oldMethod):
             cachedMethod = functools.lru_cache(maxsize=None)(oldMethod)
             caches[name] = cachedMethod
         return cachedMethod(self, *args, **kwargs)
+
+    def clearer(self):
+        caches = _methodCaches.get(self, collections.defaultdict(dict))
+        cachedMethod = caches.get(name)
+        if cachedMethod:
+            cachedMethod.cache_clear()
+
+    wrapper._scenic_cache_clearer = clearer
 
     return wrapper
 

--- a/src/scenic/simulators/newtonian/driving_model.scenic
+++ b/src/scenic/simulators/newtonian/driving_model.scenic
@@ -61,5 +61,5 @@ class Pedestrian(Pedestrian, NewtonianActor, Walks):
 
 class Debris:
     """Abstract class for debris scattered randomly in the workspace."""
-    position: Point in workspace
+    position: new Point in workspace
     yaw: Range(0, 360) deg

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -39,7 +39,22 @@ def test_dynamic_property():
     assert len(actions) == 3
 
 
-def test_dynamic_derived_property():
+def test_dynamic_final_property():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for i in range(3):
+                self.yaw = self.yaw + 0.1
+                wait
+        ego = new Object with behavior Foo
+        terminate when ego.heading >= 0.25
+    """
+    )
+    actions = sampleEgoActions(scenario, maxSteps=4)
+    assert len(actions) == 3
+
+
+def test_dynamic_cached_property():
     scenario = compileScenic(
         """
         behavior Foo():
@@ -48,6 +63,21 @@ def test_dynamic_derived_property():
                 wait
         ego = new Object with behavior Foo
         terminate when ego.left.position.y >= 3
+    """
+    )
+    actions = sampleEgoActions(scenario, maxSteps=4)
+    assert len(actions) == 3
+
+
+def test_dynamic_cached_method():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for i in range(3):
+                self.position = self.position + 0@1
+                wait
+        ego = new Object with behavior Foo
+        terminate when ego.distanceTo(0@4) < 1
     """
     )
     actions = sampleEgoActions(scenario, maxSteps=4)


### PR DESCRIPTION
We now use a single copy of each object throughout a dynamic simulation, mutating its dynamic properties, recomputing dynamic final properties, and explicitly clearing the caches for cached properties/methods (for those using Scenic's own internal decorators, of course: people using `functools.cached` etc. probably don't expect that to get cleared every step). As a result, we no longer need to run specifier resolution at each time step (previously necessary to ensure dynamic final properties were updated), which turned out to cause major slowdowns when an object had a property storing a large nested list. For such cases the major performance regression from Scenic 2 to 3 should be substantially reduced.

(I've removed my previous comment about the remaining overhead when recomputing dynamic finals: the latest version of this PR gets rid of all the extraneous work we can eliminate without special-casing known properties like `orientation` to remove type checks, etc.)