### PR TITLE
Removed Redundant Mesh Loading/Voxel Code

### DIFF
--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -56,7 +56,7 @@ from scenic.core.geometry import (
 )
 from scenic.core.lazy_eval import isLazy, valueInContext
 from scenic.core.type_support import toOrientation, toScalar, toVector
-from scenic.core.utils import cached, cached_method, cached_property, loadMesh, unifyMesh
+from scenic.core.utils import cached, cached_method, cached_property, unifyMesh
 from scenic.core.vectors import (
     Orientation,
     OrientedVector,
@@ -848,9 +848,7 @@ class MeshRegion(Region):
         self.orientation = orientation
 
     @classmethod
-    def fromFile(
-        cls, path, filetype=None, compressed=None, binary=False, unify=True, **kwargs
-    ):
+    def fromFile(cls, path, unify=True, **kwargs):
         """Load a mesh region from a file, attempting to infer filetype and compression.
 
         For example: "foo.obj.bz2" is assumed to be a compressed .obj file.
@@ -867,7 +865,7 @@ class MeshRegion(Region):
             unify (bool): Whether or not to attempt to unify this mesh.
             kwargs: Additional arguments to the MeshRegion initializer.
         """
-        mesh = loadMesh(path, filetype, compressed, binary)
+        mesh = trimesh.load(path, force="mesh")
 
         if unify and issubclass(cls, MeshVolumeRegion):
             mesh = unifyMesh(mesh, verbose=True)

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -2049,9 +2049,7 @@ class VoxelRegion(Region):
             raise ValueError("Tried to create an empty VoxelRegion.")
 
         # Store voxel grid and extract points and scale
-        self.voxelGrid = trimesh.voxel.VoxelGrid(
-            voxelGrid.encoding, transform=voxelGrid.transform.copy()
-        )
+        self.voxelGrid = voxelGrid
         self.voxel_points = self.voxelGrid.points
         self.scale = self.voxelGrid.scale
 

--- a/src/scenic/core/shapes.py
+++ b/src/scenic/core/shapes.py
@@ -11,7 +11,7 @@ from trimesh.transformations import (
 )
 
 from scenic.core.type_support import toOrientation
-from scenic.core.utils import cached_property, loadMesh, unifyMesh
+from scenic.core.utils import cached_property, unifyMesh
 from scenic.core.vectors import Orientation
 
 ###################################################################################################
@@ -122,9 +122,7 @@ class MeshShape(Shape):
         super().__init__(dimensions, scale)
 
     @classmethod
-    def fromFile(
-        cls, path, filetype=None, compressed=None, binary=False, unify=True, **kwargs
-    ):
+    def fromFile(cls, path, unify=True, **kwargs):
         """Load a mesh shape from a file, attempting to infer filetype and compression.
 
         For example: "foo.obj.bz2" is assumed to be a compressed .obj file.
@@ -141,7 +139,7 @@ class MeshShape(Shape):
             unify (bool): Whether or not to attempt to unify this mesh.
             kwargs: Additional arguments to the MeshShape initializer.
         """
-        mesh = loadMesh(path, filetype, compressed, binary)
+        mesh = trimesh.load(path, force="mesh")
         if not mesh.is_volume:
             raise ValueError(
                 "A MeshShape cannot be defined with a mesh that does not have a well defined volume."

--- a/src/scenic/core/utils.py
+++ b/src/scenic/core/utils.py
@@ -124,44 +124,6 @@ def alarm(seconds, handler=None, noNesting=False):
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 
-def loadMesh(path, filetype, compressed, binary):
-    working_path = path
-
-    if binary:
-        mode = "rb"
-    else:
-        mode = "r"
-
-    # Check if file is compressed
-    if compressed is None:
-        root, ext = os.path.splitext(working_path)
-
-        if ext == ".bz2":
-            compressed = True
-            working_path = root
-        else:
-            compressed = False
-
-    # Check mesh filetype
-    if filetype is None:
-        root, ext = os.path.splitext(working_path)
-
-        if ext == "":
-            raise ValueError("Mesh filetype not provided, but could not be extracted")
-
-        filetype = ext
-
-    if compressed:
-        open_function = bz2.open
-    else:
-        open_function = open
-
-    with open_function(path, mode) as mesh_file:
-        mesh = trimesh.load(mesh_file, file_type=filetype, force="mesh")
-
-    return mesh
-
-
 def unifyMesh(mesh, verbose=False):
     """Attempt to merge mesh bodies, raising a `ValueError` if something fails.
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -4,18 +4,12 @@ import numpy
 import pytest
 import trimesh
 
-from scenic.core.utils import loadMesh, repairMesh, unifyMesh
+from scenic.core.utils import repairMesh, unifyMesh
 
 
 @pytest.mark.slow
 def test_mesh_repair(getAssetPath):
-    plane_mesh = loadMesh(
-        path=getAssetPath("meshes/classic_plane.obj.bz2"),
-        filetype="obj",
-        compressed=True,
-        binary=False,
-    )
-
+    plane_mesh = trimesh.load(getAssetPath("meshes/classic_plane.obj.bz2"), force="mesh")
     # Test simple fix
     inverted_mesh = plane_mesh.copy()
     inverted_mesh.invert()


### PR DESCRIPTION
Removed code that was made redundant by up-streaming [these](https://github.com/mikedh/trimesh/pull/2115) features to Trimesh. We can now load bz2 compressed meshes correctly. Also removed code needed to work around [this](https://github.com/mikedh/trimesh/issues/2033) Trimesh bug.