### PR TITLE
Various optimizations

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -810,9 +810,7 @@ class Point(Constructible):
         if hasattr(Vector, attr):
             return getattr(self.toVector(), attr)
         else:
-            raise AttributeError(
-                f"'{type(self).__name__}' object has no attribute '{attr}'"
-            )
+            self.__getattribute__(attr)
 
 
 ## OrientedPoint

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1304,6 +1304,7 @@ class Object(OrientedPoint):
             dimensions=(self.width, self.length, self.height),
             position=self.position,
             rotation=self.orientation,
+            centerMesh=False,
         )
 
     @property

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1299,12 +1299,15 @@ class Object(OrientedPoint):
     @cached_property
     def occupiedSpace(self):
         """A region representing the space this object occupies"""
+        shape = self.shape
         return MeshVolumeRegion(
-            mesh=self.shape.mesh,
+            mesh=shape.mesh,
             dimensions=(self.width, self.length, self.height),
             position=self.position,
             rotation=self.orientation,
             centerMesh=False,
+            _internal=True,
+            _isConvex=shape.isConvex,
         )
 
     @property

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -613,15 +613,15 @@ class Mutator:
     """
 
     def appliedTo(self, obj):
-        """Return a mutated copy of the given object. Implemented by subclasses.
+        """Return a mutated version of the given object. Implemented by subclasses.
 
         The mutator may inspect the ``mutationScale`` attribute of the given object
         to scale its effect according to the scale given in ``mutate O by S``.
 
         Returns:
-            A pair consisting of the mutated copy of the object (which is most easily
-            created using `_copyWith`) together with a Boolean indicating whether the
-            mutator inherited from the superclass (if any) should also be applied.
+            A pair consisting of the mutated version of the object together with a
+            Boolean indicating whether the mutator inherited from the superclass
+            (if any) should also be applied.
         """
         raise NotImplementedError
 
@@ -642,8 +642,8 @@ class PositionMutator(Mutator):
             random.gauss(0, self.stddevs[1] * obj.mutationScale),
             random.gauss(0, self.stddevs[2] * obj.mutationScale),
         )
-        pos = obj.position + noise
-        return (obj._copyWith(position=pos), True)  # allow further mutation
+        obj.position += noise
+        return (obj, True)  # allow further mutation
 
     def __eq__(self, other):
         if type(other) is not type(self):
@@ -665,13 +665,11 @@ class OrientationMutator(Mutator):
         self.stddevs = tuple(stddevs)
 
     def appliedTo(self, obj):
-        yaw = obj.yaw + random.gauss(0, self.stddevs[0] * obj.mutationScale)
-        pitch = obj.pitch + random.gauss(0, self.stddevs[1] * obj.mutationScale)
-        roll = obj.roll + random.gauss(0, self.stddevs[2] * obj.mutationScale)
+        obj.yaw += random.gauss(0, self.stddevs[0] * obj.mutationScale)
+        obj.pitch += random.gauss(0, self.stddevs[1] * obj.mutationScale)
+        obj.roll += random.gauss(0, self.stddevs[2] * obj.mutationScale)
 
-        new_obj = obj._copyWith(yaw=yaw, pitch=pitch, roll=roll)
-
-        return (new_obj, True)  # allow further mutation
+        return (obj, True)  # allow further mutation
 
     def __eq__(self, other):
         if type(other) is not type(self):
@@ -803,6 +801,7 @@ class Point(Constructible):
                 sample, proceed = mutator.appliedTo(sample)
                 if not proceed:
                     break
+            sample._recomputeDynamicFinals()
         return sample
 
     # Points automatically convert to Vectors when needed

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1071,8 +1071,9 @@ class MeshVolumeRegion(MeshRegion):
         onDirection: The direction to use if an object being placed on this region doesn't specify one.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, _internal=False, _isConvex=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self._isConvex = _isConvex
 
         if isLazy(self):
             return
@@ -1084,7 +1085,7 @@ class MeshVolumeRegion(MeshRegion):
                     raise ValueError(f"{name} of MeshVolumeRegion must be positive")
 
         # Ensure the mesh is a well defined volume
