### PR TITLE
fix: adding seed under reproduce in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -50,7 +50,7 @@ body:
         Please provide a minimal example to help us reproduce the bug. Code should be wrapped with ```triple quotes blocks``` to improve readability. 
         If it is not possible to reproduce the bug with a short self-contained Scenic or Python file, for example if a specific mesh is required, you can attach any required files below or include a link to them.
 
-        Along with that info, please specify a seed when reproducing the issue by running scenic with the seed argument: `scenic -s SEED, --seed SEED  random seed`
+        If possible/applicable, please specify a seed that will reproduce the issue by running scenic with the seed argument: `scenic -s SEED, --seed SEED  random seed`
       placeholder: |
         1. First step to reproduce bug
         2. Second step, etc

--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -49,6 +49,8 @@ body:
       description: |
         Please provide a minimal example to help us reproduce the bug. Code should be wrapped with ```triple quotes blocks``` to improve readability. 
         If it is not possible to reproduce the bug with a short self-contained Scenic or Python file, for example if a specific mesh is required, you can attach any required files below or include a link to them.
+
+        Along with that info, please specify a seed when reproducing the issue by running scenic with the seed argument: `scenic -s SEED, --seed SEED  random seed`
       placeholder: |
         1. First step to reproduce bug
         2. Second step, etc


### PR DESCRIPTION
### Description
As part of the bug report template, adding clarification of running `scenic` commands with a SEED to ensure reproducibility.

### Issue Link
Adhoc request from @Eric-Vin 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->