### PR TITLE
Raise ValueError for missing sumo_map in MetaDriveSimulator initializer

### DIFF
--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -38,6 +38,10 @@ class MetaDriveSimulator(DrivingSimulator):
         self.render3D = render3D if render else False
         self.scenario_number = 0
         self.timestep = timestep
+        if sumo_map is None:
+            raise ValueError(
+                "Missing SUMO map: Please specify a valid 'sumo_map' path when instantiating MetaDriveSimulator."
+            )
         self.sumo_map = sumo_map
         self.real_time = real_time
         self.scenic_offset, self.sumo_map_boundary = utils.getMapParameters(self.sumo_map)

--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -27,10 +27,10 @@ class MetaDriveSimulator(DrivingSimulator):
 
     def __init__(
         self,
+        sumo_map,
         timestep=0.1,
         render=True,
         render3D=False,
-        sumo_map=None,
         real_time=True,
     ):
         super().__init__()
@@ -38,10 +38,6 @@ class MetaDriveSimulator(DrivingSimulator):
         self.render3D = render3D if render else False
         self.scenario_number = 0
         self.timestep = timestep
-        if sumo_map is None:
-            raise ValueError(
-                "Missing SUMO map: Please specify a valid 'sumo_map' path when instantiating MetaDriveSimulator."
-            )
         self.sumo_map = sumo_map
         self.real_time = real_time
         self.scenic_offset, self.sumo_map_boundary = utils.getMapParameters(self.sumo_map)


### PR DESCRIPTION
This PR updates the MetaDriveSimulator initializer to explicitly check for a missing sumo_map parameter. If it's not provided, a clear ValueError is raised. This change is meant for users who manually instantiate the simulator via the API. When using the Scenic command line, the required sumo_map is automatically provided by the Scenic program.

### Issue Link
[Issue #331](https://github.com/BerkeleyLearnVerify/Scenic/issues/331) 

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)
