### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -8,7 +8,8 @@ on:
         required: true
         type: string
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   call-run-tests:

--- a/.github/workflows/weekly-ci-tests.yml
+++ b/.github/workflows/weekly-ci-tests.yml
@@ -1,12 +1,12 @@
 name: Weekly CI tests
 
-# No permissions needed
-permissions: {}
-
 # Trigger every Thursday at 9:15 AM Pacific Time (16:15 UTC)
 on:
   schedule:
     - cron: '15 16 * * 4'
+
+permissions:
+  contents: read
 
 jobs:
   run-tests:


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

Fixes permissions for a couple workflows that were set to be too restrictive in #366. These workflows call other workflows that need `contents: read` permissions, so they need those permissions too.