### PR TITLE
Remove unused CameraManager.images list and append

### DIFF
--- a/src/scenic/simulators/carla/utils/visuals.py
+++ b/src/scenic/simulators/carla/utils/visuals.py
@@ -271,7 +271,6 @@ class CameraManager(object):
         self._surface = None
         self._actor = actor
         self._hud = hud
-        self.images = []
         self._camera_transforms = [
             carla.Transform(carla.Location(x=-5.5, z=2.8), carla.Rotation(pitch=-15)),
             carla.Transform(carla.Location(x=1.6, z=1.7)),
@@ -365,7 +364,6 @@ class CameraManager(object):
             array = array[:, :, :3]
             array = array[:, :, ::-1]
             self._surface = pygame.surfarray.make_surface(array.swapaxes(0, 1))
-        self.images.append(image)
 
     def destroy_sensor(self):
         if self.sensor is not None:


### PR DESCRIPTION
### Description
The images list and its append call in CameraManager._parse_image were never used and led to a memory leak. This PR removes that attribute and the append.

### Issue Link
[#350](https://github.com/BerkeleyLearnVerify/Scenic/issues/350)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A