### PR TITLE
fix: adding on-call reminders to every Wednesday

### DIFF
--- a/.github/workflows/on-call-reminder.yml
+++ b/.github/workflows/on-call-reminder.yml
@@ -2,7 +2,7 @@ name: on_call_reminder
 
 on:
   schedule:
-    - cron: '0 17 * * 2'  # Runs every Wednesday at 9am PST (17:00 UTC)
+    - cron: '0 17 * * 3'  # Runs every Wednesday at 9am PST (17:00 UTC)
   workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
0 is Sunday when I assumed 0 as Monday. Updating the on-call reminder to fire on Wednesday mornings when on-call rotations are meant to be handed off!

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->