### PR TITLE
Carla Interface Convert `record` to Absolute Path

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,8 @@ codecov:
     layout: "reach, diff, flags, files"
     behavior: default
   require_ci_to_pass: true
+  ignore:
+    - "src/scenic/simulators/**"
 cli:
   plugins:
     pycoverage:

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -139,6 +139,8 @@ class CarlaSimulation(DrivingSimulation):
             if not os.path.exists(self.record):
                 os.mkdir(self.record)
             name = "{}/scenario{}.log".format(self.record, self.scenario_number)
+            # Carla is looking for an absolute path, so convert it if necessary.
+            name = os.path.abspath(name)
             self.client.start_recorder(name)
 
         # Create objects.


### PR DESCRIPTION
### Description
Code to ensure Carla interface `record` parameter is an absolute path.

### Issue Link
https://github.com/BerkeleyLearnVerify/Scenic/issues/21

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
@dfremont @abanuelo Unable to test these changes with Carla at the moment due to server issues, but perhaps we could do so with the new simulator CI?