### PR TITLE
fix: add more clarity to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -36,7 +36,7 @@ body:
 
         1. Clear and concise description of the bug
         2. `scenic` command you ran locally (e.g. `scenic test.scenic --count 1 -b`, etc.). Please rerun your simulation error with the **`-b`** parameter for a full stack trace.
-        2. Error log. It helps improving readability if the error log is wrapped in ```triple quotes blocks```.
+        3. Error log. It helps improving readability if the error log is wrapped in ```triple quotes blocks```.
 
       placeholder: |
         1. Scenic has a bug

--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -32,11 +32,16 @@ body:
     attributes:
       label: Detailed Description
       description: |
-        Please provide a clear and concise description of what the bug is and paste the error log below. Please rerun your simulation error with the **`-b`** parameter for a full stack trace.
-        It helps improving readability if the error log is wrapped in ```triple quotes blocks```.
-      placeholder: |
-        A clear and concise description of what the bug is. You can rerun your Scenic simulation with `-b` to get a full stack trace.
+        Please provide a clear and concise description of what the bug is and paste the error log below.
 
+        1. Clear and concise description of the bug
+        2. `scenic` command you ran locally (e.g. `scenic test.scenic --count 1 -b`, etc.). Please rerun your simulation error with the **`-b`** parameter for a full stack trace.
+        2. Error log. It helps improving readability if the error log is wrapped in ```triple quotes blocks```.
+
+      placeholder: |
+        1. Scenic has a bug
+        2. `scenic test.scenic -b`
+        3. Error Log
         ```
         # error full stack trace
         ```
@@ -67,5 +72,5 @@ body:
       options:
         - label: I am reporting an issue, not asking a question
           required: true
-        - label: I checked the open issues, forum, etc. and have not found any solution
+        - label: I checked the open and closed issues, forum, etc. and have not found any solution
         - label: I have provided all necessary code, etc. to reproduce the issue

--- a/.github/ISSUE_TEMPLATE/2-docs.yml
+++ b/.github/ISSUE_TEMPLATE/2-docs.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        #### Thank you for contributing! Before submitting a doc issue, please make sure it has no duplicate and has not already been addressed by searching through [the existing and past issues](https://github.com/BerkeleyLearnVerify/Scenic/issues)
+        #### Thank you for contributing! Before submitting a doc issue, please make sure it has no duplicate and has not already been addressed by searching through [the existing and past open and closed issues](https://github.com/BerkeleyLearnVerify/Scenic/issues)
 
   - type: textarea
     attributes:
@@ -32,4 +32,4 @@ body:
       options:
         - label: I am reporting an issue, not asking a question
           required: true
-        - label: I checked the open issues, forum, etc. and have not found any solution
+        - label: I checked the open and closed issues, forum, etc. and have not found any solution

--- a/.github/ISSUE_TEMPLATE/3-feature.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        #### Thank you for contributing! Before submitting a feature request, please make sure it has no duplicate and has not already been addressed by searching through [the existing and past issues](https://github.com/BerkeleyLearnVerify/Scenic/issues)
+        #### Thank you for contributing! Before submitting a feature request, please make sure it has no duplicate and has not already been addressed by searching through [the existing and past open and closed issues](https://github.com/BerkeleyLearnVerify/Scenic/issues)
 
   - type: textarea
     attributes:
@@ -28,4 +28,4 @@ body:
     attributes:
       label: Issue Submission Checklist
       options:
-        - label: I checked the open issues, forum, etc. and have not found any solution
+        - label: I checked the open and closed issues, forum, etc. and have not found any solution


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
When running through on-call, issue triaging, there was a need to enhance the existing issue templates to include:

1. explicit mention of looking through both closed and open issues before filing the bug/feat request
2. adding the exact `scenic` command to be able to reproduce locally

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->