### PR TITLE
Minor Fixes for 3.0

### DIFF
--- a/docs/reference/functions.rst
+++ b/docs/reference/functions.rst
@@ -70,6 +70,10 @@ localPath
 ---------
 The `localPath` function takes a relative path with respect to the directory containing the ``.scenic`` file where it is used, and converts it to an absolute path. Note that the path is returned as a `pathlib.Path` object.
 
+.. versionchanged:: 3.0
+
+    This function now returns a `pathlib.Path` object instead of a string.
+
 .. _verbosePrint_func:
 
 verbosePrint

--- a/examples/webots/city_intersection/city_intersection.scenic
+++ b/examples/webots/city_intersection/city_intersection.scenic
@@ -52,7 +52,7 @@ class LogImageAction(Action):
     def applyTo(self, obj, sim):
         print("Other Car Visible:", self.visible)
         
-        target_path = self.path + "/"
+        target_path = str(self.path) + "/"
         target_path += "visible" if self.visible else "invisible"
 
         if not os.path.exists(target_path):

--- a/tests/syntax/test_pruning.py
+++ b/tests/syntax/test_pruning.py
@@ -55,14 +55,14 @@ def test_containment_2d_region():
 
     # Test both combined, in a slightly more complicated case.
     # Specifically, there is a non vertical component to baseOffset
-    # that should be accounted for and the height is random.
+    # that should be accounted.
     scenario = compileScenic(
         """
         class TestObject:
             baseOffset: (0.1, 0, self.height/2)
 
         workspace = Workspace(PolygonalRegion([0@0, 2@0, 2@2, 0@2]))
-        ego = new TestObject on workspace, with height Range(0.1,0.5)
+        ego = new TestObject on workspace, with height 100
         """
     )
     # Sampling should fail ~30.56% of the time, so


### PR DESCRIPTION
### Description
Adjusts a pruning test to be less difficult and fixes a Webots example to account for a change to the `localPath` function.

### Issue Link
https://github.com/BerkeleyLearnVerify/Scenic/issues/261

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A