### PR TITLE
Support pedestrian movement in Newtonian simulator

### DIFF
--- a/src/scenic/simulators/newtonian/driving_model.scenic
+++ b/src/scenic/simulators/newtonian/driving_model.scenic
@@ -59,9 +59,18 @@ class Car(Vehicle, Steers):
         return True
 
 class Pedestrian(Pedestrian, NewtonianActor, Walks):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.control = {'heading': None, 'speed': None}
+
+    def setWalkingDirection(self, heading):
+        self.control['heading'] = heading
+
+    def setWalkingSpeed(self, speed):
+        self.control['speed'] = speed
 
 class Debris:
     """Abstract class for debris scattered randomly in the workspace."""
     position: new Point in workspace
     yaw: Range(0, 360) deg
+


### PR DESCRIPTION
### Description
Enable pedestrian movement in Newtonian simulator by storing heading & speed in control and applying via setVelocity in step().

### Issue Link
[#355 ](https://github.com/BerkeleyLearnVerify/Scenic/issues/355)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A