### PR TITLE
Behavior Override Fix

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1020,7 +1020,7 @@ class Object(OrientedPoint):
         behavior: Behavior for dynamic agents, if any (see :ref:`dynamics`). Default
           value ``None``.
         lastActions: Tuple of :term:`actions` taken by this agent in the last time step
-          (or `None` if the object is not an agent or this is the first time step).
+          (an empty tuple if the object is not an agent or this is the first time step).
     """
 
     _scenic_properties = {
@@ -1045,7 +1045,7 @@ class Object(OrientedPoint):
         "angularVelocity": PropertyDefault((), {"dynamic"}, lambda self: Vector(0, 0, 0)),
         "angularSpeed": PropertyDefault((), {"dynamic"}, lambda self: 0),
         "behavior": None,
-        "lastActions": None,
+        "lastActions": tuple(),
         # weakref to scenario which created this object, for internal use
         "_parentScenario": None,
     }

--- a/src/scenic/core/simulators.py
+++ b/src/scenic/core/simulators.py
@@ -297,7 +297,7 @@ class Simulation(abc.ABC):
         agents: List of :term:`agents` in the simulation. An agent is any object that has
             or had a behavior at any point in the simulation. The agents list may have objects
             appended to the end as the simulation progresses (if a non-agent object has its
-            behavior overriden), but once an object is in the agents list its position is fixed.
+            behavior overridden), but once an object is in the agents list its position is fixed.
         result (`SimulationResult`): Result of the simulation, or `None` if it has not
             yet completed. This is the primary object which should be inspected to get
             data out of the simulation: the other undocumented attributes of this class

--- a/src/scenic/core/simulators.py
+++ b/src/scenic/core/simulators.py
@@ -482,7 +482,6 @@ class Simulation(abc.ABC):
             if self.verbosity >= 3:
                 for agent, actions in allActions.items():
                     print(f"      Agent {agent} takes action(s) {actions}")
-
             self.actionSequence.append(allActions)
             self.executeActions(allActions)
 

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -639,7 +639,7 @@ def test_subbehavior_until():
         """
     )
     actions = sampleEgoActions(scenario, maxSteps=4)
-    assert tuple(actions) == (1, 1, 2, None)
+    assert tuple(actions) == (1, 1, 2, actionsNone)
 
 
 def test_subbehavior_incompatible_modifiers():
@@ -2084,4 +2084,33 @@ def test_record():
         (1, (2, 0, 0)),
         (2, (4, 0, 0)),
         (3, (6, 0, 0)),
+    )
+
+
+## lastActions Property
+def test_lastActions():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for i in range(3):
+                take i
+                wait
+        ego = new Object with behavior Foo
+        other = new Object
+        record ego.lastActions as ego_lastActions
+        record other.lastActions as other_lastActions
+        """
+    )
+    result = sampleResult(scenario, maxSteps=4)
+    assert tuple(result.records["ego_lastActions"]) == (
+        (0, (0)),
+        (1, (1)),
+        (2, (2)),
+        (3, (3)),
+    )
+    assert tuple(result.records["other.lastActions"]) == (
+        (0, tuple()),
+        (1, tuple()),
+        (2, tuple()),
+        (3, tuple()),
     )

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -639,7 +639,7 @@ def test_subbehavior_until():
         """
     )
     actions = sampleEgoActions(scenario, maxSteps=4)
-    assert tuple(actions) == (1, 1, 2, actionsNone)
+    assert tuple(actions) == (1, 1, 2, None)
 
 
 def test_subbehavior_incompatible_modifiers():
@@ -2092,25 +2092,26 @@ def test_lastActions():
     scenario = compileScenic(
         """
         behavior Foo():
-            for i in range(3):
+            for i in range(4):
                 take i
-                wait
-        ego = new Object with behavior Foo
-        other = new Object
+        ego = new Object with behavior Foo, with allowCollisions True
+        other = new Object with allowCollisions True
         record ego.lastActions as ego_lastActions
         record other.lastActions as other_lastActions
         """
     )
     result = sampleResult(scenario, maxSteps=4)
     assert tuple(result.records["ego_lastActions"]) == (
-        (0, (0)),
-        (1, (1)),
-        (2, (2)),
-        (3, (3)),
+        (0, tuple()),
+        (1, (0,)),
+        (2, (1,)),
+        (3, (2,)),
+        (4, (3,)),
     )
