### PR TITLE
Fix boundingPolygon issue and other recent CI errors/warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ metadrive = [
 	"sumolib >= 1.21.0",
 ]
 test = [	# minimum dependencies for running tests (used for tox virtualenvs)
-	"pytest >= 7.0.0, <8",
+	"pytest >= 7.0.0, <9",
 	"pytest-cov >= 3.0.0",
 	"pytest-randomly ~= 3.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 	"scikit-image ~= 0.21",
 	"scipy ~= 1.7",
 	"shapely ~= 2.0",
-	"trimesh >=4.4.8, <5",
+	"trimesh >=4.6.0, <5",
 ]
 
 [project.optional-dependencies]

--- a/src/scenic/core/pruning.py
+++ b/src/scenic/core/pruning.py
@@ -10,8 +10,8 @@ import math
 import time
 
 import numpy
+import shapely.errors
 import shapely.geometry
-import shapely.geos
 from trimesh.transformations import translation_matrix
 
 from scenic.core.distributions import (
@@ -372,7 +372,7 @@ def pruneRelativeHeading(scenario, verbosity):
                     continue
                 try:
                     pruned = newBasePoly & feasible
-                except shapely.geos.TopologicalError:  # TODO how can we prevent these??
+                except shapely.errors.TopologicalError:  # TODO how can we prevent these??
                     pruned = newBasePoly & feasible.buffer(0.1, cap_style=2)
                 if verbosity >= 1:
                     percent = 100 * (1.0 - (pruned.area / newBasePoly.area))

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -25,6 +25,7 @@ from trimesh.transformations import (
     compose_matrix,
     identity_matrix,
     quaternion_matrix,
+    transform_points,
     translation_matrix,
 )
 import trimesh.voxel
@@ -947,8 +948,10 @@ class MeshRegion(Region):
         if self.centerMesh:
             mesh.vertices -= mesh.bounding_box.center_mass
 
-        # Apply scaling, rotation, and translation, if any
-        mesh.apply_transform(self._transform)
+        # Apply scaling, rotation, and translation, if any.
+        # N.B. Avoid using Trimesh.apply_transform since it generates random numbers (!)
+        # to check if the transform flips windings; ours are rigid motions, so don't.
+        mesh.vertices = transform_points(mesh.vertices, matrix=self._transform)
 
         return mesh
 

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1070,7 +1070,7 @@ class MeshRegion(Region):
         # Generic case for arbitrary shapes
         if self.mesh.is_watertight:
             projection = trimesh.path.polygons.projected(
-                self.mesh, normal=(0, 0, 1), rpad=1e-4
+                self.mesh, normal=(0, 0, 1), rpad=1e-4, precise=True
             )
         else:
             # Special parameters to use all faces if mesh is not watertight.
@@ -1080,6 +1080,7 @@ class MeshRegion(Region):
                 rpad=1e-4,
                 ignore_sign=False,
                 tol_dot=-float("inf"),
+                precise=True,
             )
 
         return projection

--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -1495,7 +1495,7 @@ class MeshVolumeRegion(MeshRegion):
             if slice_3d is None:
                 return nowhere
 
-            slice_2d, _ = slice_3d.to_planar(to_2D=numpy.eye(4))
+            slice_2d, _ = slice_3d.to_2D(to_2D=numpy.eye(4))
             polygons = MultiPolygon(slice_2d.polygons_full) & other.polygons
 
             if polygons.is_empty:
@@ -3204,7 +3204,7 @@ class CircularRegion(PolygonalRegion):
     @distributionFunction
     def _makePolygons(center, radius, resolution):
         ctr = makeShapelyPoint(center)
-        return ctr.buffer(radius, resolution=resolution)
+        return ctr.buffer(radius, quad_segs=resolution)
 
     ## Lazy Construction Methods ##
     def sampleGiven(self, value):
@@ -3298,7 +3298,7 @@ class SectorRegion(PolygonalRegion):
     @distributionFunction
     def _makePolygons(center, radius, heading, angle, resolution):
         ctr = makeShapelyPoint(center)
-        circle = ctr.buffer(radius, resolution=resolution)
+        circle = ctr.buffer(radius, quad_segs=resolution)
         if angle >= math.tau - 0.001:
             polygon = circle
         else:

--- a/src/scenic/simulators/webots/model.scenic
+++ b/src/scenic/simulators/webots/model.scenic
@@ -222,7 +222,7 @@ class Ground(WebotsObject):
 
             side_path = trimesh.path.Path3D(entities=[trimesh.path.entities.Line(side_indices)], vertices=vertices)
 
