### PR TITLE
chore: Updating examples for CARLA and driving domain

### DIFF
--- a/examples/carla/Carla_Challenge/carlaChallenge1.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge1.scenic
@@ -4,7 +4,7 @@ Control loss without previous action.
 The ego-vehicle loses control due to bad conditions on the road and it must recover, coming back to
 its original lane.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge1.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge1.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge1.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 01.
 Control loss without previous action.
 The ego-vehicle loses control due to bad conditions on the road and it must recover, coming back to
 its original lane.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge1.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge10.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge10.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 10.
 Crossing negotiation at an unsignalized intersection.
 The ego-vehicle needs to negotiate with other vehicles to cross an unsignalized intersection. In
 this situation it is assumed that the first to enter the intersection has priority.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge10.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge10.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge10.scenic
@@ -4,7 +4,7 @@ Crossing negotiation at an unsignalized intersection.
 The ego-vehicle needs to negotiate with other vehicles to cross an unsignalized intersection. In
 this situation it is assumed that the first to enter the intersection has priority.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge10.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge2.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge2.scenic
@@ -4,7 +4,7 @@ Longitudinal control after leading vehicle’s brake.
 The leading vehicle decelerates suddenly due to an obstacle and the ego-vehicle must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge2.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge2.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge2.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 02.
 Longitudinal control after leading vehicle’s brake.
 The leading vehicle decelerates suddenly due to an obstacle and the ego-vehicle must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge2.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 03 (dynamic).
 Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 # SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
@@ -4,7 +4,7 @@ Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge3_static.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_static.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 03 (static).
 Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge3_static.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge3_static.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_static.scenic
@@ -4,7 +4,7 @@ Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge3_static.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge4.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge4.scenic
@@ -4,7 +4,7 @@ Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge4.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge4.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge4.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 04.
 Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge4.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge5.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge5.scenic
@@ -1,6 +1,9 @@
 """ Scenario Description
 Based on 2019 Carla Challenge Traffic Scenario 05.
 Ego-vehicle performs a lane changing to evade a leading vehicle, which is moving too slowly.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge5.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')
 param carla_map = 'Town05'

--- a/examples/carla/Carla_Challenge/carlaChallenge5.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge5.scenic
@@ -2,7 +2,7 @@
 Based on 2019 Carla Challenge Traffic Scenario 05.
 Ego-vehicle performs a lane changing to evade a leading vehicle, which is moving too slowly.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge5.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')

--- a/examples/carla/Carla_Challenge/carlaChallenge6.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge6.scenic
@@ -3,7 +3,7 @@ Based on CARLA Challenge Scenario 6: https://carlachallenge.org/challenge/nhtsa/
 Ego-vehicle must go around a blocking object
 using the opposite lane, yielding to oncoming traffic.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge6.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge6.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge6.scenic
@@ -2,6 +2,9 @@
 Based on CARLA Challenge Scenario 6: https://carlachallenge.org/challenge/nhtsa/
 Ego-vehicle must go around a blocking object
 using the opposite lane, yielding to oncoming traffic.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge6.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 # N.B. Town07 is not included with CARLA by default; see installation instructions at

--- a/examples/carla/Carla_Challenge/carlaChallenge7.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge7.scenic
@@ -4,7 +4,7 @@ Ego-vehicle is going straight at an intersection but a crossing vehicle
 runs a red light, forcing the ego-vehicle to perform a collision avoidance maneuver.
 Note: The traffic light control is not implemented yet, but it will soon be. 
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge7.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')

--- a/examples/carla/Carla_Challenge/carlaChallenge7.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge7.scenic
@@ -3,6 +3,9 @@ Based on 2019 Carla Challenge Traffic Scenario 07.
 Ego-vehicle is going straight at an intersection but a crossing vehicle 
 runs a red light, forcing the ego-vehicle to perform a collision avoidance maneuver.
 Note: The traffic light control is not implemented yet, but it will soon be. 
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge7.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')
 param carla_map = 'Town05'

--- a/examples/carla/Carla_Challenge/carlaChallenge8.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge8.scenic
@@ -3,6 +3,9 @@ Traffic Scenario 08.
 Unprotected left turn at intersection with oncoming traffic.
 The ego-vehicle is performing an unprotected left turn at an intersection, yielding to oncoming
 traffic.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge8.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/Carla_Challenge/carlaChallenge8.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge8.scenic
@@ -4,7 +4,7 @@ Unprotected left turn at intersection with oncoming traffic.
 The ego-vehicle is performing an unprotected left turn at an intersection, yielding to oncoming
 traffic.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge8.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/Carla_Challenge/carlaChallenge9.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge9.scenic
@@ -2,7 +2,7 @@
 Based on 2019 Carla Challenge Traffic Scenario 09.
 Ego-vehicle is performing a right turn at an intersection, yielding to crossing traffic.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/Carla_Challenge/carlaChallenge9.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')

--- a/examples/carla/Carla_Challenge/carlaChallenge9.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge9.scenic
@@ -1,6 +1,9 @@
 """ Scenario Description
 Based on 2019 Carla Challenge Traffic Scenario 09.
 Ego-vehicle is performing a right turn at an intersection, yielding to crossing traffic.
