### PR TITLE
Mesh Loading Upgrades

### DIFF
--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1072,7 +1072,7 @@ class MeshVolumeRegion(MeshRegion):
                 if dim <= 0:
                     raise ValueError(f"{name} of MeshVolumeRegion must be positive")
 
-        # Ensure the mesh is watertight so volume is well defined
+        # Ensure the mesh is a well defined volume
         if not self._mesh.is_volume:
             raise ValueError(
                 "A MeshVolumeRegion cannot be defined with a mesh that does not have a well defined volume."

--- a/src/scenic/core/shapes.py
+++ b/src/scenic/core/shapes.py
@@ -142,6 +142,11 @@ class MeshShape(Shape):
             kwargs: Additional arguments to the MeshShape initializer.
         """
         mesh = loadMesh(path, filetype, compressed, binary)
+        if not mesh.is_volume:
+            raise ValueError(
+                "A MeshShape cannot be defined with a mesh that does not have a well defined volume."
+                " Consider using scenic.core.utils.repairMesh."
+            )
         if unify:
             mesh = unifyMesh(mesh, verbose=True)
         return cls(mesh, **kwargs)

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -157,7 +157,7 @@ def loadMesh(path, filetype, compressed, binary):
         open_function = open
 
     with open_function(path, mode) as mesh_file:
-        mesh = trimesh.load(mesh_file, file_type=filetype)
+        mesh = trimesh.load(mesh_file, file_type=filetype, force="mesh")
 
     return mesh
 


### PR DESCRIPTION
Fixes an issue where Trimesh returns a Scene instead of a mesh. Also adds a clearer error message when a shape is not a valid volume, as before we would try to unify it and trigger an assertion.