-    assert tuple(result.records["other.lastActions"]) == (
+    assert tuple(result.records["other_lastActions"]) == (
         (0, tuple()),
         (1, tuple()),
         (2, tuple()),
         (3, tuple()),
+        (4, tuple()),
     )

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -9,7 +9,6 @@ from scenic.core.errors import InvalidScenarioError, ScenicSyntaxError, Specifie
 from scenic.core.simulators import DummySimulator, TerminationType
 from tests.utils import (
     compileScenic,
-    generateChecked,
     sampleActionsFromScene,
     sampleEgo,
     sampleEgoActions,
@@ -853,16 +852,9 @@ def test_override_leakage():
         """,
         scenario="Main",
     )
-    scene, _ = generateChecked(scenario, 1)
+    scene = sampleScene(scenario)
     assert scene.objects[0].prop == 1
-    sampleActionsFromScene(
-        scene,
-        maxIterations=1,
-        maxSteps=1,
-        singleAction=True,
-        asMapping=False,
-        timestep=1,
-    )
+    sampleActionsFromScene(scene)
     assert scene.objects[0].prop == 1
 
     scenario = compileScenic(
@@ -882,17 +874,10 @@ def test_override_leakage():
         """,
         scenario="Main",
     )
-    scene, _ = generateChecked(scenario, 1)
+    scene = sampleScene(scenario)
     assert scene.objects[0].prop == 1
     with pytest.raises(NotImplementedError):
-        sampleActionsFromScene(
-            scene,
-            maxIterations=1,
-            maxSteps=1,
-            singleAction=True,
-            asMapping=False,
-            timestep=1,
-        )
+        sampleActionsFromScene(scene)
     assert scene.objects[0].prop == 1
 
 

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -809,6 +809,31 @@ def test_override_behavior():
     assert tuple(actions) == (1, -1, -2, 2)
 
 
+def test_override_none_behavior():
+    scenario = compileScenic(
+        """
+        scenario Main():
+            setup:
+                ego = new Object
+            compose:
+                wait
+                do Sub() for 2 steps
+                wait
+        scenario Sub():
+            setup:
+                override ego with behavior Bar
+        behavior Bar():
+            x = -1
+            while True:
+                take x
+                x -= 1
+    """,
+        scenario="Main",
+    )
+    actions = sampleEgoActions(scenario, maxSteps=4)
+    assert tuple(actions) == (1, -1, -2, 2)
+
+
 def test_override_dynamic():
     with pytest.raises(SpecifierError):
         compileScenic(
@@ -1048,3 +1073,41 @@ def test_scenario_signature(body):
     assert name4 == "qux"
     assert p4.default is inspect.Parameter.empty
     assert p4.kind is inspect.Parameter.VAR_KEYWORD
+
+
+# lastActions Property
+def test_lastActions_modular():
+    scenario = compileScenic(
+        """
+        scenario Main():
+            setup:
+                ego = new Object
+                record ego.lastActions as lastActions
+            compose:
+                do Sub1() for 2 steps
+                do Sub2() for 2 steps
+                do Sub1() for 2 steps
+                wait
+        scenario Sub1():
+            setup:
+                override ego with behavior Bar
+        scenario Sub2():
+            setup:
+                override ego with behavior None
+        behavior Bar():
+            x = -1
+            while True:
+                take x
+                x -= 1
+        """,
+        scenario="Main",
+    )
+    result = sampleResult(scenario, maxSteps=6)
+    assert result.records["lastActions"] == (
+        (0, (-1)),
+        (1, (-2)),
+        (2, tuple()),
+        (3, tuple()),
+        (4, (-1)),
+        (5, (-2)),
+    )

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -845,8 +845,7 @@ def test_override_leakage():
                 do Sub1()
         scenario Sub1():
             setup:
-                override ego with prop 2
-                override ego with behavior Bar
+                override ego with prop 2, with behavior Bar
         behavior Bar():
             terminate
         """,
@@ -866,8 +865,7 @@ def test_override_leakage():
                 do Sub1()
         scenario Sub1():
             setup:
-                override ego with prop 2
-                override ego with behavior Bar
+                override ego with prop 2, with behavior Bar
         behavior Bar():
             raise NotImplementedError()
             wait

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -831,7 +831,7 @@ def test_override_none_behavior():
         scenario="Main",
     )
     actions = sampleEgoActions(scenario, maxSteps=4)
-    assert tuple(actions) == (1, -1, -2, 2)
+    assert tuple(actions) == (None, -1, -2, None)
 
 
 def test_override_dynamic():
@@ -1103,11 +1103,12 @@ def test_lastActions_modular():
         scenario="Main",
     )
     result = sampleResult(scenario, maxSteps=6)
-    assert result.records["lastActions"] == (
-        (0, (-1)),
-        (1, (-2)),
-        (2, tuple()),
+    assert tuple(result.records["lastActions"]) == (
+        (0, tuple()),
+        (1, (-1,)),
+        (2, (-2,)),
         (3, tuple()),
-        (4, (-1)),
-        (5, (-2)),
+        (4, tuple()),
+        (5, (-1,)),
+        (6, (-2,)),
     )

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -829,7 +829,7 @@ def test_override_none_behavior():
             while True:
                 take x
                 x -= 1
-    """,
+        """,
         scenario="Main",
     )
     actions = sampleEgoActions(scenario, maxSteps=4)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,7 +92,10 @@ def sampleEgoActions(
         asMapping=False,
         timestep=timestep,
     )
-    return [actions[0] if actions else None for actions in allActions]
+    return [
+        actions[0] if actions else (None if singleAction else tuple())
+        for actions in allActions
+    ]
 
 
 def sampleEgoActionsFromScene(
@@ -108,7 +111,10 @@ def sampleEgoActionsFromScene(
     )
     if allActions is None:
         return None
-    return [actions[0] for actions in allActions]
+    return [
+        actions[0] if actions else (None if singleAction else tuple())
+        for actions in allActions
+    ]
 
 
 def sampleActions(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,7 +92,7 @@ def sampleEgoActions(
         asMapping=False,
         timestep=timestep,
     )
-    return [actions[0] for actions in allActions]
+    return [actions[0] if actions else None for actions in allActions]
 
 
 def sampleEgoActionsFromScene(


### PR DESCRIPTION
### Description
Fixes the bug in Issue https://github.com/BerkeleyLearnVerify/Scenic/issues/222 , where one had issues overriding behavior if it was set to `None`. Also fixed a bug where the `lastActions` property wasn't being set properly, and added various tests.

### Issue Link
https://github.com/BerkeleyLearnVerify/Scenic/issues/222

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [X] I have added test cases (if applicable)

### Additional Notes
N/A