+
+To run this file:
+    scenic examples/carla/Carla_Challenge/carlaChallenge9.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')
 param carla_map = 'Town05'

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle performs a lane change to bypass a slow 
 adversary vehicle before returning to its original lane.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle performs a lane change to bypass a slow
 adversary vehicle before returning to its original lane.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Adversary vehicle performs a lane change to bypass the 
 slow ego vehicle before returning to its original lane.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Adversary vehicle performs a lane change to bypass the
 slow ego vehicle before returning to its original lane.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic
@@ -7,7 +7,7 @@ the adversary accelerates. Ego vehicle must then slow down to avoid
 collision with leading vehicle in new lane.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic
@@ -6,6 +6,9 @@ adversary vehicle but cannot return to its original lane because
 the adversary accelerates. Ego vehicle must then slow down to avoid 
 collision with leading vehicle in new lane.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle performs multiple lane changes to bypass
 two slow adversary vehicles.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle performs multiple lane changes to bypass 
 two slow adversary vehicles.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle performs multiple lane changes to bypass three 
 slow adversary vehicles.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle performs multiple lane changes to bypass three
 slow adversary vehicles.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/bypassing/bypassing_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic
@@ -6,7 +6,7 @@ suddenly stop to avoid collision when adversary vehicle from opposite
 lane makes a left turn.
 SOURCE: NHSTA, #30
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle goes straight at 4-way intersection and must
 suddenly stop to avoid collision when adversary vehicle from opposite 
 lane makes a left turn.
 SOURCE: NHSTA, #30
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle makes a left turn at 4-way intersection and
 must suddenly stop to avoid collision when adversary vehicle from 
 opposite lane goes straight.
 SOURCE: NHSTA, #30
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic
@@ -6,7 +6,7 @@ must suddenly stop to avoid collision when adversary vehicle from
 opposite lane goes straight.
 SOURCE: NHSTA, #30
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle either goes straight or makes a left turn at
 4-way intersection and must suddenly stop to avoid collision when 
 adversary vehicle from lateral lane continues straight.
 SOURCE: NHSTA, #28 #29
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic
@@ -6,7 +6,7 @@ DESCRIPTION: Ego vehicle either goes straight or makes a left turn at
 adversary vehicle from lateral lane continues straight.
 SOURCE: NHSTA, #28 #29
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic
@@ -6,7 +6,7 @@ DESCRIPTION: Ego vehicle either goes straight or makes a left turn at
 adversary vehicle from lateral lane makes a left turn.
 SOURCE: NHSTA, #28 #29
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle either goes straight or makes a left turn at
 4-way intersection and must suddenly stop to avoid collision when 
 adversary vehicle from lateral lane makes a left turn.
 SOURCE: NHSTA, #28 #29
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle makes a right turn at 4-way intersection
 while adversary vehicle from opposite lane makes a left turn.
 SOURCE: NHSTA, #25
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle makes a right turn at 4-way intersection 
 while adversary vehicle from opposite lane makes a left turn.
 SOURCE: NHSTA, #25
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle makes a right turn at 4-way intersection while
 adversary vehicle from lateral lane goes straight.
 SOURCE: NHSTA, #25 #26
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle makes a right turn at 4-way intersection while 
 adversary vehicle from lateral lane goes straight.
 SOURCE: NHSTA, #25 #26
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_06.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic
@@ -6,7 +6,7 @@ must suddenly stop to avoid collision when adversary vehicle from
 lateral lane continues straight.
 SOURCE: NHSTA, #30
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle makes a left turn at 3-way intersection and
 must suddenly stop to avoid collision when adversary vehicle from 
 lateral lane continues straight.
 SOURCE: NHSTA, #30
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_07.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic
@@ -6,7 +6,7 @@ suddenly stop to avoid collision when adversary vehicle makes a left
 turn.
 SOURCE: NHSTA, #30
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego vehicle goes straight at 3-way intersection and must
 suddenly stop to avoid collision when adversary vehicle makes a left 
 turn.
 SOURCE: NHSTA, #30
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_08.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle makes a right turn at 3-way intersection
 while adversary vehicle from lateral lane goes straight.
 SOURCE: NHSTA, #28 #29
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle makes a right turn at 3-way intersection 
 while adversary vehicle from lateral lane goes straight.
 SOURCE: NHSTA, #28 #29
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_09.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic
@@ -5,6 +5,9 @@ DESCRIPTION: Ego Vehicle waits at 4-way intersection while adversary
 vehicle in adjacent lane passes before performing a lane change to 
 bypass a stationary vehicle waiting to make a left turn.
 SOURCE: NHSTA, #16
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic
+++ b/examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic
@@ -6,7 +6,7 @@ vehicle in adjacent lane passes before performing a lane change to
 bypass a stationary vehicle waiting to make a left turn.
 SOURCE: NHSTA, #16
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/intersection/intersection_10.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle must suddenly stop to avoid collision when
 pedestrian crosses the road unexpectedly.
 SOURCE: Carla Challenge, #03
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle must suddenly stop to avoid collision when 
 pedestrian crosses the road unexpectedly.
 SOURCE: Carla Challenge, #03
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_01.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Both ego and adversary vehicles must suddenly stop to avoid 
 collision when pedestrian crosses the road unexpectedly.
 SOURCE: Carla Challenge, #03
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Both ego and adversary vehicles must suddenly stop to avoid
 collision when pedestrian crosses the road unexpectedly.
 SOURCE: Carla Challenge, #03
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_02.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle makes a left turn at an intersection and must 
 suddenly stop to avoid collision when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle makes a left turn at an intersection and must
 suddenly stop to avoid collision when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle makes a right turn at an intersection and must 
 yield when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle makes a right turn at an intersection and must
 yield when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic
