### PR TITLE
Fix orientation conversion for CARLA

### DIFF
--- a/src/scenic/simulators/carla/utils/utils.py
+++ b/src/scenic/simulators/carla/utils/utils.py
@@ -33,7 +33,9 @@ def scenicToCarlaLocation(pos, z=None, world=None, blueprint=None):
 
 
 def scenicToCarlaRotation(orientation):
-    pitch, yaw, roll = orientation.r.as_euler("XZY", degrees=True)
+    # CARLA uses intrinsic yaw, pitch, roll rotations (in that order), like Scenic,
+    # but with yaw being left-handed and with zero yaw being East.
+    yaw, pitch, roll = orientation.r.as_euler("ZXY", degrees=True)
     yaw = -yaw - 90
     return carla.Rotation(pitch=pitch, yaw=yaw, roll=roll)
 
@@ -54,9 +56,9 @@ def carlaToScenicElevation(loc):
 
 
 def carlaToScenicOrientation(rot):
-    angles = (rot.pitch, -rot.yaw - 90, rot.roll)
+    angles = (-rot.yaw - 90, rot.pitch, rot.roll)
     r = scipy.spatial.transform.Rotation.from_euler(
-        seq="XZY", angles=angles, degrees=True
+        seq="ZXY", angles=angles, degrees=True
     )
     return Orientation(r)
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Fixes the conversions between Scenic orientations and CARLA rotations so that they work for arbitrary 3D orientations.
### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
#176 was probably a combination of this bug and the broader Scenic bug fixed in #241; this PR fixes the scenario provided in #176.
### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->
Once the CARLA CI is set up we can add tests for this conversion; there isn't really anything we can add to the main test suite, unfortunately.

For future reference, the discussion of CARLA's conventions for rotations in #176 was wrong (CARLA's documentation is absolutely unhelpful here): in the course of fixing this issue I determined by experiment that CARLA uses the same ZXY intrinsic rotation sequence as Scenic, except that the Z rotation (yaw) is left-handed and the global orientation points East. I've added a comment to this effect in the code.