### PR TITLE
feat: adding output gif for newtonian simulator

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,6 +17,7 @@ codecov:
   require_ci_to_pass: true
   ignore:
     - "src/scenic/simulators/**"
+    - "tests/**"
     - "!src/scenic/simulators/newtonian/**"
     - "!src/scenic/simulators/utils/**"
 cli:

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -68,10 +68,8 @@ class NewtonianSimulator(DrivingSimulator):
         simulation = NewtonianSimulation(
             scene, self.network, self.render, self.export_gif, **kwargs
         )
-        if self.export_gif:
-            print("Starting to generate gif")
+        if self.export_gif and self.render:
             simulation.generate_gif("simulation.gif")
-            print("Ending generation for gif")
         return simulation
 
 

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -196,7 +196,7 @@ class NewtonianSimulation(DrivingSimulation):
             pygame.event.pump()
 
     def draw_objects(self):
-        self.screen.fill((255, 255, 255))
+        # self.screen.fill((255, 255, 255))
         for screenPoints, color, width in self.network_polygons:
             pygame.draw.lines(self.screen, color, False, screenPoints, width=width)
 

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -196,7 +196,7 @@ class NewtonianSimulation(DrivingSimulation):
             pygame.event.pump()
 
     def draw_objects(self):
-        # self.screen.fill((255, 255, 255))
+        self.screen.fill((255, 255, 255))
         for screenPoints, color, width in self.network_polygons:
             pygame.draw.lines(self.screen, color, False, screenPoints, width=width)
 

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -65,16 +65,21 @@ class NewtonianSimulator(DrivingSimulator):
         self.network = network
 
     def createSimulation(self, scene, **kwargs):
-        simulation = NewtonianSimulation(scene, self.network, self.render, **kwargs)
+        simulation = NewtonianSimulation(
+            scene, self.network, self.render, self.export_gif, **kwargs
+        )
         if self.export_gif:
+            print("Starting to generate gif")
             simulation.generate_gif("simulation.gif")
+            print("Ending generation for gif")
         return simulation
 
 
 class NewtonianSimulation(DrivingSimulation):
     """Implementation of `Simulation` for the Newtonian simulator."""
 
-    def __init__(self, scene, network, render, timestep, **kwargs):
+    def __init__(self, scene, network, render, export_gif, timestep, **kwargs):
+        self.export_gif = export_gif
         self.render = render
         self.network = network
         self.frames = []

--- a/src/scenic/simulators/newtonian/simulator.py
+++ b/src/scenic/simulators/newtonian/simulator.py
@@ -58,14 +58,16 @@ class NewtonianSimulator(DrivingSimulator):
         when not otherwise specified is still 0.1 seconds.
     """
 
-    def __init__(self, network=None, render=False):
+    def __init__(self, network=None, render=False, export_gif=False):
         super().__init__()
+        self.export_gif = export_gif
         self.render = render
         self.network = network
 
     def createSimulation(self, scene, **kwargs):
         simulation = NewtonianSimulation(scene, self.network, self.render, **kwargs)
-        simulation.generate_gif("simulation.gif")
+        if self.export_gif:
+            simulation.generate_gif("simulation.gif")
         return simulation
 
 
@@ -220,9 +222,10 @@ class NewtonianSimulation(DrivingSimulation):
 
         pygame.display.update()
 
-        frame = pygame.surfarray.array3d(self.screen)
-        frame = np.transpose(frame, (1, 0, 2))
-        self.frames.append(frame)
+        if self.export_gif:
+            frame = pygame.surfarray.array3d(self.screen)
+            frame = np.transpose(frame, (1, 0, 2))
+            self.frames.append(frame)
 
         time.sleep(self.timestep)
 

--- a/tests/simulators/newtonian/driving.scenic
+++ b/tests/simulators/newtonian/driving.scenic
@@ -21,3 +21,5 @@ third = new Car on visible ego.road, with behavior Potpourri
 require abs((apparent heading of third) - 180 deg) <= 30 deg
 
 new Object visible, with width 0.1, with length 0.1
+
+terminate after 2 steps

--- a/tests/simulators/newtonian/test_newtonian.py
+++ b/tests/simulators/newtonian/test_newtonian.py
@@ -37,6 +37,7 @@ def test_driving_2D(loadLocalScenario):
     check()
     check()  # If we fail here, something is leaking.
 
+
 @pytest.mark.graphical
 def test_gif_creation(loadLocalScenario):
     scenario = loadLocalScenario("driving.scenic", mode2D=True)

--- a/tests/simulators/newtonian/test_newtonian.py
+++ b/tests/simulators/newtonian/test_newtonian.py
@@ -1,5 +1,10 @@
+import os
+from pathlib import Path
+
+from PIL import Image as IPImage
 import pytest
 
+from scenic.domains.driving.roads import Network
 from scenic.simulators.newtonian import NewtonianSimulator
 from tests.utils import pickle_test, sampleScene, tryPickling
 
@@ -31,6 +36,17 @@ def test_driving_2D(loadLocalScenario):
     # Run this twice to catch leaks between successive compilations.
     check()
     check()  # If we fail here, something is leaking.
+
+
+def test_gif_creation(loadLocalScenario):
+    scenario = loadLocalScenario("driving.scenic", mode2D=True)
+    scene, _ = scenario.generate(maxIterations=1000)
+    path = Path("assets") / "maps" / "CARLA" / "Town01.xodr"
+    network = Network.fromFile(path)
+    simulator = NewtonianSimulator(render=True, network=network, export_gif=True)
+    simulation = simulator.simulate(scene, maxSteps=100)
+    gif_path = Path("") / "simulation.gif"
+    assert os.path.exists(gif_path)
 
 
 @pickle_test

--- a/tests/simulators/newtonian/test_newtonian.py
+++ b/tests/simulators/newtonian/test_newtonian.py
@@ -37,7 +37,7 @@ def test_driving_2D(loadLocalScenario):
     check()
     check()  # If we fail here, something is leaking.
 
-
+@pytest.mark.graphical
 def test_gif_creation(loadLocalScenario):
     scenario = loadLocalScenario("driving.scenic", mode2D=True)
     scene, _ = scenario.generate(maxIterations=1000)


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
As a way to illustrate dynamic scenarios more concretely in Google Colab, added a feature to show dynamic scenarios via an output gif. See the output gif when running: 

```
scenic examples/driving/badlyParkedCarPullingIn.scenic -S -m scenic.simulators.newtonian.driving_model --2d
```

https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/b7f640b8-af61-4a27-8754-f42ccff40cef

Also I am adding that it works with Colab:


https://github.com/BerkeleyLearnVerify/Scenic/assets/32311654/667fc2fb-097b-4d17-9166-5a1e54ae9d32



### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->