@@ -5,7 +5,7 @@ DESCRIPTION: Ego vehicle goes straight at an intersection and must
 yield when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic
+++ b/examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic
@@ -4,6 +4,9 @@ AUTHOR: Francis Indaheng, findaheng@berkeley.edu
 DESCRIPTION: Ego vehicle goes straight at an intersection and must 
 yield when pedestrian crosses the crosswalk.
 SOURCE: Carla Challenge, #04
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/pedestrian/pedestrian_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 #################################

--- a/examples/carla/OAS_Scenarios/oas_scenario_05.scenic
+++ b/examples/carla/OAS_Scenarios/oas_scenario_05.scenic
@@ -1,6 +1,9 @@
 """ Scenario Description
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:Pa>E:03
 The lead car suddenly stops and then resumes moving forward
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/OAS_Scenarios/oas_scenario_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town01.xodr')  # or other CARLA map that definitely works

--- a/examples/carla/OAS_Scenarios/oas_scenario_05.scenic
+++ b/examples/carla/OAS_Scenarios/oas_scenario_05.scenic
@@ -2,7 +2,7 @@
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:Pa>E:03
 The lead car suddenly stops and then resumes moving forward
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/OAS_Scenarios/oas_scenario_05.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/OAS_Scenarios/oas_scenario_06.scenic
+++ b/examples/carla/OAS_Scenarios/oas_scenario_06.scenic
@@ -2,6 +2,9 @@
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:Pa>E:03
 The car ahead of ego that is badly parked over the sidewalk cuts into ego vehicle's lane.
 This scenario may fail if there exists any obstacle (e.g. fences) on the sidewalk 
+
+To run this file:
+    scenic examples/carla/NHTSA_Scenarios/OAS_Scenarios/oas_scenario_06.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 

--- a/examples/carla/OAS_Scenarios/oas_scenario_06.scenic
+++ b/examples/carla/OAS_Scenarios/oas_scenario_06.scenic
@@ -3,7 +3,7 @@ Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:Pa>E:03
 The car ahead of ego that is badly parked over the sidewalk cuts into ego vehicle's lane.
 This scenario may fail if there exists any obstacle (e.g. fences) on the sidewalk 
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/NHTSA_Scenarios/OAS_Scenarios/oas_scenario_06.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/adjacentLanes.scenic
+++ b/examples/carla/adjacentLanes.scenic
@@ -1,3 +1,8 @@
+'''
+To run this file: 
+    scenic examples/carla/adjacentLanes.scenic --2d --model scenic.simulators.carla.model
+'''
+
 param map = localPath('../../assets/maps/CARLA/Town03.xodr')
 model scenic.simulators.carla.model
 

--- a/examples/carla/adjacentLanes.scenic
+++ b/examples/carla/adjacentLanes.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file: 
+To run this file using the Carla simulator:
     scenic examples/carla/adjacentLanes.scenic --2d --model scenic.simulators.carla.model
 '''
 

--- a/examples/carla/adjacentOpposingPair.scenic
+++ b/examples/carla/adjacentOpposingPair.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file: 
+To run this file using the Carla simulator:
     scenic examples/carla/adjacentOpposingPair.scenic --2d --model scenic.simulators.carla.model
 '''
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')

--- a/examples/carla/adjacentOpposingPair.scenic
+++ b/examples/carla/adjacentOpposingPair.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file: 
+    scenic examples/carla/adjacentOpposingPair.scenic --2d --model scenic.simulators.carla.model
+'''
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')
 model scenic.simulators.carla.model
 

--- a/examples/carla/backgroundActivity.scenic
+++ b/examples/carla/backgroundActivity.scenic
@@ -3,7 +3,7 @@ Background Activity
 The simulation is filled with vehicles that freely roam around the town.
 This simulates normal driving conditions, without any abnormal behaviors
 
-To run this file: 
+To run this file using the Carla simulator:
     scenic examples/carla/backgroundActivity.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 # SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/backgroundActivity.scenic
+++ b/examples/carla/backgroundActivity.scenic
@@ -2,6 +2,9 @@
 Background Activity
 The simulation is filled with vehicles that freely roam around the town.
 This simulates normal driving conditions, without any abnormal behaviors
+
+To run this file: 
+    scenic examples/carla/backgroundActivity.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 # SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)
 param map = localPath('../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works
@@ -17,6 +20,10 @@ behavior EgoBehavior(speed=10):
         do FollowLaneBehavior(speed)
     interrupt when withinDistanceToObjsInLane(self, 10):
         take SetBrakeAction(1.0)
+
+# PEDESTRIAN BEHAVIOR: cross the street
+behavior PedestrianBehavior(min_speed=1, threshold=10):
+    do CrossingBehavior(ego, min_speed, threshold)
 
 ## DEFINING SPATIAL RELATIONS
 # Please refer to scenic/domains/driving/roads.py how to access detailed road infrastructure
@@ -36,7 +43,7 @@ background_walkers = []
 for _ in range(10):
     sideWalk = Uniform(*network.sidewalks)
     background_walker = new Pedestrian in sideWalk,
-        with behavior WalkBehavior()
+        with behavior PedestrianBehavior()
     background_walkers.append(background_walker)
 
 

--- a/examples/carla/car.scenic
+++ b/examples/carla/car.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file: 
+To run this file using the Carla simulator:
     scenic examples/carla/car.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')

--- a/examples/carla/car.scenic
+++ b/examples/carla/car.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file: 
+    scenic examples/carla/car.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')
 model scenic.simulators.carla.model
 

--- a/examples/carla/manual_control/carlaChallenge1.scenic
+++ b/examples/carla/manual_control/carlaChallenge1.scenic
@@ -3,12 +3,15 @@ Traffic Scenario 01.
 Control loss without previous action.
 The ego-vehicle loses control due to bad conditions on the road and it must recover, coming back to
 its original lane.
+
+To run this file:
+    scenic examples/carla/manual_control/carlaChallenge1.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)
 param map = localPath('../../../assets/maps/CARLA/Town01.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town01'
-param render = '0'
+param render = 0
 model scenic.simulators.carla.model
 
 ## CONSTANTS

--- a/examples/carla/manual_control/carlaChallenge1.scenic
+++ b/examples/carla/manual_control/carlaChallenge1.scenic
@@ -4,7 +4,7 @@ Control loss without previous action.
 The ego-vehicle loses control due to bad conditions on the road and it must recover, coming back to
 its original lane.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/manual_control/carlaChallenge1.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
@@ -4,7 +4,7 @@ Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/manual_control/carlaChallenge3_dynamic.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
@@ -3,12 +3,15 @@ Traffic Scenario 03 (dynamic).
 Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/manual_control/carlaChallenge3_dynamic.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 # SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town05'
-param render = '0'
+param render = 0
 model scenic.simulators.carla.model
 
 # CONSTANTS

--- a/examples/carla/manual_control/carlaChallenge4.scenic
+++ b/examples/carla/manual_control/carlaChallenge4.scenic
@@ -4,7 +4,7 @@ Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/manual_control/carlaChallenge4.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/manual_control/carlaChallenge4.scenic
+++ b/examples/carla/manual_control/carlaChallenge4.scenic
@@ -3,12 +3,15 @@ Traffic Scenario 04.
 Obstacle avoidance without prior action.
 The ego-vehicle encounters an obstacle / unexpected entity on the road and must perform an
 emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/carla/manual_control/carlaChallenge4.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)
 param map = localPath('../../../assets/maps/CARLA/Town01.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town01'
-param render = '0'
+param render = 0
 model scenic.simulators.carla.model
 
 ## CONSTANTS

--- a/examples/carla/manual_control/carlaChallenge7.scenic
+++ b/examples/carla/manual_control/carlaChallenge7.scenic
@@ -3,12 +3,15 @@ Traffic Scenario 07.
 Crossing traffic running a red light at an intersection.
 The ego-vehicle is going straight at an intersection but a crossing vehicle runs a red light,
 forcing the ego-vehicle to avoid the collision.
+
+To run this file:
+    scenic examples/carla/manual_control/carlaChallenge7.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town05'
-param render = '0'
+param render = 0
 model scenic.simulators.carla.model
 
 ## CONSTANTS

--- a/examples/carla/manual_control/carlaChallenge7.scenic
+++ b/examples/carla/manual_control/carlaChallenge7.scenic
@@ -4,7 +4,7 @@ Crossing traffic running a red light at an intersection.
 The ego-vehicle is going straight at an intersection but a crossing vehicle runs a red light,
 forcing the ego-vehicle to avoid the collision.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/manual_control/carlaChallenge7.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/carla/pedestrian.scenic
+++ b/examples/carla/pedestrian.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file: 
+To run this file using the Carla simulator:
     scenic examples/carla/pedestrian.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 param map = localPath('../../assets/maps/CARLA/Town03.xodr')

--- a/examples/carla/pedestrian.scenic
+++ b/examples/carla/pedestrian.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file: 
+    scenic examples/carla/pedestrian.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
 param map = localPath('../../assets/maps/CARLA/Town03.xodr')
 param carla_map = 'Town03'
 model scenic.simulators.carla.model

--- a/examples/carla/trafficLights.scenic
+++ b/examples/carla/trafficLights.scenic
@@ -1,5 +1,8 @@
 """ Scenario Description
 Example scenario of traffic lights management.
