### PR TITLE
Run tests weekly + Slack notification

### DIFF
--- a/.github/workflows/weekly-ci-tests.yml
+++ b/.github/workflows/weekly-ci-tests.yml
@@ -1,17 +1,47 @@
 name: Weekly CI tests
 
-# Trigger every Thursday at 9:00 AM Pacific Time (16:00 UTC)
+# No permissions needed
+permissions: {}
+
+# Trigger every Thursday at 9:15 AM Pacific Time (16:15 UTC)
 on:
   schedule:
-    # - cron: '0 16 * * 4'
-    - cron: '50 16 * * 3'
+    - cron: '15 16 * * 4'
 
 jobs:
   run-tests:
-    # Invoke run-tests.yml as a reusable workflow
     uses: ./.github/workflows/run-tests.yml
     with:
       # Use the default branch" (i.e. main)
       ref: ''
-    # Make sure the same tokens/secrets are passed through
-    # secrets: inherit
+
+  notify:
+    name: Notify Slack
+    needs: run-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+        - name: Post result to Slack
+          uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52
+          with:
+            webhook: ${{ secrets.SLACK_WEBHOOK_URL}}
+            webhook-type: incoming-webhook
+            payload: |
+              {
+                "blocks": [
+                    {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Weekly CI tests* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}> finished."
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "${{ needs.run-tests.result == 'success' && '✅ All tests passed!' || '🚨 Some tests failed!' }}"
+                    }
+                  }
+                ]
+              }


### PR DESCRIPTION
### Description
Adds a new scheduled workflow that runs our tests every Thursday at 9:15 AM (staggered 15 min past the hour to avoid peak runner load) and then posts a simple pass/fail message (with a link) into the Slack maintenance channel.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A