### PR TITLE
Fix GTA assertion failure with time param just before midnight

### DIFF
--- a/src/scenic/simulators/gta/interface.py
+++ b/src/scenic/simulators/gta/interface.py
@@ -55,10 +55,9 @@ class GTA:
         cameraHeading = GTA.langToGTAHeading(ego.heading)
 
         params = dict(scene.params)
-        time = int(round(params.pop("time")))
-        minute = time % 60
-        hour = int((time - minute) / 60)
-        assert hour < 24
+        time = int(round(params.pop("time"))) % 1440
+        hour, minute = divmod(time, 60)
+        assert hour < 24, scene.params["time"]
         weather = params.pop("weather")
         for param in params:
             print(f'WARNING: unused scene parameter "{param}"')

--- a/tests/simulators/gta/test_gta.py
+++ b/tests/simulators/gta/test_gta.py
@@ -31,6 +31,21 @@ def test_bumper_to_bumper(loadLocalScenario):
     GTA.Config(scene)
 
 
+def test_time_near_midnight():
+    scenario = compileScenic(
+        f"""
+        from scenic.simulators.gta.map import setLocalMap
+        setLocalMap(r"{__file__}", "map.npz")
+        model scenic.simulators.gta.model
+        param time = 1439.9
+        ego = new EgoCar
+        """,
+        mode2D=True,
+    )
+    scene, _ = scenario.generate(maxIterations=50)
+    GTA.Config(scene)
+
+
 def test_make_map(request, tmp_path):
     from scenic.simulators.gta.interface import Map
 


### PR DESCRIPTION
Giving the GTA `time` global parameter a value which rounds to 1440 minutes (midnight) caused an assertion failure (this randomly happened to me when running the test suite). This PR takes `time` mod 1440 so that values greater than 1439.5 work as one would expect.