-            flat_side_path, transform = side_path.to_planar(to_2D=None, normal=None, check=True)
+            flat_side_path, transform = side_path.to_2D(to_2D=None, normal=None, check=True)
             side_vertices_2d, side_faces = flat_side_path.triangulate()
 
             side_vertices_3d = trimesh.transformations.transform_points(

--- a/src/scenic/simulators/webots/road/interface.py
+++ b/src/scenic/simulators/webots/road/interface.py
@@ -64,11 +64,11 @@ class Road(OSMObject):
         ]
         self.waypoints = tuple(cleanChain(pts, 0.05))
         assert len(self.waypoints) > 1, pts
-        self.width = float(attrs.get("width", 7))
-        self.lanes = int(attrs.get("numberOfLanes", 2))
+        self.width = float(attrs.get("width", (7,))[0])
+        self.lanes = int(attrs.get("numberOfLanes", (2,))[0])
         if self.lanes < 1:
             raise RuntimeError(f"Road {self.osmID} has fewer than 1 lane!")
-        self.forwardLanes = int(attrs.get("numberOfForwardLanes", 1))
+        self.forwardLanes = int(attrs.get("numberOfForwardLanes", (1,))[0])
         # if self.forwardLanes < 1:
         #   raise RuntimeError(f'Road {self.osmID} has fewer than 1 forward lane!')
         self.backwardLanes = self.lanes - self.forwardLanes

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -18,7 +18,7 @@ class AST(ast.AST):
     def __init_subclass__(cls):
         super().__init_subclass__()
         fts = _getFields(cls)
-        if sys.version_info >= (3, 10):
+        if sys.version_info >= (3, 13):
             # The Python 3.13+ ast.AST initializer expects types like X | None, but we
             # use Optional[X] for compatibility; convert the latter into the former.
             optionalTy = type(Optional[str])

--- a/src/scenic/syntax/ast.py
+++ b/src/scenic/syntax/ast.py
@@ -1,15 +1,41 @@
 import ast
+import inspect
+import sys
 import typing
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 
 class AST(ast.AST):
-    "Scenic AST base class"
+    """Scenic AST base class.
+
+    N.B. The attributes ``_fields`` and ``_field_types`` expected in subclasses
+    of `ast.AST` are synthesized automatically from a dataclass-like syntax:
+    see below for many examples.
+    """
 
     _attributes = ("lineno", "col_offset", "end_lineno", "end_col_offset")
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        fts = _getFields(cls)
+        if sys.version_info >= (3, 10):
+            # The Python 3.13+ ast.AST initializer expects types like X | None, but we
+            # use Optional[X] for compatibility; convert the latter into the former.
+            optionalTy = type(Optional[str])
+            for field, ty in fts.items():
+                if isinstance(ty, optionalTy):
+                    raw = typing.get_args(ty)[0]
+                    fts[field] = raw | None
+        cls._field_types = fts
+        cls._fields = tuple(cls._field_types)
+        cls.__match_args__ = tuple(cls._fields)
+
+
+if sys.version_info >= (3, 10):
+    _getFields = inspect.get_annotations
+else:
+    # We won't bother with un-stringizing annotations: they won't be used anyway
+    _getFields = lambda cls: cls.__dict__.get("__annotations__", {})
 
 
 # special statements
@@ -18,75 +44,31 @@ class AST(ast.AST):
 class TryInterrupt(AST):
     """Scenic AST node that represents try-interrupt statements"""
 
