### PR TITLE
Add dynamic pedestrian example and helper; disable MetaDrive terrain generation in 3D mode

### DIFF
--- a/examples/driving/pedestrianJaywalking.scenic
+++ b/examples/driving/pedestrianJaywalking.scenic
@@ -1,0 +1,45 @@
+""" Scenario Description
+A parked car is placed off the curb. When the ego vehicle approaches, a pedestrian steps out from in front of the parked car and crosses the road.
+The ego is expected to detect the pedestrian and brake before reaching them.
+
+To run this file using the MetaDrive simulator:
+    scenic examples/driving/pedestrianJaywalking.scenic --2d --model scenic.simulators.metadrive.model --simulate
+"""
+param map = localPath('../../assets/maps/CARLA/Town01.xodr')
+model scenic.domains.driving.model
+
+#CONSTANTS
+PEDESTRIAN_TRIGGER_DISTANCE = 15     # Distance at which pedestrian begins to cross
+BRAKE_TRIGGER_DISTANCE = 10          # Distance at which ego begins braking
+EGO_TO_PARKED_CAR_MIN_DIST = 30      # Ensure ego starts far enough away
+PEDESTRIAN_OFFSET = 3                # Offset for pedestrian placement ahead of parked car
+PARKED_CAR_OFFSET = 1                # Offset for parked car from the curb
+
+#EGO BEHAVIOR: Ego drives by following lanes, but brakes if a pedestrian is close
+behavior DriveAndBrakeForPedestrians():
+    try:
+        do FollowLaneBehavior()
+    interrupt when withinDistanceToAnyPedestrians(self, BRAKE_TRIGGER_DISTANCE):
+        take SetThrottleAction(0), SetBrakeAction(1)
+
+#PEDESTRIAN BEHAVIOR: Pedestrian crosses road when ego is near
+behavior CrossRoad():
+    while distance from self to ego > PEDESTRIAN_TRIGGER_DISTANCE:
+        wait
+    take SetWalkingDirectionAction(self.heading), SetWalkingSpeedAction(1)
+
+#SCENE SETUP
+ego = new Car with behavior DriveAndBrakeForPedestrians()
+
+rightCurb = ego.laneGroup.curb
+spot = new OrientedPoint on visible rightCurb
+
+parkedCar = new Car right of spot by PARKED_CAR_OFFSET, with regionContainedIn None
+
+require distance from ego to parkedCar > EGO_TO_PARKED_CAR_MIN_DIST
+
+new Pedestrian ahead of parkedCar by PEDESTRIAN_OFFSET,
+    facing 90 deg relative to parkedCar,
+    with behavior CrossRoad()
+
+terminate after 30 seconds

--- a/src/scenic/domains/driving/model.scenic
+++ b/src/scenic/domains/driving/model.scenic
@@ -351,6 +351,18 @@ def withinDistanceToAnyObjs(vehicle, thresholdDistance):
             return True
     return False
 
+def withinDistanceToAnyPedestrians(vehicle, thresholdDistance):
+    """Returns True if any visible pedestrian is within thresholdDistance of the given vehicle."""
+    objects = simulation().objects
+    for obj in objects:
+        if obj is vehicle or not isinstance(obj, Pedestrian):
+            continue
+        if not (vehicle can see obj):
+            continue
+        if (distance from obj to front of vehicle) < thresholdDistance:
+            return True
+    return False
+
 def withinDistanceToObjsInLane(vehicle, thresholdDistance):
     """ checks whether there exists any obj
     (1) in front of the vehicle, (2) on the same lane, (3) within thresholdDistance """

--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -128,7 +128,8 @@ class MetaDriveSimulation(DrivingSimulation):
                             converted_heading,
                         ],
                     },
-                    use_mesh_terrain=self.render3D,
+                    use_mesh_terrain=False,
+                    height_scale=0.001,
                     log_level=logging.CRITICAL,
                 )
             )


### PR DESCRIPTION
### Description
This PR introduces: 
A new dynamic scenario: pedestrianJaywalking.scenic, where a pedestrian crosses the road when the ego vehicle approaches.

Added a helper function withinDistanceToAnyPedestrians() to detect nearby visible pedestrians.

Updated MetaDrive simulator settings to prevent extra physics and terrain generation in 3D render mode.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A