### PR TITLE
chore: Pin GitHub Actions to specific commit hashes

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           persist-credentials: false
 
       - name: Run black to check formatting
-        uses: psf/black@stable
+        uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b
         with:
           version: "25.1.0"
 
       - name: Run isort to check import order
-        uses: isort/isort-action@v1
+        uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326
         with:
           isort-version: "5.12.0"

--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -29,21 +29,21 @@ jobs:
 
     steps:
     - name: Checkout given ref
-      uses: actions/checkout@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: inputs.ref != ''
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
 
     - name: Checkout current branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: inputs.ref == ''
       with:
         ref: ${{ github.ref }}
         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -59,9 +59,9 @@ jobs:
     - name: Run and report code coverage
       run: |
         pytest --cov --cov-report json
-    
+
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: BerkeleyLearnVerify/Scenic

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,21 +43,21 @@ jobs:
 
     steps:
     - name: Checkout given ref
-      uses: actions/checkout@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: inputs.ref != ''
       with:
         ref: ${{ inputs.ref }}
         persist-credentials: false
 
     - name: Checkout current branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: inputs.ref == ''
       with:
         ref: ${{ github.ref }}
         persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/sync-issues-with-jira.yml
+++ b/.github/workflows/sync-issues-with-jira.yml
@@ -9,7 +9,7 @@ jobs:
         steps:
           - name: Get issue details
             id: get_issue_details
-            uses: actions/github-script@v4
+            uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
             with:
               github-token: ${{ secrets.GH_ACCESS_TOKEN }}
               script: |
@@ -19,7 +19,7 @@ jobs:
                 const issueLink = `https://github.com/${repoName}/issues/${issueNumber}`;
                 console.log(`::set-output name=issueTitle::${issueTitle}`);
                 console.log(`::set-output name=issueLink::${issueLink}`);
-        
+
           - name: Create Jira Ticket
             env:
                 JIRA_DOMAIN: ${{ secrets.JIRA_DOMAIN }}
@@ -30,7 +30,7 @@ jobs:
             run: |
                 echo "Issue Title: $ISSUE_TITLE"
                 echo "Issue Link: $ISSUE_LINK"
-            
+
                 curl --request POST \
                 --url "https://$JIRA_DOMAIN.atlassian.net/rest/api/3/issue" \
                 --user "$JIRA_EMAIL:$JIRA_API_TOKEN" \

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,20 +18,20 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174
 
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif 
+        run: uvx zizmor --format sarif . > results.sarif
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@1b549b9259bda1cb5ddde3b41741a82a2d15a841
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
### Description
This PR updates our workflows to use fixed, verified commit hashes for GitHub Actions instead of version tags to enhance security.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)
