### PR TITLE
Mark MetaDrive static pedestrian test as slow and graphical

### DIFF
--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -155,6 +155,8 @@ def test_initial_velocity_movement(getMetadriveSimulator):
     assert dx < -0.1, f"Expected car to move west (negative dx), but got dx = {dx}"
 
 
+@pytest.mark.slow
+@pytest.mark.graphical
 def test_static_pedestrian(getMetadriveSimulator):
     simulator, openDrivePath, sumoPath = getMetadriveSimulator(
         "Town01", render=True, render3D=True


### PR DESCRIPTION
### Description
Decorate `test_static_pedestrian` with  `@pytest.mark.slow` and `@pytest.mark.graphical`.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A