### PR TITLE
Add Tox plugin to work around cyclic dependency on verifai

### DIFF
--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,17 @@
+import tox.plugin
+
+
+@tox.plugin.impl
+def tox_on_install(tox_env, arguments, section, of_type):
+    # Add extra installation stage to install Scenic *before* its dependencies,
+    # so that if we install VerifAI we won't pull in a different version of
+    # Scenic that might have different dependencies. (This is currently
+    # necessary since Tox installs the dependencies and Scenic in 2 different
+    # invocations of pip. See https://github.com/tox-dev/tox/discussions/3273
+    # for a discussion.)
+    if section == "RunToxEnv" and of_type == "package":
+        assert len(arguments) == 1
+        package = arguments[0]
+        path = package.path
+        install_args = ["--force-reinstall", "--no-deps", str(path)]
+        tox_env.installer._execute_installer(install_args, "package_early")


### PR DESCRIPTION
### Description

The `tox` environments with the `test-full` extra (`py38-extras` etc.) recently broke, since they install `verifai`, whose cyclic dependency on `scenic` causes issues with the way that `tox` installs dependencies (see discussion [here](https://github.com/tox-dev/tox/discussions/3273)). Until we get a better solution, this PR adds a Tox plugin which works around the problem.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

n/a

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->