### PR TITLE
replace deprecated set-output command in sync-issues-with-jira.yml

### DIFF
--- a/.github/workflows/sync-issues-with-jira.yml
+++ b/.github/workflows/sync-issues-with-jira.yml
@@ -19,8 +19,8 @@ jobs:
                 const issueNumber = context.payload.issue.number;
                 const issueTitle = context.payload.issue.title;
                 const issueLink = `https://github.com/${repoName}/issues/${issueNumber}`;
-                console.log(`::set-output name=issueTitle::${issueTitle}`);
-                console.log(`::set-output name=issueLink::${issueLink}`);
+                core.setOutput('issueTitle', issueTitle);
+                core.setOutput('issueLink', issueLink);
 
           - name: Create Jira Ticket
             env:


### PR DESCRIPTION
### Description
Replaces the deprecated `::set-output` command with `core.setOutput` in `sync-issues-with-jira.yml`.

### Issue Link
N/A

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A