### PR TITLE
Fix Verifai Sampler with more than 10 objects

### DIFF
--- a/src/scenic/core/external_params.py
+++ b/src/scenic/core/external_params.py
@@ -195,7 +195,7 @@ class VerifaiSampler(ExternalSampler):
                 usingProbs = True
         space = verifai.features.FeatureSpace(
             {
-                f"param{index}": verifai.features.Feature(param.domain)
+                self.nameForParam(index): verifai.features.Feature(param.domain)
                 for index, param in enumerate(self.params)
             }
         )
@@ -262,7 +262,12 @@ class VerifaiSampler(ExternalSampler):
         return self.sampler.getSample()
 
     def valueFor(self, param):
-        return self.cachedSample[param.index]
+        return getattr(self.cachedSample, self.nameForParam(param.index))
+    
+    @staticmethod
+    def nameForParam(i):
+        """Paramter name for a given index in the Feature Space."""
+        return f'param{i}'
 
 
 class ExternalParameter(Distribution):

--- a/src/scenic/core/external_params.py
+++ b/src/scenic/core/external_params.py
@@ -263,11 +263,11 @@ class VerifaiSampler(ExternalSampler):
 
     def valueFor(self, param):
         return getattr(self.cachedSample, self.nameForParam(param.index))
-    
+
     @staticmethod
     def nameForParam(i):
         """Paramter name for a given index in the Feature Space."""
-        return f'param{i}'
+        return f"param{i}"
 
 
 class ExternalParameter(Distribution):

--- a/src/scenic/core/external_params.py
+++ b/src/scenic/core/external_params.py
@@ -266,7 +266,7 @@ class VerifaiSampler(ExternalSampler):
 
     @staticmethod
     def nameForParam(i):
-        """Paramter name for a given index in the Feature Space."""
+        """Parameter name for a given index in the Feature Space."""
         return f"param{i}"
 
 


### PR DESCRIPTION
### Description
Fixes problem with `VerifaiSampler` where there may be strange behavior when there are more than 10 samples in the scene. The problem is similar to the problem that was fixed recently in the VerifAI repo. The enumeration of objects goes as follows if there are more than 10 objects: 0, 1, 10, 2, 3, …, 9 when it expects 0, 1, 2, 3, …, 10 which causes a mismatch. This PR should fix this issue by checking that the parameter names match.

This issue might pop up for other external samplers as well, but `VerifaiSampler` is fixed at least.

### Issue Link
#276 

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A