### PR TITLE
Constrain pyglet to >=1.5, <=1.5.26 to avoid trimesh and macOS compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"pillow >= 9.1",
 	'pygame >= 2.1.3.dev8, <3; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
-	"pyglet >= 1.5",
+	"pyglet ~= 1.5",
 	"python-fcl >= 0.7",
 	"Rtree ~= 1.0",
 	"rv-ltl ~= 0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 	"pillow >= 9.1",
 	'pygame >= 2.1.3.dev8, <3; python_version >= "3.11"',
 	'pygame ~= 2.0; python_version < "3.11"',
-	"pyglet ~= 1.5",
+	"pyglet >= 1.5, <= 1.5.26",
 	"python-fcl >= 0.7",
 	"Rtree ~= 1.0",
 	"rv-ltl ~= 0.1",


### PR DESCRIPTION
### Description
This pins pyglet to the 1.5.x series to avoid incompatibilities with trimesh 
which does not support pyglet 2. It also ensures compatibility with Apple Silicon (M1, M2) Devices, 
as later pyglet versions (1.5.28) introduced issues on that platform.

### Issue Link
[Issue #2087](https://github.com/mikedh/trimesh/issues/2087)
[Issue #2155](https://github.com/mikedh/trimesh/issues/2155)
[Issue #1812](https://github.com/mikedh/trimesh/issues/1812)
[Issue #1100](https://github.com/pyglet/pyglet/issues/1100)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
[PR #330](https://github.com/BerkeleyLearnVerify/Scenic/pull/330) 
