### PR TITLE
Update pyglet constraint to allow 2.0.18 with Apple Silicon fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"pillow >= 9.1",
 	'pygame >= 2.1.3.dev8, <3; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
-	"pyglet ~= 1.5",
+	"pyglet >= 1.5",
 	"python-fcl >= 0.7",
 	"Rtree ~= 1.0",
 	"rv-ltl ~= 0.1",


### PR DESCRIPTION
### Description
Update pyglet constraint to allow pyglet 2.0.18 now that the Apple Silicon issue is fixed (see pyglet [PR #1100](https://github.com/pyglet/pyglet/issues/1100)). Previously, closing the display window on Apple Silicon would terminate the program, prompting workaround proposals in [PR #248](https://github.com/BerkeleyLearnVerify/Scenic/pull/248) and [PR #267](https://github.com/BerkeleyLearnVerify/Scenic/pull/267). With this update, that behavior is resolved.

### Issue Link
[Issue #230](https://github.com/BerkeleyLearnVerify/Scenic/issues/230)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

