### PR TITLE
Orientation Composition Fixes

### DIFF
--- a/docs/reference/operators.rst
+++ b/docs/reference/operators.rst
@@ -98,7 +98,7 @@ The orientation specified by the vector field at the given position
 The orientation obtained by starting in the second direction and then rotating according to the first direction. For example, :scenic:`-5 deg relative to 90 deg` is simply 85 degrees. If either direction is a vector field, then this operator yields an expression depending on the :prop:`position` property of the object being specified. Both operator values must be of type `heading`, `Orientation`, or `vectorField`, not tuples, as tuples are by default intepreted as `Vector` objects.
 
 .. note::
-	This operator is not necessarily commutative, for example, when composing two 3D orientations,
+	This operator is not necessarily commutative, for example, when composing two 3D orientations.
 
 
 Vector Operators

--- a/docs/reference/operators.rst
+++ b/docs/reference/operators.rst
@@ -93,9 +93,12 @@ The orientation specified by the vector field at the given position
 
 .. _{direction} relative to {direction}:
 
-(*heading* | *vectorField*) relative to (*heading* | *vectorField*)
+(*direction*) relative to (*direction*)
 -------------------------------------------------------------------
-The first heading/vector field, interpreted as an offset relative to the second heading/vector field. For example, :scenic:`-5 deg relative to 90 deg` is simply 85 degrees. If either direction is a vector field, then this operator yields an expression depending on the :prop:`position` property of the object being specified.
+The orientation obtained by starting in the second direction and then rotating according to the first direction. For example, :scenic:`-5 deg relative to 90 deg` is simply 85 degrees. If either direction is a vector field, then this operator yields an expression depending on the :prop:`position` property of the object being specified. Both operator values must be of type `heading`, `Orientation`, or `vectorField`, not tuples, as tuples are by default intepreted as `Vector` objects.
+
+.. note::
+	This operator is not necessarily commutative, for example, when composing two 3D orientations,
 
 
 Vector Operators

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -860,8 +860,8 @@ class OrientedPoint(Point):
             {"yaw", "pitch", "roll", "parentOrientation"},
             {"dynamic", "final"},
             lambda self: (
-                Orientation.fromEuler(self.yaw, self.pitch, self.roll)
-                * self.parentOrientation
+                self.parentOrientation
+                * Orientation.fromEuler(self.yaw, self.pitch, self.roll)
             ),
         ),
         # Heading is equal to orientation.yaw, which is equal to self.yaw if this OrientedPoint's

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -818,14 +818,11 @@ class Point(Constructible):
 class OrientedPoint(Point):
     """The Scenic class ``OrientedPoint``.
 
-    The default mutator for `OrientedPoint` adds Gaussian noise to ``yaw`` while
-    leaving ``pitch`` and ``roll`` unchanged, using the three standard deviations
-    (for yaw/pitch/roll respectively) given by the  ``orientationStdDev`` property.
-    It then also applies the mutator for `Point`.
-
     The default mutator for `OrientedPoint` adds Gaussian noise to ``yaw``, ``pitch``
-    and ``roll`` according to ``orientationStdDev``. By default the standard deviations
-    for ``pitch`` and ``roll`` are zero so that, by default, only ``yaw`` is mutated.
+    and ``roll``, using the three standard deviations (for yaw/pitch/roll respectively)
+    given by the  ``orientationStdDev`` property. It then also applies the mutator for `Point`.
+    By default the standard deviations for ``pitch`` and ``roll`` are zero so that, by
+    default, only ``yaw`` is mutated.
 
     Properties:
         yaw (float; dynamic): Yaw of the `OrientedPoint` in radians in the local coordinate system

--- a/src/scenic/core/vectors.py
+++ b/src/scenic/core/vectors.py
@@ -324,6 +324,12 @@ class Orientation:
 
     # will be converted to a distributionMethod after the class definition
     def __mul__(self, other) -> Orientation:
+        """To compose rotations, i.e. apply rotation A followed by rotation B,
+        one should compute A*B. Note that as rotations are represented intrinsically,
+        A should come first.
+        See https://en.wikipedia.org/wiki/Davenport_chained_rotations#Conversion_to_extrinsic_rotations
+        for more details.
+        """
         if type(other) is not Orientation:
             return NotImplemented
         # Preserve existing orientation objects when possible to help pruning.
@@ -339,7 +345,7 @@ class Orientation:
             other = Orientation._fromHeading(other)
         elif type(other) is not Orientation:
             return NotImplemented
-        return other * self
+        return self * other
 
     @distributionMethod
     def __radd__(self, other) -> Orientation:
@@ -347,7 +353,7 @@ class Orientation:
             other = Orientation._fromHeading(other)
         elif type(other) is not Orientation:
             return NotImplemented
-        return self * other
+        return other * self
 
     def __repr__(self):
         return f"Orientation.fromEuler{tuple(self.eulerAngles)!r}"
@@ -362,7 +368,7 @@ class Orientation:
         That is, considering ``self`` as the parent orientation, find the Euler angles
         expressing the given orientation.
         """
-        local = orientation * self.inverse
+        local = self.inverse * orientation
         return local.eulerAngles
 
     @distributionFunction

--- a/src/scenic/core/vectors.py
+++ b/src/scenic/core/vectors.py
@@ -324,9 +324,11 @@ class Orientation:
 
     # will be converted to a distributionMethod after the class definition
     def __mul__(self, other) -> Orientation:
-        """To compose rotations, i.e. apply rotation A followed by rotation B,
-        one should compute A*B. Note that as rotations are represented intrinsically,
-        A should come first.
+        """Apply a rotation to this orientation, yielding a new orientation.
+
+        As we represent orientations as intrinsic rotations, rotation A followed by rotation B is
+        given by the quaternion product A*B, not B*A.
+
         See https://en.wikipedia.org/wiki/Davenport_chained_rotations#Conversion_to_extrinsic_rotations
         for more details.
         """

--- a/src/scenic/domains/driving/roads.py
+++ b/src/scenic/domains/driving/roads.py
@@ -989,7 +989,7 @@ class Network:
 
         :meta private:
         """
-        return 32
+        return 33
 
     class DigestMismatchError(Exception):
         """Exception raised when loading a cached map not matching the original file."""

--- a/tests/core/test_vectors.py
+++ b/tests/core/test_vectors.py
@@ -33,6 +33,18 @@ def test_orientation_equality():
     assert o1 != o3 and not o1.approxEq(o3)
 
 
+def test_orientation_localAnglesFor():
+    for i in range(100):
+        parent = Orientation.fromEuler(
+            *[random.uniform(-math.pi, math.pi) for _ in range(3)]
+        )
+        target = Orientation.fromEuler(
+            *[random.uniform(-math.pi, math.pi) for _ in range(3)]
+        )
+        local = Orientation.fromEuler(*parent.localAnglesFor(target))
+        assert target.approxEq(parent * local)
+
+
 def test_distribution_method_encapsulation():
     vf = VectorField("Foo", lambda pos: 0)
     pt = vf.followFrom(Vector(0, 0), Options([1, 2]), steps=1)

--- a/tests/core/test_vectors.py
+++ b/tests/core/test_vectors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from scenic.core.distributions import Options, underlyingFunction
 from scenic.core.lazy_eval import (
     DelayedArgument,
@@ -34,6 +36,11 @@ def test_orientation_equality():
 
 
 def test_orientation_localAnglesFor():
+    parent = Orientation.fromEuler(math.pi / 4, math.pi / 4, 0)
+    target = Orientation.fromEuler(-3 * math.pi / 4, math.pi / 4, math.pi / 4)
+    angles = parent.localAnglesFor(target)
+    assert angles == pytest.approx((-3 * math.pi / 4, math.pi / 2, 0))
+
     for i in range(100):
         parent = Orientation.fromEuler(
             *[random.uniform(-math.pi, math.pi) for _ in range(3)]

--- a/tests/syntax/test_operators.py
+++ b/tests/syntax/test_operators.py
@@ -688,6 +688,21 @@ def test_orientation_relative_to_orientation():
     assert ego.orientation.approxEq(Orientation.fromEuler(math.pi / 2, math.pi / 2, 0))
 
 
+def test_orientation_relative_to_orientation2():
+    ego = sampleEgoFrom(
+        """
+        ego = new Object facing (Orientation.fromEuler(-135 deg, 45 deg, 0)
+        relative to Orientation.fromEuler(90 deg, 0, 0))
+    """
+    )
+    assert ego.yaw == pytest.approx(math.radians(-45))
+    assert ego.pitch == pytest.approx(math.radians(45))
+    assert ego.roll == pytest.approx(0)
+    assert ego.orientation.approxEq(
+        Orientation.fromEuler(math.radians(-45), math.radians(45), 0)
+    )
+
+
 def test_heading_relative_to_orientation():
     ego = sampleEgoFrom(
         """

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -1111,6 +1111,21 @@ def test_facing_directly_away_from():
     assert ego.roll == 0
 
 
+def test_facing_directly_toward_parent_orientation():
+    ego = sampleEgoFrom(
+        """
+        ego = new Object facing directly toward (1,1,2**0.5),
+            with parentOrientation (90 deg, 0, 0)
+    """
+    )
+    assert ego.yaw == pytest.approx(-math.radians(135))
+    assert ego.pitch == pytest.approx(math.radians(45))
+    assert ego.roll == pytest.approx(0)
+    assert ego.orientation.approxEq(
+        Orientation.fromEuler(math.radians(45), math.radians(45), 0)
+    )
+
+
 # Apparently Facing
 def test_apparently_facing():
     ego = sampleEgoFrom(

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -10,6 +10,7 @@ from tests.utils import (
     compileScenic,
     sampleEgo,
     sampleEgoFrom,
+    sampleParamPFrom,
     sampleScene,
     sampleSceneFrom,
 )
@@ -1069,6 +1070,20 @@ def test_facing_vf_3d():
     )
 
 
+def test_facing_equivalence():
+    p = sampleParamPFrom(
+        """
+        a = new OrientedPoint facing (Orientation.fromEuler(-135 deg, 45 deg, 0)
+        relative to Orientation.fromEuler(90 deg, 0, 0))
+
+        b = new OrientedPoint with parentOrientation (90 deg, 0, 0), with yaw -135 deg, with pitch 45 deg, with roll 0
+        param p = (a, b)
+        """
+    )
+    a, b = p
+    assert a.orientation.eulerAngles == pytest.approx(b.orientation.eulerAngles)
+
+
 # Facing Toward/Away From
 def test_facing_toward():
     ego = sampleEgoFrom(
@@ -1122,7 +1137,7 @@ def test_facing_directly_toward_parent_orientation():
     assert ego.pitch == pytest.approx(math.radians(45))
     assert ego.roll == pytest.approx(0)
     assert ego.orientation.approxEq(
-        Orientation.fromEuler(math.radians(45), math.radians(45), 0)
+        Orientation.fromEuler(math.radians(-45), math.radians(45), 0)
     )
 
 


### PR DESCRIPTION
### Description
Fixed orientations being composed backwards. Also added several tests and updated some documentation.

### Issue Link
N/A

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [X] I have added test cases (if applicable)

### Additional Notes
N/A