### PR TITLE
chore: Updating Webots examples

### DIFF
--- a/examples/webots/city_intersection/README.md
+++ b/examples/webots/city_intersection/README.md
@@ -2,6 +2,8 @@
 
 An example showing how to use Scenic to generate training data for an autonomous car. In this example the ego car is approaching an intersection where it has an obligation to yield, with another car crossing the intersection. At regular intervals the ego car's camera output will be saved, and tagged with whether or not the crossing car is visible or not visible.
 
-First navigate to `controllers/create_avoid_obstacles` and run `make` (you may need to first set the Webots environment variable as shown [here](https://cyberbotics.com/doc/guide/compiling-controllers-in-a-terminal)). Then run the scenario using the `worlds/city_intersection.wbt` file in webots and play the simulation by pressing one of the buttons at the top (we recommend "Run the simulation as fast as possible" to maximize speed). After Webots closes (indicating the simulations has completed), look in the `images` directory for the tagged images.
+First ensure that you have your `WEBOTS_HOME` environment variable set to the root of your Webots directory by running: `export WEBOTS_HOME=/path/to/webots`.
+
+Then navigate to `controllers/autonomous_vehicle` and run `make` (you may need to first set the Webots environment variable as shown [here](https://cyberbotics.com/doc/guide/compiling-controllers-in-a-terminal)). Then run the scenario using the `worlds/city_intersection.wbt` file in webots and play the simulation by pressing one of the buttons at the top (we recommend "Run the simulation as fast as possible" to maximize speed). After Webots closes (indicating the simulations has completed), look in the `images` directory for the tagged images.
 
 These examples are intended to be run **without** the ``--2d`` flag.

--- a/examples/webots/vacuum/README.md
+++ b/examples/webots/vacuum/README.md
@@ -2,6 +2,8 @@
 
 An example showing how to use Scenic to evaluate the coverage of a robot vacuum. 
 
-First navigate to `controllers/create_avoid_obstacles` and run `make` (you may need to first set the Webots environment variable as shown [here](https://cyberbotics.com/doc/guide/compiling-controllers-in-a-terminal)). Then run the scenario using the `worlds/create.wbt` file in webots and play the simulation by pressing one of the buttons at the top (we recommend "Run the simulation as fast as possible" to maximize speed). After Webots closes (indicating all simulations have run), run `python summary.py` to get a summary of the output.
+First ensure that you have your `WEBOTS_HOME` environment variable set to the root of your Webots directory by running: `export WEBOTS_HOME=/path/to/webots`.
+
+Then navigate to `controllers/create_avoid_obstacles` and run `make` (you may need to first set the Webots environment variable as shown [here](https://cyberbotics.com/doc/guide/compiling-controllers-in-a-terminal)). Then run the scenario using the `worlds/create.wbt` file in webots and play the simulation by pressing one of the buttons at the top (we recommend "Run the simulation as fast as possible" to maximize speed). After Webots closes (indicating all simulations have run), run `python summary.py` to get a summary of the output.
 
 These examples are intended to be run **without** the ``--2d`` flag.


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
This PR aims to clean up the `examples/webots` folder. Namely, more clarification was added to the `README.md` on how to run dynamic simulations in Webots.

**Pending items:** #262 some of the examples are a bit outdated so will wait to hear on the status of what to do with these examples next. 

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
Related to #262 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->