### PR TITLE
fix: defaulting carla_map to map .xodr path in scenic files

### DIFF
--- a/src/scenic/simulators/carla/model.scenic
+++ b/src/scenic/simulators/carla/model.scenic
@@ -70,7 +70,8 @@ except ModuleNotFoundError:
     class _CarlaVehicle: pass
     class _CarlaPedestrian: pass
 
-param carla_map = None
+map_town = ((str(globalParameters.map).split('/'))[-1]).split('.')[0]
+param carla_map = map_town if globalParameters.map else None
 param address = '127.0.0.1'
 param port = 2000
 param timeout = 10


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
When `carla_map` is undefined in a `.scenic` file it defaults to `None` when it should default to the `map` town if the `map` param is present in the file. 

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
#228 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->