+
+To run this file:
+    scenic examples/carla/trafficLights.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 ## SET MAP AND MODEL (i.e. definitions of all referenceable vehicle types, road library, etc)

--- a/examples/carla/trafficLights.scenic
+++ b/examples/carla/trafficLights.scenic
@@ -1,7 +1,7 @@
 """ Scenario Description
 Example scenario of traffic lights management.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/carla/trafficLights.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/Carla_Challenge/carlaChallenge2.scenic
+++ b/examples/driving/Carla_Challenge/carlaChallenge2.scenic
@@ -3,6 +3,9 @@ Based on 2019 Carla Challenge Traffic Scenario 02.
 Leading vehicle decelerates suddently due to an obstacle and 
 ego-vehicle must react, performing an emergency brake or an avoidance maneuver.
 Note: The scenario may fail if the leadCar or the ego get past the intersection while following the roadDirection
+
+To run this file:
+    scenic examples/driving/Carla_Challenge/carlaChallenge2.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town07.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town07'

--- a/examples/driving/Carla_Challenge/carlaChallenge2.scenic
+++ b/examples/driving/Carla_Challenge/carlaChallenge2.scenic
@@ -4,7 +4,7 @@ Leading vehicle decelerates suddently due to an obstacle and
 ego-vehicle must react, performing an emergency brake or an avoidance maneuver.
 Note: The scenario may fail if the leadCar or the ego get past the intersection while following the roadDirection
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/Carla_Challenge/carlaChallenge2.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town07.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/Carla_Challenge/carlaChallenge3.scenic
+++ b/examples/driving/Carla_Challenge/carlaChallenge3.scenic
@@ -2,6 +2,9 @@
 Based on 2019 Carla Challenge Traffic Scenario 03.
 Leading vehicle decelerates suddenly due to an obstacle and 
 ego-vehicle must react, performing an emergency brake or an avoidance maneuver.
+
+To run this file:
+    scenic examples/driving/Carla_Challenge/carlaChallenge3.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town01.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town01'

--- a/examples/driving/Carla_Challenge/carlaChallenge3.scenic
+++ b/examples/driving/Carla_Challenge/carlaChallenge3.scenic
@@ -3,7 +3,7 @@ Based on 2019 Carla Challenge Traffic Scenario 03.
 Leading vehicle decelerates suddenly due to an obstacle and 
 ego-vehicle must react, performing an emergency brake or an avoidance maneuver.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/Carla_Challenge/carlaChallenge3.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town01.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_03.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_03.scenic
@@ -1,6 +1,9 @@
 """ Scenario Description
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR
 The ego vehicle follows the lead car
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town04.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_03.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_03.scenic
@@ -2,7 +2,7 @@
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR
 The ego vehicle follows the lead car
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_03.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/OAS_Scenarios/oas_scenario_04.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_04.scenic
@@ -2,7 +2,7 @@
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:01
 The ego vehicle follows the lead car which suddenly stops
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/OAS_Scenarios/oas_scenario_04.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_04.scenic
@@ -1,6 +1,9 @@
 """ Scenario Description
 Voyage OAS Scenario Unique ID: 2-2-XX-CF-STR-CAR:01
 The ego vehicle follows the lead car which suddenly stops
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_04.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town07.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_28.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_28.scenic
@@ -4,7 +4,7 @@ At three-way intersection. The ego vehicle goes straight.
 The other car, on the other leg of the intersection, takes a left turn first 
 because it is closer to the intersection.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_28.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/OAS_Scenarios/oas_scenario_28.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_28.scenic
@@ -3,6 +3,9 @@ Voyage OAS Scenario Unique ID: 3-2-ESW-I-STR-CAR:S>W:02
 At three-way intersection. The ego vehicle goes straight. 
 The other car, on the other leg of the intersection, takes a left turn first 
 because it is closer to the intersection.
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_28.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_29.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_29.scenic
@@ -3,6 +3,9 @@ Voyage OAS Scenario Unique ID: 3-2-NSW-I-L-CAR:S>W:02
 At 3 way intersection. The ego car turns left. 
 The other car, on a different leg of the intersection, 
 has the right of the way and makes a left turn first because it is closer to the intersection.
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_29.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works
 param carla_map = 'Town05'

--- a/examples/driving/OAS_Scenarios/oas_scenario_29.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_29.scenic
@@ -4,7 +4,7 @@ At 3 way intersection. The ego car turns left.
 The other car, on a different leg of the intersection, 
 has the right of the way and makes a left turn first because it is closer to the intersection.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_29.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 param map = localPath('../../../assets/maps/CARLA/Town05.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_30.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_30.scenic
@@ -3,6 +3,9 @@ Voyage OAS Scenario Unique ID: 3-2-NWS-I-L-CAR:S>W:01
 At 3 way intersection. The ego car turns left. 
 The other car approaches from a different leg of the intersection to make a left turn, but
 ego has the right of the way because it is closer to the intersection.
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_30.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town10HD.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/OAS_Scenarios/oas_scenario_30.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_30.scenic
@@ -4,7 +4,7 @@ At 3 way intersection. The ego car turns left.
 The other car approaches from a different leg of the intersection to make a left turn, but
 ego has the right of the way because it is closer to the intersection.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_30.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/OAS_Scenarios/oas_scenario_32.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_32.scenic
@@ -3,7 +3,7 @@ Voyage OAS Scenario Unique ID: 3-2-W-I-L-CAR:N>S
 At 3-way intersection, ego turns left and the other car on a different leg of the
 intersection goes straight. There is no requirement on which vehicle has the right of the way.
 
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/OAS_Scenarios/oas_scenario_32.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 

--- a/examples/driving/OAS_Scenarios/oas_scenario_32.scenic
+++ b/examples/driving/OAS_Scenarios/oas_scenario_32.scenic
@@ -2,6 +2,9 @@
 Voyage OAS Scenario Unique ID: 3-2-W-I-L-CAR:N>S
 At 3-way intersection, ego turns left and the other car on a different leg of the
 intersection goes straight. There is no requirement on which vehicle has the right of the way.
+
+To run this file:
+    scenic examples/driving/OAS_Scenarios/oas_scenario_32.scenic --2d --model scenic.simulators.carla.model --simulate
 """
 
 param map = localPath('../../../assets/maps/CARLA/Town10HD.xodr')  # or other CARLA map that definitely works