-    __match_args__ = (
-        "body",
-        "interrupt_when_handlers",
-        "except_handlers",
-        "orelse",
-        "finalbody",
-    )
-
-    def __init__(
-        self,
-        body: typing.List[ast.stmt],
-        interrupt_when_handlers: typing.List["InterruptWhenHandler"],
-        except_handlers: typing.List[ast.ExceptHandler],
-        orelse: typing.List[ast.stmt],
-        finalbody: typing.List[ast.AST],
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.body = body
-        self.interrupt_when_handlers = interrupt_when_handlers
-        self.except_handlers = except_handlers
-        self.orelse = orelse
-        self.finalbody = finalbody
-        self._fields = [
-            "body",
-            "interrupt_when_handlers",
-            "except_handlers",
-            "orelse",
-            "finalbody",
-        ]
-        self._attributes = []
+    body: typing.List[ast.stmt]
+    interrupt_when_handlers: typing.List["InterruptWhenHandler"]
+    except_handlers: typing.List[ast.ExceptHandler]
+    orelse: typing.List[ast.stmt]
+    finalbody: typing.List[ast.AST]
 
 
 class InterruptWhenHandler(AST):
-    __match_args__ = ("cond", "body")
-
-    def __init__(
-        self, cond: ast.AST, body: typing.List[ast.AST], *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.cond = cond
-        self.body = body
-        self._fields = ["cond", "body"]
+    cond: ast.AST
+    body: typing.List[ast.AST]
 
 
 class TrackedAssign(AST):
-    __match_args__ = (
-        "target",
-        "value",
-    )
-
-    def __init__(
-        self, target: Union["Ego", "Workspace"], value: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.value = value
-        self._fields = ["target", "value"]
+    target: Union["Ego", "Workspace"]
+    value: ast.AST
 
 
 class Ego(AST):
-    "`ego` tracked assign target"
+    """`ego` tracked assign target"""
 
     functionName = "ego"
 
 
 class Workspace(AST):
-    ":term:`workspace` tracked assign target"
+    """:term:`workspace` tracked assign target"""
 
     functionName = "workspace"
 
@@ -96,326 +78,127 @@ class InitialScenario(AST):
 
 
 class PropertyDef(AST):
-    __match_args__ = ("property", "attributes", "value")
-
-    def __init__(
-        self,
-        property: str,
-        attributes: typing.List[Union["Additive", "Dynamic", "Final"]],
-        value=ast.AST,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.property = property
-        self.attributes = attributes
-        self.value = value
-        self._fields = ["property", "attributes", "value"]
+    property: str
+    attributes: typing.List[Union["Additive", "Dynamic", "Final"]]
+    value: ast.AST
 
 
 class Additive(AST):
     keyword = "additive"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Dynamic(AST):
     keyword = "dynamic"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Final(AST):
     keyword = "final"
-
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
 
 
 # behavior / monitor
 
 
 class BehaviorDef(AST):
-    __match_args__ = ("name", "args", "docstring", "header", "body")
-
-    def __init__(
-        self,
-        name: str,
-        args: ast.arguments,
-        docstring: Optional[str],
-        header: typing.List[Union["Precondition", "Invariant"]],
-        body: typing.List[any],
-        *_args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*_args, **kwargs)
-        self.name = name
-        self.args = args
-        self.docstring = docstring
-        self.header = header
-        self.body = body
-        self._fields = ["name", "args", "docstring", "header", "body"]
+    name: str
+    args: ast.arguments
+    docstring: Optional[str]
+    header: typing.List[Union["Precondition", "Invariant"]]
+    body: typing.List[ast.AST]
 
 
 class MonitorDef(AST):
-    __match_args__ = ("name", "args", "docstring", "body")
-
-    def __init__(
-        self,
-        name: str,
-        args: ast.arguments,
-        docstring: Optional[str],
-        body: typing.List[ast.AST],
-        *_args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*_args, **kwargs)
-        self.name = name
-        self.args = args
-        self.docstring = docstring
-        self.body = body
-        self._fields = ["name", "args", "docstring", "body"]
+    name: str
+    args: ast.arguments
+    docstring: Optional[str]
+    body: typing.List[ast.AST]
 
 
 class Precondition(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+    value: ast.AST
 
 
 class Invariant(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+    value: ast.AST
 
 
 # modular scenarios
 
 
 class ScenarioDef(AST):
-    __match_args__ = ("name", "args", "docstring", "header", "setup", "compose")
-
-    def __init__(
-        self,
-        name: str,
-        args: ast.arguments,
-        docstring: Optional[str],
-        header: Optional[typing.List[Union[Precondition, Invariant]]],
-        setup: typing.List[ast.AST],
-        compose: typing.List[ast.AST],
-        *_args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*_args, **kwargs)
-        self.name = name
-        self.args = args
-        self.docstring = docstring
-        self.header = header
-        self.setup = setup
-        self.compose = compose
-        self._fields = ["name", "args", "docstring", "header", "setup", "compose"]
+    name: str
+    args: ast.arguments
+    docstring: Optional[str]
+    header: Optional[typing.List[Union[Precondition, Invariant]]]
+    setup: typing.List[ast.AST]
+    compose: typing.List[ast.AST]
 
 
 # simple statements
 
 
 class Model(AST):
-    __match_args__ = ("name",)
-
-    def __init__(self, name: str, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.name = name
-        self._fields = ["name"]
+    name: str
 
 
 class Param(AST):
-    ":keyword:`param` statements"
+    """:keyword:`param` statements"""
 
-    __match_args__ = ("elts",)
-
-    def __init__(self, elts: typing.List["parameter"], *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self._fields = ["elts"]
+    elts: typing.List["parameter"]
 
 
 class parameter(AST):
-    "represents a parameter that is defined with `param` statements"
+    """Represents a parameter that is defined with `param` statements"""
 
-    __match_args__ = ("identifier", "value")
-
-    def __init__(
-        self, identifier: str, value: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.identifier = identifier
-        self.value = value
-        self._fields = ["identifier", "value"]
+    identifier: str
+    value: ast.AST
 
 
 class Require(AST):
-    __match_args__ = ("cond", "prob", "name")
-
-    def __init__(
-        self,
-        cond: ast.AST,
-        prob: Optional[float] = None,
-        name: Optional[str] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.cond = cond
-        self.prob = prob
-        self.name = name
-        self._fields = ["cond", "prob", "name"]
+    cond: ast.AST
+    prob: Optional[float] = None
+    name: Optional[str] = None
 
 
 class RequireMonitor(AST):
-    __match_args__ = ("monitor", "name")
-
-    def __init__(
-        self, monitor: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.monitor = monitor
-        self.name = name
-        self._fields = ["monitor", "name"]
+    monitor: ast.AST
+    name: Optional[str] = None
 
 
 class Always(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
-
-    def __reduce__(self):
-        return (
-            type(self),
-            (self.value,),
-            {
-                "lineno": self.lineno,
-                "end_lineno": self.end_lineno,
-                "col_offset": self.col_offset,
-                "end_col_offset": self.end_col_offset,
-            },
-        )
+    value: ast.AST
 
 
 class Eventually(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
-
-    def __reduce__(self):
-        return (
-            type(self),
-            (self.value,),
-            {
-                "lineno": self.lineno,
-                "end_lineno": self.end_lineno,
-                "col_offset": self.col_offset,
-                "end_col_offset": self.end_col_offset,
-            },
-        )
+    value: ast.AST
 
 
 class Next(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
-
-    def __reduce__(self):
-        return (
-            type(self),
-            (self.value,),
-            {
-                "lineno": self.lineno,
-                "end_lineno": self.end_lineno,
-                "col_offset": self.col_offset,
-                "end_col_offset": self.end_col_offset,
-            },
-        )
+    value: ast.AST
 
 
 class Record(AST):
-    __match_args__ = ("value", "name")
-
-    def __init__(
-        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self.name = name
-        self._fields = ["value", "name"]
+    value: ast.AST
+    name: Optional[str] = None
 
 
 class RecordInitial(AST):
-    __match_args__ = ("value", "name")
-
-    def __init__(
-        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self.name = name
-        self._fields = ["value", "name"]
+    value: ast.AST
+    name: Optional[str] = None
 
 
 class RecordFinal(AST):
-    __match_args__ = ("value", "name")
-
-    def __init__(
-        self, value: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self.name = name
-        self._fields = ["value", "name"]
+    value: ast.AST
+    name: Optional[str] = None
 
 
 class Mutate(AST):
-    __match_args__ = ("elts", "scale")
-
-    def __init__(
-        self,
-        elts: typing.List[ast.Name],
-        scale: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self.scale = scale
-        self._fields = ["elts", "scale"]
+    elts: typing.List[ast.Name]
+    scale: Optional[ast.AST] = None
 
 
 class Override(AST):
-    __match_args__ = ("target", "specifiers")
-
-    def __init__(
-        self, target: ast.AST, specifiers: typing.List[ast.AST], *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.specifiers = specifiers
-        self._fields = ["target", "specifiers"]
+    target: ast.AST
+    specifiers: typing.List[ast.AST]
 
 
 class Abort(AST):
@@ -423,12 +206,7 @@ class Abort(AST):
 
 
 class Take(AST):
-    __match_args__ = ("elts",)
-
-    def __init__(self, elts: typing.List[ast.AST], *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self._fields = ["elts"]
+    elts: typing.List[ast.AST]
 
 
 class Wait(AST):
@@ -444,840 +222,412 @@ class TerminateSimulation(AST):
 
 
 class TerminateSimulationWhen(AST):
-    __match_args__ = (
-        "cond",
-        "name",
-    )
-
-    def __init__(
-        self, cond: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.cond = cond
-        self.name = name
-        self._fields = ["cond", "name"]
+    cond: ast.AST
+    name: Optional[str] = None
 
 
 class TerminateWhen(AST):
-    __match_args__ = (
-        "cond",
-        "name",
-    )
-
-    def __init__(
-        self, cond: ast.AST, name: Optional[str] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.cond = cond
-        self.name = name
-        self._fields = ["cond", "name"]
+    cond: ast.AST
+    name: Optional[str] = None
 
 
 class TerminateAfter(AST):
-    __match_args__ = ("duration",)
-
-    def __init__(
-        self, duration: Union["Seconds", "Steps"], *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.duration = duration
-        self._fields = ["duration"]
+    duration: Union["Seconds", "Steps"]
 
 
 class DoFor(AST):
-    __match_args__ = ("elts", "duration")
-
-    def __init__(
-        self,
-        elts: typing.List[ast.AST],
-        duration: Union["Seconds", "Steps"],
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self.duration = duration
-        self._fields = ["elts", "duration"]
+    elts: typing.List[ast.AST]
+    duration: Union["Seconds", "Steps"]
 
 
 class Seconds(AST):
-    __match_args__ = ("value",)
     unitStr = "seconds"
 
-    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+    value: ast.AST
 
 
 class Steps(AST):
-    __match_args__ = ("value",)
     unitStr = "steps"
 
-    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+    value: ast.AST
 
 
 class DoUntil(AST):
-    __match_args__ = ("elts", "cond")
-
-    def __init__(
-        self, elts: typing.List[ast.AST], cond: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self.cond = cond
-        self._fields = ["elts", "cond"]
+    elts: typing.List[ast.AST]
+    cond: ast.AST
 
 
 class DoChoose(AST):
-    __match_args__ = ("elts",)
-
-    def __init__(self, elts: typing.List[ast.AST], *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self._fields = ["elts"]
+    elts: typing.List[ast.AST]
 
 
 class DoShuffle(AST):
-    __match_args__ = ("elts",)
-
-    def __init__(self, elts: typing.List[ast.AST], *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self._fields = ["elts"]
+    elts: typing.List[ast.AST]
 
 
 class Do(AST):
-    __match_args__ = ("elts",)
-
-    def __init__(self, elts: typing.List[ast.AST], *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.elts = elts
-        self._fields = ["elts"]
+    elts: typing.List[ast.AST]
 
 
 class Simulator(AST):
-    __match_args__ = ("value",)
-
-    def __init__(self, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.value = value
-        self._fields = ["value"]
+    value: ast.AST
 
 
 # Instance Creation
 
 
 class New(AST):
-    __match_args__ = ("className", "specifiers")
+    className: str
+    specifiers: Optional[typing.List[ast.AST]]
 
-    def __init__(
-        self, className: str, specifiers: list, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.className = className
-        self.specifiers = specifiers if specifiers is not None else []
-        self._fields = ["className", "specifiers"]
+    def __init__(self, className, specifiers, **kwargs):
+        specs = specifiers if specifiers is not None else []
+        super().__init__(className, specs, **kwargs)
 
 
 # Specifiers
 
 
 class WithSpecifier(AST):
-    __match_args__ = ("prop", "value")
-
-    def __init__(self, prop: str, value: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.prop = prop
-        self.value = value
-        self._fields = ["prob", "value"]
+    prop: str
+    value: ast.AST
 
 
 class AtSpecifier(AST):
-    __match_args__ = ("position",)
-
-    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self._fields = ["position"]
+    position: ast.AST
 
 
 class OffsetBySpecifier(AST):
-    __match_args__ = ("offset",)
-
-    def __init__(self, offset: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.offset = offset
-        self._fields = ["offset"]
+    offset: ast.AST
 
 
 class OffsetAlongSpecifier(AST):
-    __match_args__ = ("direction", "offset")
-
-    def __init__(
-        self, direction: ast.AST, offset: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.direction = direction
-        self.offset = offset
-        self._fields = ["direction", "offset"]
+    direction: ast.AST
+    offset: ast.AST
 
 
 class DirectionOfSpecifier(AST):
-    __match_args__ = ("direction", "position", "distance")
-
-    def __init__(
-        self,
-        direction: Union["LeftOf", "RightOf", "AheadOf", "Behind"],
-        position: ast.AST,
-        distance: Optional[ast.AST],
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.direction = direction
-        self.position = position
-        self.distance = distance
-        self._fields = ["direction", "position", "distance"]
+    direction: Union["LeftOf", "RightOf", "AheadOf", "Behind"]
+    position: ast.AST
+    distance: Optional[ast.AST] = None
 
 
 class LeftOf(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class RightOf(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class AheadOf(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class Behind(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class Above(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class Below(AST):
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
+    pass
 
 
 class BeyondSpecifier(AST):
-    __match_args__ = ("position", "offset", "base")
-
-    def __init__(
-        self,
-        position: ast.AST,
-        offset: ast.AST,
-        base: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self.offset = offset
-        self.base = base
-        self._fields = ["position", "offset", "base"]
+    position: ast.AST
+    offset: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class VisibleSpecifier(AST):
-    __match_args__ = ("base",)
-
-    def __init__(self, base: Optional[ast.AST] = None, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.base = base
-        self._fields = ["base"]
+    base: Optional[ast.AST] = None
 
 
 class NotVisibleSpecifier(AST):
-    __match_args__ = ("base",)
-
-    def __init__(self, base: Optional[ast.AST] = None, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.base = base
-        self._fields = ["base"]
+    base: Optional[ast.AST] = None
 
 
 class InSpecifier(AST):
-    __match_args__ = ("region",)
-
-    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self._fields = ["region"]
+    region: ast.AST
 
 
 class OnSpecifier(AST):
-    __match_args__ = ("region",)
-
-    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self._fields = ["region"]
+    region: ast.AST
 
 
 class ContainedInSpecifier(AST):
-    __match_args__ = ("region",)
-
-    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self._fields = ["region"]
+    region: ast.AST
 
 
 class FollowingSpecifier(AST):
-    __match_args__ = ("field", "distance", "base")
-
-    def __init__(
-        self,
-        field: ast.AST,
-        distance: ast.AST,
-        base: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.field = field
-        self.distance = distance
-        self.base = base
-        self._fields = ["field", "distance", "base"]
+    field: ast.AST
+    distance: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class FacingSpecifier(AST):
-    __match_args__ = ("heading",)
-
-    def __init__(self, heading: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.heading = heading
-        self._fields = ["heading"]
+    heading: ast.AST
 
 
 class FacingTowardSpecifier(AST):
-    __match_args__ = ("position",)
-
-    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self._fields = ["position"]
+    position: ast.AST
 
 
 class FacingAwayFromSpecifier(AST):
-    __match_args__ = ("position",)
-
-    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self._fields = ["position"]
+    position: ast.AST
 
 
 class FacingDirectlyTowardSpecifier(AST):
-    __match_args__ = ("position",)
-
-    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self._fields = ["position"]
+    position: ast.AST
 
 
 class FacingDirectlyAwayFromSpecifier(AST):
-    __match_args__ = ("position",)
-
-    def __init__(self, position: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self._fields = ["position"]
+    position: ast.AST
 
 
 class ApparentlyFacingSpecifier(AST):
-    __match_args__ = ("heading", "base")
-
-    def __init__(
-        self, heading: ast.AST, base: Optional[ast.AST] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.heading = heading
-        self.base = base
-        self._fields = ["heading", "base"]
+    heading: ast.AST
+    base: Optional[ast.AST] = None
 
 
 # Operators
 
 
 class ImpliesOp(AST):
-    __match_args__ = ("hypothesis", "conclusion")
-
-    def __init__(
-        self, hypothesis: ast.AST, conclusion: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.hypothesis = hypothesis
-        self.conclusion = conclusion
-        self._fields = ["hypothesis", "conclusion"]
-
-    def __reduce__(self):
-        return (
-            type(self),
-            (self.hypothesis, self.conclusion),
-            {
-                "lineno": self.lineno,
-                "end_lineno": self.end_lineno,
-                "col_offset": self.col_offset,
-                "end_col_offset": self.end_col_offset,
-            },
-        )
+    hypothesis: ast.AST
+    conclusion: ast.AST
 
 
 class UntilOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
-
-    def __reduce__(self):
-        return (
-            type(self),
-            (self.left, self.right),
-            {
-                "lineno": self.lineno,
-                "end_lineno": self.end_lineno,
-                "col_offset": self.col_offset,
-                "end_col_offset": self.end_col_offset,
-            },
-        )
+    left: ast.AST
+    right: ast.AST
 
 
 class RelativePositionOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class RelativeHeadingOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class ApparentHeadingOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self, target: ast.AST, base: ast.AST = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class DistanceFromOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self,
-        # because `to` and `from` are symmetric, the first operand will be `target` and the second will be `base`
-        target: ast.AST,
-        base: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    # because `to` and `from` are symmetric, the first operand will be `target` and the second will be `base`
+    target: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class DistancePastOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self, target: ast.AST, base: Optional[ast.AST] = None, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: ast.AST
+    base: Optional[ast.AST] = None
 
 
 class AngleFromOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self,
-        target: Optional[ast.AST] = None,
-        base: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: Optional[ast.AST] = None
+    base: Optional[ast.AST] = None
 
 
 class AltitudeFromOp(AST):
-    __match_args__ = ("target", "base")
-
-    def __init__(
-        self,
-        target: Optional[ast.AST] = None,
-        base: Optional[ast.AST] = None,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self._fields = ["target", "base"]
+    target: Optional[ast.AST] = None
+    base: Optional[ast.AST] = None
 
 
 class FollowOp(AST):
-    __match_args__ = ("target", "base", "distance")
-
-    def __init__(
-        self, target: ast.AST, base: ast.AST, distance: ast.AST, *args: any, **kwargs: any
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.target = target
-        self.base = base
-        self.distance = distance
-        self._fields = ["target", "base", "distance"]
+    target: ast.AST
+    base: ast.AST
+    distance: ast.AST
 
 
 class VisibleOp(AST):
-    __match_args__ = ("region",)
-
-    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self._fields = ["region"]
+    region: ast.AST
 
 
 class NotVisibleOp(AST):
-    __match_args__ = ("region",)
-
-    def __init__(self, region: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self._fields = ["region"]
+    region: ast.AST
 
 
 class VisibleFromOp(AST):
-    __match_args__ = ("region", "base")
-
-    def __init__(self, region: ast.AST, base: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self.base = base
-        self._fields = ["region", "base"]
+    region: ast.AST
+    base: ast.AST
 
 
 class NotVisibleFromOp(AST):
-    __match_args__ = ("region", "base")
-
-    def __init__(self, region: ast.AST, base: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.region = region
-        self.base = base
-        self._fields = ["region", "base"]
+    region: ast.AST
+    base: ast.AST
 
 
 class PositionOfOp(AST):
-    __match_args__ = ("position", "target")
-
-    def __init__(
-        self,
-        position: Union[
-            "Front",
-            "Back",
-            "Left",
-            "Right",
-            "Top",
-            "Bottom",
-            "FrontLeft",
-            "FrontRight",
-            "BackLeft",
-            "BackRight",
-            "TopFrontLeft",
-            "TopFrontRight",
-            "TopBackLeft",
-            "TopBackRight",
-            "BottomFrontLeft",
-            "BottomFrontRight",
-            "BottomBackLeft",
-            "BottomBackRight",
-        ],
-        target: ast.AST,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.position = position
-        self.target = target
-        self._fields = ["position", "target"]
+    position: Union[
+        "Front",
+        "Back",
+        "Left",
+        "Right",
+        "Top",
+        "Bottom",
+        "FrontLeft",
+        "FrontRight",
+        "BackLeft",
+        "BackRight",
+        "TopFrontLeft",
+        "TopFrontRight",
+        "TopBackLeft",
+        "TopBackRight",
+        "BottomFrontLeft",
+        "BottomFrontRight",
+        "BottomBackLeft",
+        "BottomBackRight",
+    ]
+    target: ast.AST
 
 
 class Front(AST):
-    "Represents position of :scenic:`front of` operator"
+    """Represents position of :scenic:`front of` operator"""
 
     functionName = "Front"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Back(AST):
-    "Represents position of :scenic:`back of` operator"
+    """Represents position of :scenic:`back of` operator"""
 
     functionName = "Back"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Left(AST):
-    "Represents position of :scenic:`left of` operator"
+    """Represents position of :scenic:`left of` operator"""
 
     functionName = "Left"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Right(AST):
-    "Represents position of :scenic:`right of` operator"
+    """Represents position of :scenic:`right of` operator"""
 
     functionName = "Right"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Top(AST):
-    "Represents position of :scenic:`top of` operator"
+    """Represents position of :scenic:`top of` operator"""
 
     functionName = "Top"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class Bottom(AST):
-    "Represents position of :scenic:`bottom of` operator"
+    """Represents position of :scenic:`bottom of` operator"""
 
     functionName = "Bottom"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class FrontLeft(AST):
-    "Represents position of :scenic:`front left of` operator"
+    """Represents position of :scenic:`front left of` operator"""
 
     functionName = "FrontLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class FrontRight(AST):
-    "Represents position of :scenic:`front right of` operator"
+    """Represents position of :scenic:`front right of` operator"""
 
     functionName = "FrontRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BackLeft(AST):
-    "Represents position of :scenic:`back left of` operator"
+    """Represents position of :scenic:`back left of` operator"""
 
     functionName = "BackLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BackRight(AST):
-    "Represents position of :scenic:`back right of` operator"
+    """Represents position of :scenic:`back right of` operator"""
 
     functionName = "BackRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class TopFrontLeft(AST):
-    "Represents position of :scenic:`top front left of` operator"
+    """Represents position of :scenic:`top front left of` operator"""
 
     functionName = "TopFrontLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class TopFrontRight(AST):
-    "Represents position of :scenic:`top front right of` operator"
+    """Represents position of :scenic:`top front right of` operator"""
 
     functionName = "TopFrontRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class TopBackLeft(AST):
-    "Represents position of :scenic:`top back left of` operator"
+    """Represents position of :scenic:`top back left of` operator"""
 
     functionName = "TopBackLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class TopBackRight(AST):
-    "Represents position of :scenic:`top back right of` operator"
+    """Represents position of :scenic:`top back right of` operator"""
 
     functionName = "TopBackRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BottomFrontLeft(AST):
-    "Represents position of :scenic:`bottom front left of` operator"
+    """Represents position of :scenic:`bottom front left of` operator"""
 
     functionName = "BottomFrontLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BottomFrontRight(AST):
-    "Represents position of :scenic:`bottom front right of` operator"
+    """Represents position of :scenic:`bottom front right of` operator"""
 
     functionName = "BottomFrontRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BottomBackLeft(AST):
-    "Represents position of :scenic:`bottom back left of` operator"
+    """Represents position of :scenic:`bottom back left of` operator"""
 
     functionName = "BottomBackLeft"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class BottomBackRight(AST):
-    "Represents position of :scenic:`bottom back right of` operator"
+    """Represents position of :scenic:`bottom back right of` operator"""
 
     functionName = "BottomBackRight"
 
-    def __init__(self, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-
 
 class DegOp(AST):
-    __match_args__ = ("operand",)
-
-    def __init__(self, operand: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.operand = operand
-        self._fields = ["operand"]
+    operand: ast.AST
 
 
 class VectorOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
+    left: ast.AST
+    right: ast.AST
 
 
 class FieldAtOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
+    left: ast.AST
+    right: ast.AST
 
 
 class RelativeToOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
+    left: ast.AST
+    right: ast.AST
 
 
 class OffsetAlongOp(AST):
-    __match_args__ = ("base", "direction", "offset")
-
-    def __init__(
-        self,
-        base: ast.AST,
-        direction: ast.AST,
-        offset: ast.AST,
-        *args: any,
-        **kwargs: any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.base = base
-        self.direction = direction
-        self.offset = offset
-        self._fields = ["base", "direction", "offset"]
+    base: ast.AST
+    direction: ast.AST
+    offset: ast.AST
 
 
 class CanSeeOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
+    left: ast.AST
+    right: ast.AST
 
 
 class IntersectsOp(AST):
-    __match_args__ = ("left", "right")
-
-    def __init__(self, left: ast.AST, right: ast.AST, *args: any, **kwargs: any) -> None:
-        super().__init__(*args, **kwargs)
-        self.left = left
-        self.right = right
-        self._fields = ["left", "right"]
+    left: ast.AST
+    right: ast.AST

--- a/src/scenic/syntax/scenic.gram
+++ b/src/scenic/syntax/scenic.gram
@@ -1408,7 +1408,7 @@ pattern_capture_target[str]:
     | !"_" name=NAME !('.' | '(' | '=') { name.string }
 
 wildcard_pattern["ast.MatchAs"]:
-    | "_" { ast.MatchAs(pattern=None, target=None, LOCATIONS) }
+    | "_" { ast.MatchAs(pattern=None, name=None, LOCATIONS) }
 
 value_pattern["ast.MatchValue"]:
     | attr=attr !('.' | '(' | '=') { ast.MatchValue(value=attr, LOCATIONS) }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,15 +119,15 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(mark)
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     """
     Some test files use Python syntax (e.g., structural pattern matching) that is only available in newer versions of Python.
     To avoid syntax errors on older versions, put `# pytest: python>=x.y` where x and y represent major and minor versions, respectively,
     required to run the test file.
     """
-    if path.isfile() and path.ext in (".py", ".scenic"):
+    if collection_path.is_file() and collection_path.suffix in (".py", ".scenic"):
         firstLine = ""
-        with path.open() as f:
+        with collection_path.open() as f:
             firstLine = f.readline()
         m = re.search(
             r"^#\s*pytest:\s*python\s*>=\s*(?P<major>\d+)\.(?P<minor>\d+)\s*$", firstLine

--- a/tests/syntax/test_distributions.py
+++ b/tests/syntax/test_distributions.py
@@ -707,11 +707,11 @@ def test_reproducibility_3d():
     scenario = compileScenic(
         """
         ego = new Object
-        workspace = Workspace(SpheroidRegion(dimensions=(5,5,5)))
+        workspace = Workspace(SpheroidRegion(dimensions=(25,15,10)))
         region = BoxRegion(dimensions=(25,15,0.1))
-        #obj_1 = new Object in workspace, facing Range(0, 360) deg, with width Range(0.5, 1), with length Range(0.5,1)
+        obj_1 = new Object in workspace, facing Range(0, 360) deg, with width Range(0.5, 1), with length Range(0.5,1)
         obj_2 = new Object in workspace, facing (Range(0, 360) deg, Range(0, 360) deg, Range(0, 360) deg)
-        #obj_3 = new Object in workspace, on region
+        obj_3 = new Object in workspace, on region
         param foo = ego intersects obj_2
         x = Range(0, 1)
         require x > 0.8


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->
Main changes in this PR:

- Improve the quality of `MeshRegion.boundingPolygon`, hopefully fixing the frequent CI failures we've been seeing from it.
- Fix a bunch of warnings that I saw in the CI.
- Restore the `test_reproducibility_3d` test, which I'd accidentally commented out parts of previously. Uncommenting those parts triggered a reproducibility failure which I'd previously discussed with @Eric-Vin but never fixed, caused by extra random numbers being generated on the first sample as part of computing a mesh for a region which is then cached and re-used on subsequent samples (so that resetting the random seed doesn't give the exact same behavior, since on the second run fewer random numbers are generated). I've fixed the specific problem by changing our code to not need to generate random numbers for the mesh computation, but we should probably try to come up with a fix for this whole class of bugs later.
- Reduce the boilerplate needed to define AST nodes: I had to make changes so that `ast.dump` continues to work with Scenic ASTs on Python 3.13.5 and newer, and while I was at it I took the opportunity to simplify this code.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->