### PR TITLE
Add minimum required permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-coverage.yml
+++ b/.github/workflows/run-coverage.yml
@@ -17,6 +17,9 @@ on:
         description: Git ref on which to run the tests.
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     strategy:

--- a/.github/workflows/run-simulators.yml
+++ b/.github/workflows/run-simulators.yml
@@ -4,6 +4,8 @@ on:
   # portal of the repo!!! Do not modify this workflow's trigger!
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
     start_ec2_instance:
       name: start_ec2_instance

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,9 @@ on:
         default: --no-graphics
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check-format:
     uses: ./.github/workflows/check-formatting.yml

--- a/.github/workflows/sync-issues-with-jira.yml
+++ b/.github/workflows/sync-issues-with-jira.yml
@@ -3,6 +3,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
     generate-issue-link:
         runs-on: ubuntu-latest

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   call-run-tests:
     uses: ./.github/workflows/run-tests.yml


### PR DESCRIPTION
### Description
Sets minimal permissions for each workflow to follow GitHub security best practices and remove `excessive-permissions` warnings.

### Issue Link
N/A

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A