### PR TITLE
feat: Adding Discourse Links to Relevant Sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions
-    url: https://forum.scenic-lang.org/latest
-    about: Send your questions to our Discourse
+    url: https://forum.scenic-lang.org/
+    about: Post your questions on our community forum

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Questions
-    url: https://forms.gle/uUhQNuPzQrvvBFJX9
-    about: Send your questions via Google Form
+    url: https://forum.scenic-lang.org/latest
+    about: Send your questions to our Discourse

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Scenic was initially designed and implemented by Daniel J. Fremont, Tommaso Dreo
 Additionally, Edward Kim made major contributions to Scenic 2, and Eric Vin, Shun Kashiwa, Matthew Rhea, and Ellen Kalvan to Scenic 3.
 Please see our [Credits](https://scenic-lang.readthedocs.io/en/latest/credits.html) page for details and more contributors.
 
-If you have any problems using Scenic, please submit an issue to [our GitHub repository](https://github.com/BerkeleyLearnVerify/Scenic) or start a conversation on our [Discourse community](https://forum.scenic-lang.org/latest).
+If you have any problems using Scenic, please submit an issue to [our GitHub repository](https://github.com/BerkeleyLearnVerify/Scenic) or start a conversation on our [community forum](https://forum.scenic-lang.org/).
 
 The repository is organized as follows:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Scenic was initially designed and implemented by Daniel J. Fremont, Tommaso Dreo
 Additionally, Edward Kim made major contributions to Scenic 2, and Eric Vin, Shun Kashiwa, Matthew Rhea, and Ellen Kalvan to Scenic 3.
 Please see our [Credits](https://scenic-lang.readthedocs.io/en/latest/credits.html) page for details and more contributors.
 
-If you have any problems using Scenic, please submit an issue to [our GitHub repository](https://github.com/BerkeleyLearnVerify/Scenic).
+If you have any problems using Scenic, please submit an issue to [our GitHub repository](https://github.com/BerkeleyLearnVerify/Scenic) or start a conversation on our [Discourse community](https://forum.scenic-lang.org/latest).
 
 The repository is organized as follows:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,7 @@ codecov:
   require_ci_to_pass: true
   ignore:
     - "src/scenic/simulators/**"
+    - "tests/**"
     - "!src/scenic/simulators/newtonian/**"
     - "!src/scenic/simulators/utils/**"
 cli:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Discourse is not set up for Scenic 🥳 🎉 . Let's add references to it where relevant!

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->
N/A

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->