### PR TITLE
fix: Apple Silicon devices can generate multiple scenarios

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"pillow ~= 9.1",
 	'pygame >= 2.1.3.dev8, <3; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
-	"pyglet ~= 1.5",
+	"pyglet == 1.5.26",
 	"python-fcl >= 0.7",
 	"Rtree ~= 1.0",
 	"rv-ltl ~= 0.1",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
For this fix, I noticed that when if we use `pyglet>=1.5.28` in our `pyproject.toml` it will use default to shutting down the generated Scenario immediately after the [`.show()` is called to render the trimesh Scene](https://github.com/BerkeleyLearnVerify/Scenic/blob/d846a15bced1b5fd3030101116d6eb5af89d4a34/src/scenic/core/scenarios.py#L234). To resolve this I played with installing earlier versions of `pyglet` and landed on `1.5.26` as a good alternative to allow us to create multiple scenarios on Apple silicon devices, as is the expected behavior. Below is a video illustrating the fix:


https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/4c439741-985d-44b4-80f5-5978f785d3c6



### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
#230 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->