### PR TITLE
feat: sync opened GitHub issues with Jira

### DIFF
--- a/.github/workflows/sync-issues-with-jira.yml
+++ b/.github/workflows/sync-issues-with-jira.yml
@@ -4,70 +4,61 @@ on:
     types: [opened]
 
 jobs:
-  generate-issue-link:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sync issue with Jira
-        uses: actions/github-script@v4
-        env:
-            JIRA_DOMAIN: ${{ secrets.JIRA_DOMAIN }}
-            JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-            JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fetch = require('node-fetch');
-            const repoName = context.payload.repository.full_name;
-            const issueNumber = context.payload.issue.number;
-            const issueTitle = context.payload.issue.title;
-            const issueLink = `https://github.com/${repoName}/issues/${issueNumber}`;
-            console.log(`Issue Title: ${issueTitle}`);
-            console.log(`Issue Link: ${issueLink}`);
-
-            const bodyData = `
-            "fields": {
-                "description": {
-                  "content": [
-                    {
-                      "content": [
-                        {
-                          "text": "${issueLink}",
-                          "type": "text"
+    generate-issue-link:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Get issue details
+            id: get_issue_details
+            uses: actions/github-script@v4
+            with:
+              github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+              script: |
+                const repoName = context.payload.repository.full_name;
+                const issueNumber = context.payload.issue.number;
+                const issueTitle = context.payload.issue.title;
+                const issueLink = `https://github.com/${repoName}/issues/${issueNumber}`;
+                console.log(`::set-output name=issueTitle::${issueTitle}`);
+                console.log(`::set-output name=issueLink::${issueLink}`);
+        
+          - name: Create Jira Ticket
+            env:
+                JIRA_DOMAIN: ${{ secrets.JIRA_DOMAIN }}
+                JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+                JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+                ISSUE_TITLE: ${{ steps.get_issue_details.outputs.issueTitle }}
+                ISSUE_LINK: ${{ steps.get_issue_details.outputs.issueLink }}
+            run: |
+                echo "Issue Title: $ISSUE_TITLE"
+                echo "Issue Link: $ISSUE_LINK"
+            
+                curl --request POST \
+                --url "https://$JIRA_DOMAIN.atlassian.net/rest/api/3/issue" \
+                --user "$JIRA_EMAIL:$JIRA_API_TOKEN" \
+                --header "Accept: application/json" \
+                --header "Content-Type: application/json" \
+                --data '{
+                    "fields": {
+                        "description": {
+                            "content": [
+                            {
+                                "content": [
+                                {
+                                    "text": "'"$ISSUE_LINK"'",
+                                    "type": "text"
+                                }
+                                ],
+                                "type": "paragraph"
+                            }
+                            ],
+                            "type": "doc",
+                            "version": 1
+                        },
+                        "summary": "'"$ISSUE_TITLE"'",
+                        "issuetype": {
+                            "id": "10001"
+                        },
+                        "project": {
+                            "key": "SCENIC"
                         }
-                      ],
-                      "type": "paragraph"
                     }
-                  ],
-                  "type": "doc",
-                  "version": 1
-                },
-                "summary": "${issueTitle}",
-                "issuetype": {
-                  "id": "10001"
-                },
-                "project": {
-                  "key": "SCENIC"
-                }
-              }
-            `;
-
-            fetch(`https://${JIRA_DOMAIN}.atlassian.net/rest/api/3/issue`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Basic ${Buffer.from(
-                `${JIRA_EMAIL}:{JIRA_API_TOKEN}`
-                ).toString('base64')}`,
-                'Accept': 'application/json',
-                'Content-Type': 'application/json'
-            },
-            body: bodyData
-            })
-            .then(response => {
-                console.log(
-                `Response: ${response.status} ${response.statusText}`
-                );
-                return response.text();
-            })
-            .then(text => console.log(text))
-            .catch(err => console.error(err));
-
+                }'

--- a/.github/workflows/sync-issues-with-jira.yml
+++ b/.github/workflows/sync-issues-with-jira.yml
@@ -1,0 +1,73 @@
+name: sync_issues_with_jira
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  generate-issue-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync issue with Jira
+        uses: actions/github-script@v4
+        env:
+            JIRA_DOMAIN: ${{ secrets.JIRA_DOMAIN }}
+            JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+            JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fetch = require('node-fetch');
+            const repoName = context.payload.repository.full_name;
+            const issueNumber = context.payload.issue.number;
+            const issueTitle = context.payload.issue.title;
+            const issueLink = `https://github.com/${repoName}/issues/${issueNumber}`;
+            console.log(`Issue Title: ${issueTitle}`);
+            console.log(`Issue Link: ${issueLink}`);
+
+            const bodyData = `
+            "fields": {
+                "description": {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "${issueLink}",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "paragraph"
+                    }
+                  ],
+                  "type": "doc",
+                  "version": 1
+                },
+                "summary": "${issueTitle}",
+                "issuetype": {
+                  "id": "10001"
+                },
+                "project": {
+                  "key": "SCENIC"
+                }
+              }
+            `;
+
+            fetch(`https://${JIRA_DOMAIN}.atlassian.net/rest/api/3/issue`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Basic ${Buffer.from(
+                `${JIRA_EMAIL}:{JIRA_API_TOKEN}`
+                ).toString('base64')}`,
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: bodyData
+            })
+            .then(response => {
+                console.log(
+                `Response: ${response.status} ${response.statusText}`
+                );
+                return response.text();
+            })
+            .then(text => console.log(text))
+            .catch(err => console.error(err));
+


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
As part of the maintenance group, I have created a GitHub actions workflow that syncs issues that are opened on GitHub to our Jira board. This will allow us to use Jira as the source of truth for all open issues. I have tested on the [internal repo](https://github.com/BerkeleyLearnVerify/Scenic-internal-testing/actions/runs/8654624448/job/23732157249), and confirmed that it does create a Jira ticket (see image below). 

The new Jira ticket has the same title as the original issue opened and the body is simply a link back to the original ticket.
<img width="416" alt="Screenshot 2024-04-11 at 4 39 24 PM" src="https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/3f9a08ad-39ac-4a29-9c97-287bee60126d">

**Note**
For this action to work we need to add three more repo secrets:
1. `JIRA_EMAIL`
2. `JIRA_DOMAIN`
3. `JIRA_API_KEY`

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->