-        if not self._mesh.is_volume:
+        if not _internal and not self._mesh.is_volume:
             raise ValueError(
                 "A MeshVolumeRegion cannot be defined with a mesh that does not have a well defined volume."
                 " Consider using scenic.core.utils.repairMesh."
@@ -1737,6 +1738,10 @@ class MeshVolumeRegion(MeshRegion):
             return 0
         else:
             return region_distance
+
+    @cached_property
+    def isConvex(self):
+        return self.mesh.is_convex if self._isConvex is None else self._isConvex
 
     @property
     def dimensionality(self):

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -842,26 +842,17 @@ class MeshRegion(Region):
         if centerMesh:
             self.mesh.vertices -= self.mesh.bounding_box.center_mass
 
-        # If dimensions are provided, scale mesh to those dimension
+        # Apply scaling, rotation, and translation, if any
         if self.dimensions is not None:
-            scale = self.mesh.extents / numpy.array(self.dimensions)
-
-            scale_matrix = numpy.eye(4)
-            scale_matrix[:3, :3] /= scale
-
-            self.mesh.apply_transform(scale_matrix)
-
-        # If rotation is provided, apply rotation
+            scale = numpy.array(self.dimensions) / self.mesh.extents
+        else:
+            scale = None
         if self.rotation is not None:
-            rotation_matrix = quaternion_matrix(
-                (self.rotation.w, self.rotation.x, self.rotation.y, self.rotation.z)
-            )
-            self.mesh.apply_transform(rotation_matrix)
-
-        # If position is provided, translate mesh.
-        if self.position is not None:
-            position_matrix = translation_matrix(self.position)
-            self.mesh.apply_transform(position_matrix)
+            angles = self.rotation._trimeshEulerAngles()
+        else:
+            angles = None
+        matrix = compose_matrix(scale=scale, angles=angles, translate=self.position)
+        self.mesh.apply_transform(matrix)
 
         self.orientation = orientation
 

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1123,11 +1123,13 @@ class MeshVolumeRegion(MeshRegion):
             # Check if bounding boxes intersect. If not, volumes cannot intersect.
             # For bounding boxes to intersect there must be overlap of the bounds
             # in all 3 dimensions.
-            range_overlaps = [
-                (self.mesh.bounds[0, dim] <= other.mesh.bounds[1, dim])
-                and (other.mesh.bounds[0, dim] <= self.mesh.bounds[1, dim])
+            bounds = self._mesh.bounds
+            obounds = other._mesh.bounds
+            range_overlaps = (
+                (bounds[0, dim] <= obounds[1, dim])
+                and (obounds[0, dim] <= bounds[1, dim])
                 for dim in range(3)
-            ]
+            )
             bb_overlap = all(range_overlaps)
 
             if not bb_overlap:

--- a/src/scenic/core/vectors.py
+++ b/src/scenic/core/vectors.py
@@ -311,6 +311,9 @@ class Orientation:
         """Global intrinsic Euler angles yaw, pitch, roll."""
         return self.r.as_euler("ZXY", degrees=False)
 
+    def _trimeshEulerAngles(self):
+        return self.r.as_euler("xyz", degrees=False)
+
     def getRotation(self):
         return self.r
 

--- a/src/scenic/simulators/utils/colors.py
+++ b/src/scenic/simulators/utils/colors.py
@@ -119,7 +119,7 @@ class ColorMutator(Mutator):
         hueNoise = random.gauss(0, stddev)
         satNoise = random.gauss(0, stddev)
         lightNoise = random.gauss(0, stddev)
-        color = NoisyColorDistribution.addNoiseTo(
+        obj.color = NoisyColorDistribution.addNoiseTo(
             obj.color, hueNoise, lightNoise, satNoise
         )
-        return (obj._copyWith(color=color), True)  # allow further mutation
+        return (obj, True)  # allow further mutation

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -111,7 +111,10 @@ def test_param_write():
 def test_mutate():
     scenario = compileScenic(
         """
-        ego = new Object at 3@1, facing 0
+        class Thing:
+            foo: self.heading
+
+        ego = new Thing at 3@1, facing 0
         mutate
         """
     )
@@ -119,6 +122,7 @@ def test_mutate():
     assert ego1.position.x != pytest.approx(3)
     assert ego1.position.y != pytest.approx(1)
     assert ego1.heading != pytest.approx(0)
+    assert ego1.foo == 0
 
 
 def test_mutate_object():
@@ -158,7 +162,7 @@ def test_mutate_nonobject():
             """
             ego = new Object
             mutate sin
-        """
+            """
         )
 
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Optimizes various things, mainly `MeshVolumeRegion` computations. These give a substantial speedup on the Webots vacuum scenarios for instance, without noticeably slowing down any scenarios (I checked some GTA, CARLA, and 2D-mode Webots scenarios).

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
n/a
### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->
The new ability of mutators to directly modify the object they are applied to makes it easier to introduce subtle bugs, so I'm not advertising this ability in the documentation, and may in fact decide to get rid of it before the 3.0.0 release.