--- a/examples/driving/badlyParkedCarPullingIn.scenic
+++ b/examples/driving/badlyParkedCarPullingIn.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/badlyParkedCarPullingIn.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 

--- a/examples/driving/badlyParkedCarPullingIn.scenic
+++ b/examples/driving/badlyParkedCarPullingIn.scenic
@@ -1,3 +1,8 @@
+'''
+To run this file:
+    scenic examples/driving/badlyParkedCarPullingIn.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
+
 param map = localPath('../../assets/maps/CARLA/Town05.xodr')
 param carla_map = 'Town05'
 param time_step = 1.0/10

--- a/examples/driving/car.scenic
+++ b/examples/driving/car.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/car.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 

--- a/examples/driving/car.scenic
+++ b/examples/driving/car.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file:
+    scenic examples/driving/car.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
 
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')
 

--- a/examples/driving/pedestrian.scenic
+++ b/examples/driving/pedestrian.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file:
+    scenic examples/driving/pedestrian.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
 
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')
 param carla_map = 'Town01'

--- a/examples/driving/pedestrian.scenic
+++ b/examples/driving/pedestrian.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/pedestrian.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 

--- a/examples/driving/pedestrianAcrossRoad.scenic
+++ b/examples/driving/pedestrianAcrossRoad.scenic
@@ -1,3 +1,7 @@
+'''
+To run this file:
+    scenic examples/driving/pedestrianAcrossRoad.scenic --2d --model scenic.simulators.carla.model --simulate
+'''
 
 param map = localPath('../../assets/maps/CARLA/Town01.xodr')
 

--- a/examples/driving/pedestrianAcrossRoad.scenic
+++ b/examples/driving/pedestrianAcrossRoad.scenic
@@ -1,5 +1,5 @@
 '''
-To run this file:
+To run this file using the Carla simulator:
     scenic examples/driving/pedestrianAcrossRoad.scenic --2d --model scenic.simulators.carla.model --simulate
 '''
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
This PR: 
- Updates the necessary `*.scenic` example files for the CARLA and driving domain manual control from strings to integers
- Testing was done on a Linux machine to see if the files were still working. 
- Python comments were added informing users how to run said files. 

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
As a result of testing and implementing these changes, two issues were open:
#255 
#256 

This PR intends to workaround the issues rather than provide a direct fix.

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->