### PR TITLE
Add support for initial velocity in MetaDrive simulations

### DIFF
--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -118,12 +118,7 @@ class MetaDriveSimulation(DrivingSimulation):
                 converted_position,
                 converted_heading,
             ]
-            if obj.velocity and (obj.velocity.x != 0 or obj.velocity.y != 0):
-                full_md_velocity = utils.scenicToMetaDriveVelocity(obj.velocity)
-                vehicle_config["spawn_velocity"] = utils.scenicToMetaDriveVelocity(
-                    obj.velocity
-                )
-                vehicle_config["spawn_velocity_car_frame"] = True
+            vehicle_config["spawn_velocity"] = [obj.velocity.x, obj.velocity.y]
 
         if not self.defined_ego:
             decision_repeat = math.ceil(self.timestep / 0.02)
@@ -231,7 +226,7 @@ class MetaDriveSimulation(DrivingSimulation):
         position = utils.metadriveToScenicPosition(
             metaDriveActor.position, self.scenic_offset
         )
-        velocity = utils.metaDriveToScenicVelocity(metaDriveActor.velocity)
+        velocity = Vector(*metaDriveActor.velocity, 0)
         speed = metaDriveActor.speed
         md_ang_vel = metaDriveActor.body.getAngularVelocity()
         angularVelocity = Vector(*md_ang_vel)

--- a/src/scenic/simulators/metadrive/utils.py
+++ b/src/scenic/simulators/metadrive/utils.py
@@ -79,26 +79,6 @@ def metaDriveToScenicHeading(metaDriveHeading):
     return (scenicHeading + math.pi) % (2 * math.pi) - math.pi
 
 
-def scenicToMetaDriveVelocity(scenic_velocity):
-    """Converts Scenic velocity to MetaDrive velocity by rotating the vector by π/2 (90 degrees)."""
-    speed = math.sqrt(scenic_velocity.x**2 + scenic_velocity.y**2)
-    scenic_heading = math.atan2(scenic_velocity.x, scenic_velocity.y)
-    md_heading = scenicToMetaDriveHeading(scenic_heading)
-    md_vx = speed * math.cos(md_heading)
-    md_vy = speed * math.sin(md_heading)
-    return (md_vx, md_vy)
-
-
-def metaDriveToScenicVelocity(md_velocity):
-    """Converts MetaDrive velocity to Scenic velocity by rotating the vector by -π/2 (i.e. subtracting π/2)."""
-    speed = math.sqrt(md_velocity[0] ** 2 + md_velocity[1] ** 2)
-    md_heading = math.atan2(md_velocity[1], md_velocity[0])
-    scenic_heading = metaDriveToScenicHeading(md_heading)
-    scenic_vx = speed * math.sin(scenic_heading)
-    scenic_vy = speed * math.cos(scenic_heading)
-    return Vector(scenic_vx, scenic_vy, 0)
-
-
 class DriveEnv(BaseEnv):
     def reward_function(self, agent):
         """Dummy reward function."""

--- a/src/scenic/simulators/metadrive/utils.py
+++ b/src/scenic/simulators/metadrive/utils.py
@@ -79,6 +79,26 @@ def metaDriveToScenicHeading(metaDriveHeading):
     return (scenicHeading + math.pi) % (2 * math.pi) - math.pi
 
 
+def scenicToMetaDriveVelocity(scenic_velocity):
+    """Converts Scenic velocity to MetaDrive velocity by rotating the vector by π/2 (90 degrees)."""
+    speed = math.sqrt(scenic_velocity.x**2 + scenic_velocity.y**2)
+    scenic_heading = math.atan2(scenic_velocity.x, scenic_velocity.y)
+    md_heading = scenicToMetaDriveHeading(scenic_heading)
+    md_vx = speed * math.cos(md_heading)
+    md_vy = speed * math.sin(md_heading)
+    return (md_vx, md_vy)
+
+
+def metaDriveToScenicVelocity(md_velocity):
+    """Converts MetaDrive velocity to Scenic velocity by rotating the vector by -π/2 (i.e. subtracting π/2)."""
+    speed = math.sqrt(md_velocity[0] ** 2 + md_velocity[1] ** 2)
+    md_heading = math.atan2(md_velocity[1], md_velocity[0])
+    scenic_heading = metaDriveToScenicHeading(md_heading)
+    scenic_vx = speed * math.sin(scenic_heading)
+    scenic_vy = speed * math.cos(scenic_heading)
+    return Vector(scenic_vx, scenic_vy, 0)
+
+
 class DriveEnv(BaseEnv):
     def reward_function(self, agent):
         """Dummy reward function."""

--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -128,3 +128,26 @@ def test_pedestrian_movement(getMetadriveSimulator):
     initialPos = simulation.result.records["InitialPos"]
     finalPos = simulation.result.records["FinalPos"]
     assert initialPos != finalPos
+
+
+def test_initial_velocity_movement(getMetadriveSimulator):
+    simulator, openDrivePath, sumoPath = getMetadriveSimulator("Town01")
+    code = f"""
+        param map = r'{openDrivePath}'
+        param sumo_map = r'{sumoPath}'
+
+        model scenic.simulators.metadrive.model
+
+        # Car should move 5 m/s west
+        ego = new Car at (30, 2), with velocity (-5, 0)
+        record initial ego.position as InitialPos
+        record final ego.position as FinalPos
+        terminate after 1 steps
+    """
+    scenario = compileScenic(code, mode2D=True)
+    scene = sampleScene(scenario)
+    simulation = simulator.simulate(scene)
+    initialPos = simulation.result.records["InitialPos"]
+    finalPos = simulation.result.records["FinalPos"]
+    dx = finalPos[0] - initialPos[0]
+    assert dx < 0, f"Expected car to move west (negative dx), but got dx = {dx}"

--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -150,4 +150,4 @@ def test_initial_velocity_movement(getMetadriveSimulator):
     initialPos = simulation.result.records["InitialPos"]
     finalPos = simulation.result.records["FinalPos"]
     dx = finalPos[0] - initialPos[0]
-    assert dx < 0, f"Expected car to move west (negative dx), but got dx = {dx}"
+    assert dx < -0.1, f"Expected car to move west (negative dx), but got dx = {dx}"


### PR DESCRIPTION
### Description
This PR adds the ability to set an initial velocity for vehicles in the MetaDrive simulator.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A