### PR TITLE
fix: enable scenario termination from closing display

### DIFF
--- a/src/scenic/core/simulators.py
+++ b/src/scenic/core/simulators.py
@@ -328,6 +328,7 @@ class Simulation(abc.ABC):
         continueAfterDivergence=False,
         verbosity=0,
     ):
+        self.screen = None
         self.result = None
         self.scene = scene
         self.objects = []

--- a/src/scenic/core/simulators.py
+++ b/src/scenic/core/simulators.py
@@ -430,6 +430,13 @@ class Simulation(abc.ABC):
                 terminationReason = newReason
                 terminationType = TerminationType.terminatedByMonitor
 
+            # Check if users manually closed out display for simulator
+            if "Dead" in str(self.screen):
+                return (
+                    TerminationType.terminatedByUser,
+                    "user manually terminated simulation",
+                )
+
             # "Always" and scenario-level requirements have been checked;
             # now safe to terminate if the top-level scenario has finished,
             # a monitor requested termination, or we've hit the timeout
@@ -865,6 +872,9 @@ class TerminationType(enum.Enum):
 
     #: A :term:`dynamic behavior` used :keyword:`terminate simulation` to end the simulation.
     terminatedByBehavior = "a behavior terminated the simulation"
+
+    #: A user manually intervenes and closes display window
+    terminatedByUser = "manually terminated by user"
 
 
 class SimulationResult:

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -70,6 +70,7 @@ class NewtonianSimulation(DrivingSimulation):
     def __init__(self, scene, network, render, timestep, **kwargs):
         self.render = render
         self.network = network
+        self.screen = None
 
         if timestep is None:
             timestep = 0.1
@@ -186,6 +187,11 @@ class NewtonianSimulation(DrivingSimulation):
             obj.heading += obj.angularSpeed * self.timestep
 
         if self.render:
+            # Handle closing out pygame screen
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.destroy()
+                    return
             self.draw_objects()
             pygame.event.pump()
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Fix that allows users to manually close out display via the UI and continue subsequent simulations to continue. Here is a video illustrating the working changes

https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/a6b7d7e5-71b6-4580-b7a7-8b33d3e4da58

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
#230 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->