### PR TITLE
feat: adding on-call reminder to Slack

### DIFF
--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -4,7 +4,6 @@ import requests
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-
 # Put users into the dict
 def save_users(users_array):
     users = {}

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -39,7 +39,7 @@ def postSlackMessage(client, CHANNEL_ID, OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_
 
         result = client.chat_postMessage(
             channel=CHANNEL_ID,
-            text=f"""🛠️ Maintenance On-Call: <@{slack_id}>\n
+            text=f"""🛠️Maintenance On-Call: <@{slack_id}>, you will be on-call for the next week. Resources:\n
     📖 <https://https://scenic-lang.atlassian.net/l/cp/cnaQtVXY|On Call Best Practices>
     🔍 <https://scenic-lang.atlassian.net/l/cp/jR0CifEf|Issue Triage Guide>
     📊 <https://scenic-lang.atlassian.net/jira/software/projects/SCENIC/boards/1|Jira Board to monitor active workstreams>

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -4,7 +4,7 @@ import requests
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-# Put users into the dict
+
 def save_users(users_array):
     users = {}
     for user in users_array:
@@ -25,9 +25,7 @@ def grab_whos_on_call(OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):
     else:
         print(f"Request failed with status code {response.status_code}")
         print("Response content:")
-        print(
-            response.content.decode("utf-8")
-        )  # Decode response content if it's in bytes
+        print(response.content.decode("utf-8"))
     return data["data"]["onCallParticipants"][0]["name"]
 
 
@@ -64,7 +62,7 @@ if __name__ == "__main__":
     OPS_GENIE_API_TOKEN = args.ops_genie_api_token
     # NOTE: Feel free to grab the relevant channel ID to post the message to but ensure the App is installed within the channel
     CHANNEL_ID = "C06N9KJHN2J"
-    # NOTE: Rotation schedule is grabbed directly from within the OpsGenie
+    # NOTE: Rotation schedule is grabbed directly from within the OpsGenie site
     ROTATION_SCHEDULE_ID = "904cd122-f269-418d-8c29-3e6751716bae"
 
     client = WebClient(token=SLACK_API_TOKEN)

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -4,6 +4,7 @@ import requests
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+
 # Put users into the dict
 def save_users(users_array):
     users = {}

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -12,7 +12,7 @@ def save_users(users_array):
         profile = user["profile"]
         if "email" in profile.keys():
             user_email = profile["email"]
-            username = user_email.split('@')[0]
+            username = user_email.split("@")[0]
             users[username] = user
     return users
 
@@ -27,7 +27,7 @@ def grab_whos_on_call(OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):
         print(f"Request failed with status code {response.status_code}")
         print("Response content:")
         print(response.content.decode("utf-8"))
-    return data["data"]["onCallParticipants"][0]["name"].split('@')[0]
+    return data["data"]["onCallParticipants"][0]["name"].split("@")[0]
 
 
 def postSlackMessage(client, CHANNEL_ID, OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -1,0 +1,71 @@
+import argparse
+
+import requests
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+# Put users into the dict
+def save_users(users_array):
+    users = {}
+    for user in users_array:
+        # NOTE: some apps, slackbots do not have emails to map to
+        profile = user["profile"]
+        if "email" in profile.keys():
+            user_email = profile["email"]
+            users[user_email] = user
+    return users
+
+
+def grab_whos_on_call(OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):
+    url = f"https://api.opsgenie.com/v2/schedules/{ROTATION_SCHEDULE_ID}/on-calls"
+    headers = {"Authorization": f"GenieKey {OPS_GENIE_API_TOKEN}"}
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        data = response.json()
+    else:
+        print(f"Request failed with status code {response.status_code}")
+        print("Response content:")
+        print(
+            response.content.decode("utf-8")
+        )  # Decode response content if it's in bytes
+    return data["data"]["onCallParticipants"][0]["name"]
+
+
+def postSlackMessage(client, CHANNEL_ID, OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):
+    try:
+        result = client.users_list()
+        users = save_users(result["members"])
+        on_call = grab_whos_on_call(OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID)
+        slack_id = users[on_call]["id"]
+
+        result = client.chat_postMessage(
+            channel=CHANNEL_ID,
+            text=f"""🛠️ Maintenance On-Call: <@{slack_id}>\n
+    📖 <https://https://scenic-lang.atlassian.net/l/cp/cnaQtVXY|On Call Best Practices>
+    🔍 <https://scenic-lang.atlassian.net/l/cp/jR0CifEf|Issue Triage Guide>
+    📊 <https://scenic-lang.atlassian.net/jira/software/projects/SCENIC/boards/1|Jira Board to monitor active workstreams>
+    📋 <https://scenic-lang.atlassian.net/jira/software/projects/SCENIC/boards/1/backlog?epics=visible|Jira Backlog to monitor issues that need triaging>
+    🔧 <https://github.com/BerkeleyLearnVerify/Scenic/issues|Scenic GitHub Issues>
+    """,
+        )
+    except SlackApiError as e:
+        print(f"SlackAPIError: {e}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Script that notifies on-call rotation daily"
+    )
+    parser.add_argument("--slack_api_token", required=True, type=str)
+    parser.add_argument("--ops_genie_api_token", required=True, type=str)
+    args = parser.parse_args()
+
+    SLACK_API_TOKEN = args.slack_api_token
+    OPS_GENIE_API_TOKEN = args.ops_genie_api_token
+    # NOTE: Feel free to grab the relevant channel ID to post the message to but ensure the App is installed within the channel
+    CHANNEL_ID = "C06N9KJHN2J"
+    # NOTE: Rotation schedule is grabbed directly from within the OpsGenie
+    ROTATION_SCHEDULE_ID = "904cd122-f269-418d-8c29-3e6751716bae"
+
+    client = WebClient(token=SLACK_API_TOKEN)
+    postSlackMessage(client, CHANNEL_ID, OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID)

--- a/.github/slack_oncall_reminder.py
+++ b/.github/slack_oncall_reminder.py
@@ -12,7 +12,8 @@ def save_users(users_array):
         profile = user["profile"]
         if "email" in profile.keys():
             user_email = profile["email"]
-            users[user_email] = user
+            username = user_email.split('@')[0]
+            users[username] = user
     return users
 
 
@@ -26,7 +27,7 @@ def grab_whos_on_call(OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):
         print(f"Request failed with status code {response.status_code}")
         print("Response content:")
         print(response.content.decode("utf-8"))
-    return data["data"]["onCallParticipants"][0]["name"]
+    return data["data"]["onCallParticipants"][0]["name"].split('@')[0]
 
 
 def postSlackMessage(client, CHANNEL_ID, OPS_GENIE_API_TOKEN, ROTATION_SCHEDULE_ID):

--- a/.github/workflows/on-call-reminder.yml
+++ b/.github/workflows/on-call-reminder.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/on-call-reminder.yml
+++ b/.github/workflows/on-call-reminder.yml
@@ -2,7 +2,7 @@ name: on_call_reminder
 
 on:
   schedule:
-    - cron: '0 17 * * 1-5'  # Runs Monday to Friday at 10am PST (17:00 UTC)
+    - cron: '0 17 * * 2'  # Runs every Wednesday at 9am PST (17:00 UTC)
   workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:

--- a/.github/workflows/on-call-reminder.yml
+++ b/.github/workflows/on-call-reminder.yml
@@ -1,0 +1,30 @@
+name: on_call_reminder
+
+on:
+  schedule:
+    - cron: '0 17 * * 1-5'  # Runs Monday to Friday at 10am PST (17:00 UTC)
+  workflow_dispatch:  # Allows manual triggering of the workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests slack_sdk argparse
+
+      - name: Run Python script
+        env:
+          SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          OPS_GENIE_API_TOKEN: ${{ secrets.OPS_GENIE_API_TOKEN }}
+        run: python .github/slack_oncall_reminder.py --slack_api_token $SLACK_API_TOKEN --ops_genie_api_token $OPS_GENIE_API_TOKEN


### PR DESCRIPTION
### Important!!!!
This will need a `SLACK_API_TOKEN` and `OPS_GENIE_API_TOKEN` repo variables set.
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
This Github action creates a slack post within the #maintenance channel that notifies who is on-call and best practices. The current schedule for the reminder is to be everyday Monday through Friday at 10am PST. 

Here is a working example within internal repo: [here](https://github.com/BerkeleyLearnVerify/Scenic-internal-testing/actions/runs/8696879919). An image of the message will be as follows:

<img width="763" alt="Screenshot 2024-04-15 at 3 38 17 PM" src="https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/680efaf5-152b-43b4-a702-98cfb90e12f2">

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->