### PR TITLE
chore: Adding flag for `pyglet` downgrade for Apple Silicon Devices

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,7 @@ codecov:
   require_ci_to_pass: true
   ignore:
     - "src/scenic/simulators/**"
+    - "tests/**"
     - "!src/scenic/simulators/newtonian/**"
     - "!src/scenic/simulators/utils/**"
 cli:

--- a/docs/install_notes.rst
+++ b/docs/install_notes.rst
@@ -96,12 +96,10 @@ If on an Apple-silicon machine you get an error related to pip being unable to i
 Scenic generates only one scene on Apple silicon
 +++++++++++++++++++++++++++++++++++++++++++++++++++
 
-If on an Apple-silicon machine you get an error where your run a ``.scenic`` file and it only generates a single scene, you may need to downgrade the version of ``pyglet`` as follows:
+If you're using an Apple-silicon machine and you encounter an issue where running a ``.scenic`` file generates only a single scene, try the following steps to adjust the ``pyglet`` version:
 
-1. Follow the MacOS instructions on :ref:`quickstart` for the repository installation.
-2. Inside the root of the Scenic repo, update the ``pyglet`` version from ``"pyglet ~= 1.5"`` to ``"pyglet == 1.5.26"``. 
-3. Activate the virutal environment if you haven't done so already and run: ``python -m pip install -e .``
-4. Confirm that you are using the updated version of ``pyglet`` by running: ``pip freeze``.
+1. Complete the usual Scenic installation steps, including activating a virtual environment.
+2. Run: ``pip install pyglet==1.5.26``
 
 For more updates on the related issue, please refer to the `GitHub open issue <https://github.com/BerkeleyLearnVerify/Scenic/issues/230>`_.
 

--- a/docs/install_notes.rst
+++ b/docs/install_notes.rst
@@ -91,6 +91,20 @@ If on an Apple-silicon machine you get an error related to pip being unable to i
 4. Activate your virtual environment if you haven't already.
 5. Install the package using pip with the following command: :command:`CPATH=$(brew --prefix)/include:$(brew --prefix)/include/eigen3 LD_LIBRARY_PATH=$(brew --prefix)/lib python -m pip install .`
 
+.. _pygletversion:
+
+Scenic generates only one scene on Apple silicon
++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+If on an Apple-silicon machine you get an error where your run a ``.scenic`` file and it only generates a single scene, you may need to downgrade the version of ``pyglet`` as follows:
+
+1. Follow the MacOS instructions on :ref:`quickstart` for the repository installation.
+2. Inside the root of the Scenic repo, update the ``pyglet`` version from ``"pyglet ~= 1.5"`` to ``"pyglet == 1.5.26"``. 
+3. Activate the virutal environment if you haven't done so already and run: ``python -m pip install -e .``
+4. Confirm that you are using the updated version of ``pyglet`` by running: ``pip freeze``.
+
+For more updates on the related issue, please refer to the `GitHub open issue <https://github.com/BerkeleyLearnVerify/Scenic/issues/230>`_.
+
 Windows
 -------
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
As a temporarily workaround in place, we are working to add some steps in the documentation FAQs to get Apple Silicon users of Scenic to downgrade to `pyglet` 1.5.26 to be able to generate multiple scenes.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
#230 

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->