### PR TITLE
Fix drivable region

### DIFF
--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2643,10 +2643,14 @@ class PolygonalRegion(Region):
     @distributionFunction
     def unionAll(regions, buf=0):
         regions = tuple(regions)
-        if not all([r.z == regions[0].z for r in regions]):
-            raise ValueError(
-                "union of PolygonalRegions with different z values is undefined."
-            )
+        z = None
+        for reg in regions:
+            if z is not None and isinstance(reg, PolygonalRegion) and reg.z != z:
+                raise ValueError(
+                    "union of PolygonalRegions with different z values is undefined."
+                )
+            if isinstance(reg, PolygonalRegion) and z is None:
+                z = reg.z
 
         regs, polys = [], []
         for reg in regions:
@@ -2659,7 +2663,8 @@ class PolygonalRegion(Region):
             raise TypeError(f"cannot take union of regions {regions}")
         union = polygonUnion(polys, buf=buf)
         orientation = VectorField.forUnionOf(regs, tolerance=buf)
-        return PolygonalRegion(polygon=union, orientation=orientation)
+        z = 0 if z is None else z
+        return PolygonalRegion(polygon=union, orientation=orientation, z=z)
 
     @property
     @distributionFunction

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -923,9 +923,18 @@ class Network:
             self.shoulderRegion = PolygonalRegion.unionAll(self.shoulders)
 
         if self.drivableRegion is None:
-            self.drivableRegion = self.laneRegion.union(self.intersectionRegion)
+            self.drivableRegion = PolygonalRegion.unionAll(
+                (
+                    self.laneRegion,
+                    self.roadRegion,  # can contain points slightly outside laneRegion
+                    self.intersectionRegion,
+                )
+            )
         assert self.drivableRegion.containsRegion(
             self.laneRegion, tolerance=self.tolerance
+        )
+        assert self.drivableRegion.containsRegion(
+            self.roadRegion, tolerance=self.tolerance
         )
         assert self.drivableRegion.containsRegion(
             self.intersectionRegion, tolerance=self.tolerance
@@ -980,7 +989,7 @@ class Network:
 
         :meta private:
         """
-        return 31
+        return 32
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""

--- a/tests/core/test_regions.py
+++ b/tests/core/test_regions.py
@@ -213,6 +213,24 @@ def test_polygon_region():
     )
 
 
+def test_polygon_unionAll():
+    poly1 = PolygonalRegion([(1, 0), (1, 1), (2, 1), (2, 0)], z=2)
+    poly2 = PolygonalRegion([(-1, 0), (-1, 1), (0, 1), (0, 0)], z=2)
+    union = PolygonalRegion.unionAll((poly1, nowhere, poly2))
+    assert isinstance(union, PolygonalRegion)
+    assert union.z == 2
+    assert union.containsPoint((1.5, 0.5))
+    assert union.containsPoint((-0.5, 0.5))
+    assert not union.containsPoint((0.5, 0.5))
+
+    poly3 = PolygonalRegion([(0, 0), (1, 1), (1, 0)], z=1)
+    with pytest.raises(ValueError):
+        PolygonalRegion.unionAll((poly1, poly3))
+
+    with pytest.raises(TypeError):
+        PolygonalRegion.unionAll((poly1, everywhere))
+
+
 def test_polygon_sampling():
     p = shapely.geometry.Polygon(
         [(0, 0), (0, 3), (3, 3), (3, 0)], holes=[[(1, 1), (1, 2), (2, 2), (2, 1)]]


### PR DESCRIPTION
`Network.roadRegion` can contain some points slightly outside of `Network.laneRegion`, because roads are formed as unions of their lanes with buffering+erosion to remove small gaps. Since we compute `drivableRegion` using `laneRegion` (unioned with `intersectionRegion`), this means that points at a distance from `drivableRegion` greater than the network tolerance can still have a road at them (according to `Network.roadAt` etc.). This caused a test failure in PR #178.

This PR adds `roadRegion` to `drivableRegion` to remove the discrepancy above. I've also robustified some of the road network tests that have failed recently so that hopefully in the future they will fail closer to when the actual bug is introduced rather than taking several CI runs to first turn up.