### PR TITLE
fix: ignoring src/scenic/simulators in codecov report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,8 @@ codecov:
     layout: "reach, diff, flags, files"
     behavior: default
   require_ci_to_pass: true
+  ignore:
+    - "src/scenic/simulators/**"
 cli:
   plugins:
     pycoverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,8 @@ codecov:
   require_ci_to_pass: true
   ignore:
     - "src/scenic/simulators/**"
+    - "!src/scenic/simulators/newtonian/**"
+    - "!src/scenic/simulators/utils/**"
 cli:
   plugins:
     pycoverage:


### PR DESCRIPTION
### Description
PR #223 merge is blocked by decreased code coverage directly resulting from adding code to carla simulator.py.

### Issue Link
None, adhoc fix needed to merge in PR #223 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->