### PR TITLE
Add screen recording support to MetaDrive interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,6 @@ dmypy.json
 # generated parser
 src/scenic/syntax/parser.py
 
+# generated media/output
 simulation.gif
+metadrive_gifs/

--- a/src/scenic/simulators/metadrive/model.scenic
+++ b/src/scenic/simulators/metadrive/model.scenic
@@ -21,6 +21,13 @@ Global Parameters:
         If False (default), it will render in 2D.
     real_time (bool): If True (default), the simulation will run in real time, ensuring each step takes at least
         as long as the specified timestep. If False, the simulation runs as fast as possible.
+    screen_record (bool): Whether to record a screen capture of the simulation (as a GIF).
+        Only supported in 2D rendering mode (requires ``render=True`` and ``render3D=False``).
+        Default is False.
+    screen_record_filename (str or None): Name of the GIF file to save. If not specified (default),
+        a timestamp will be used for each scenario recording.
+    screen_record_path (str): Directory where the GIFs will be saved. Defaults to "metadrive_gifs".
+        If not customized, recordings are grouped into this folder using timestamps for filenames.
 """
 import pathlib
 
@@ -66,6 +73,19 @@ param timestep = 0.1
 param render = 1
 param render3D = 0
 param real_time = 1
+param screen_record = 0
+param screen_record_filename = None
+param screen_record_path = "metadrive_gifs"
+
+if bool(globalParameters.screen_record) and bool(globalParameters.render3D):
+    raise InvalidScenarioError(
+        "screen_record=True is only supported with 2D rendering. Set render3D=False."
+    )
+
+if bool(globalParameters.screen_record) and not bool(globalParameters.render):
+    raise InvalidScenarioError(
+        "screen_record=True requires render=True. Cannot record when rendering is disabled."
+    )
 
 simulator MetaDriveSimulator(
     sumo_map=globalParameters.sumo_map,
@@ -73,6 +93,9 @@ simulator MetaDriveSimulator(
     render=bool(globalParameters.render),
     render3D=bool(globalParameters.render3D),
     real_time=bool(globalParameters.real_time),
+    screen_record=bool(globalParameters.screen_record),
+    screen_record_filename=globalParameters.screen_record_filename,
+    screen_record_path=globalParameters.screen_record_path,
 )
 
 class MetaDriveActor(DrivingObject):

--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -258,8 +258,12 @@ class MetaDriveSimulation(DrivingSimulation):
                 filename += ".gif"
             path = os.path.join(self.screen_record_path, filename)
             os.makedirs(os.path.dirname(path), exist_ok=True)
+
+            # Convert timestep (seconds) → milliseconds for GIF duration
+            duration_ms = int(round(self.timestep * 1000))
+
             print(f"Saving screen recording to {path}")
-            self.client.top_down_renderer.generate_gif(path)
+            self.client.top_down_renderer.generate_gif(path, duration=duration_ms)
 
         if self.client and self.client.engine:
             object_ids = list(self.client.engine._spawned_objects.keys())


### PR DESCRIPTION
### Description
This PR adds support for screen recording in the MetaDrive simulator interface. When `screen_record=True` and the simulation is run in 2D mode (`render=True`, `render3D=False`), a .gif of the scenario is saved to a `metadrive_gifs/ ` directory by default(created automatically if it doesn't exist). Users can optionally override the filename or output path using `screen_record_filename` and `screen_record_path`. Filenames default to timestamps to avoid overwriting. MetaDrive's screen recording feature only works in top-down 2D render mode. The `metadrive_gifs/ ` directory has been added to `.gitignore` to avoid committing generated recordings.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A