### PR TITLE
Improve Carla Autopilot configuration for Scenic

### DIFF
--- a/src/scenic/simulators/carla/actions.py
+++ b/src/scenic/simulators/carla/actions.py
@@ -121,7 +121,7 @@ class SetAutopilotAction(VehicleAction):
         """
         if not isinstance(enabled, bool):
             raise RuntimeError("Enabled must be a boolean.")
-        
+
         self.enabled = enabled
 
         # Default values for optional parameters

--- a/src/scenic/simulators/carla/actions.py
+++ b/src/scenic/simulators/carla/actions.py
@@ -108,14 +108,22 @@ class SetTrafficLightAction(VehicleAction):
 
 
 class SetAutopilotAction(VehicleAction):
-    def __init__(self, enabled):
+    def __init__(self, enabled, speed=None):
+        ":param speed: speed of car in m/s"
         if not isinstance(enabled, bool):
             raise RuntimeError("Enabled must be a boolean.")
         self.enabled = enabled
+        self.speed = speed
 
     def applyTo(self, obj, sim):
         vehicle = obj.carlaActor
         vehicle.set_autopilot(self.enabled, sim.tm.get_port())
+        sim.tm.auto_lane_change(vehicle, False)
+        if self.speed:
+            sim.tm.set_desired_speed(vehicle, 3.6*self.speed)
+        sim.tm.update_vehicle_lights(vehicle, True)
+        sim.tm.random_left_lanechange_percentage(vehicle, 0)
+        sim.tm.random_right_lanechange_percentage(vehicle, 0)
 
 
 class SetVehicleLightStateAction(VehicleAction):

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -7,9 +7,9 @@ try:
 except ModuleNotFoundError:
     pass    # ignore; error will be caught later if user attempts to run a simulation
 
-behavior AutopilotBehavior():
+behavior AutopilotBehavior(speed=None):
     """Behavior causing a vehicle to use CARLA's built-in autopilot."""
-    take SetAutopilotAction(True)
+    take SetAutopilotAction(True, speed)
 
 behavior WalkForwardBehavior(speed=0.5):
     take SetWalkingDirectionAction(self.heading), SetWalkingSpeedAction(speed)

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -7,9 +7,9 @@ try:
 except ModuleNotFoundError:
     pass    # ignore; error will be caught later if user attempts to run a simulation
 
-behavior AutopilotBehavior(speed=None):
+behavior AutopilotBehavior(enabled = True, **kwargs):
     """Behavior causing a vehicle to use CARLA's built-in autopilot."""
-    take SetAutopilotAction(True, speed)
+    take SetAutopilotAction(enabled=enabled, **kwargs)
 
 behavior WalkForwardBehavior(speed=0.5):
     take SetWalkingDirectionAction(self.heading), SetWalkingSpeedAction(speed)


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

I have added improvement to Carla Autopilot behavior. Now you can control speed, path and other configuration options using the traffic manager Python API. 

Previous versions did not include setting these options. More argument can be added to this as desired. 

### Issue Link

Speed values were not working. With Autopilot and subsequent changes we rely on Carla Autopilot to adjust speed. Changing the max throttle does not work well with the PID controllers in some maps. 

https://github.com/BerkeleyLearnVerify/Scenic/issues/38 

<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [X] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->