### PR TITLE
fix: updating pillow version for MacOS Apple Silicon installation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,7 @@ codecov:
   require_ci_to_pass: true
   ignore:
     - "src/scenic/simulators/**"
+    - "tests/**"
     - "!src/scenic/simulators/newtonian/**"
     - "!src/scenic/simulators/utils/**"
 cli:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 	"numpy ~= 1.24",
 	"opencv-python ~= 4.5",
 	"pegen >= 0.3.0",
-	"pillow ~= 9.1",
+	"pillow >= 9.1",
 	'pygame >= 2.1.3.dev8, <3; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
 	"pyglet ~= 1.5",


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Adding looser constraint for `pillow` version to facilitate MacOS Apple Silicon wheels installation. 

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
N/A

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->