### PR TITLE
Fix: Use shapely.points instead of shapely.lib.points for point creation

### DIFF
--- a/src/scenic/core/geometry.py
+++ b/src/scenic/core/geometry.py
@@ -110,7 +110,7 @@ def distanceToLine(point, a, b):
 
 
 # Fastest known way to make a Shapely Point from a list/tuple/Vector
-makeShapelyPoint = shapely.lib.points
+makeShapelyPoint = shapely.points
 
 
 def polygonUnion(polys, buf=0, tolerance=0, holeTolerance=0.002):


### PR DESCRIPTION
### Description
This commit replaces the internal call to shapely.lib.points with the public API shapely.points. Our code worked with Shapely 2.0.7, but with the release of 2.1.0 the internal method no longer accepts our inputs correctly, causing errors during point creation. This fix resolves those errors by using the officially supported method.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A