### PR TITLE
MetaDrive: initialize pedestrian velocity on spawn to Scenic starting speed

### DIFF
--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -162,6 +162,10 @@ class MetaDriveSimulation(DrivingSimulation):
                 heading_theta=converted_heading,
             )
             obj.metaDriveActor = metaDriveActor
+
+            # Manually initialize pedestrian velocity to Scenic’s starting speed
+            direction = [math.cos(converted_heading), math.sin(converted_heading)]
+            metaDriveActor.set_velocity(direction, obj.speed)
             return
 
         # If the object type is unsupported, raise an error

--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -28,10 +28,12 @@ def test_pickle(loadLocalScenario):
 def getMetadriveSimulator(getAssetPath):
     base = getAssetPath("maps/CARLA")
 
-    def _getMetadriveSimulator(town):
+    def _getMetadriveSimulator(town, *, render=False, render3D=False):
         openDrivePath = os.path.join(base, f"{town}.xodr")
         sumoPath = os.path.join(base, f"{town}.net.xml")
-        simulator = MetaDriveSimulator(sumo_map=sumoPath, render=False)
+        simulator = MetaDriveSimulator(
+            sumo_map=sumoPath, render=render, render3D=render3D
+        )
         return simulator, openDrivePath, sumoPath
 
     yield _getMetadriveSimulator
@@ -151,3 +153,37 @@ def test_initial_velocity_movement(getMetadriveSimulator):
     finalPos = simulation.result.records["FinalPos"]
     dx = finalPos[0] - initialPos[0]
     assert dx < -0.1, f"Expected car to move west (negative dx), but got dx = {dx}"
+
+
+def test_static_pedestrian(getMetadriveSimulator):
+    simulator, openDrivePath, sumoPath = getMetadriveSimulator(
+        "Town01", render=True, render3D=True
+    )
+    code = f"""
+        param map = r'{openDrivePath}'
+        param sumo_map = r'{sumoPath}'
+
+        model scenic.simulators.metadrive.model
+
+        ego = new Car at (266.21, -59.57)
+        pedestrian = new Pedestrian at (275, -59.57), with regionContainedIn None
+        record initial pedestrian.position as InitialPos
+        record final pedestrian.position as FinalPos
+        terminate after 5 steps
+    """
+    scenario = compileScenic(code, mode2D=True)
+    scene = sampleScene(scenario)
+
+    try:
+        simulation = simulator.simulate(scene)
+    except Exception as e:
+        if "Could not open window" in str(e):
+            pytest.skip("render3D unsupported on this platform")
+        else:
+            raise
+    initialPos = simulation.result.records["InitialPos"]
+    finalPos = simulation.result.records["FinalPos"]
+    assert initialPos == finalPos, (
+        f"Expected pedestrian to remain stationary (default speed=0), "
+        f"but moved from {initialPos} to {finalPos}"
+    )


### PR DESCRIPTION
### Description
In MetaDrive’s 3D mode, pedestrians would auto-start at MetaDrive’s default non-zero speed before Scenic applied its initial (usually zero) speed, causing them to move too early. This patch fixes that by calling `set_velocity(direction, obj.speed)` immediately after spawning each Pedestrian, enforcing Scenic’s starting speed.

### Issue Link
[#355 ](https://github.com/BerkeleyLearnVerify/Scenic/issues/355)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A