### PR TITLE
Apply black and isort to test-webots file

### DIFF
--- a/tests/simulators/webots/test_webots.py
+++ b/tests/simulators/webots/test_webots.py
@@ -27,14 +27,16 @@ def test_dynamics_scenarios(launchWebots):
     cleanup_results()
 
     timeout_seconds = 300
-    
+
     command = f"bash {WEBOTS_ROOT}/webots --no-rendering --minimize --batch {WEBOTS_WORLD_FILE_PATH}"
 
     try:
         subprocess.run(command, shell=True, timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
-        pytest.fail(f"Webots test exceeded the timeout of {timeout_seconds} seconds and failed.")
-        
+        pytest.fail(
+            f"Webots test exceeded the timeout of {timeout_seconds} seconds and failed."
+        )
+
     data = receive_results()
     assert data != None
     start_z = float(data.split(",")[1].strip(" )]"))


### PR DESCRIPTION
### Description
This PR addresses formatting issues in the test_webots.py file that caused it to fail the black code formatter. The following changes were made:

Reformatted the file to meet black's formatting rules.
Corrected spacing and line breaks to ensure consistent code style.
The file now passes black formatting without errors. 

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->