### PR TITLE
Move CARLA-specific setup from sensors to simulator to unblock docs build

### DIFF
--- a/src/scenic/simulators/carla/sensors.py
+++ b/src/scenic/simulators/carla/sensors.py
@@ -32,9 +32,7 @@ class CarlaVisionSensor(CallbackSensor):
 
         self.convert = None
         convert = self.attributes.get("convert")
-        if convert is not None and not (
-            isinstance(convert, str) or isinstance(convert, int)
-        ):
+        if convert is not None and not isinstance(convert, (str, int)):
             raise TypeError("'convert' has to be int or string.")
         self.convert = convert
 

--- a/src/scenic/simulators/carla/sensors.py
+++ b/src/scenic/simulators/carla/sensors.py
@@ -1,8 +1,3 @@
-import os
-from time import sleep
-
-import carla
-import cv2
 import numpy as np
 
 from scenic.core.sensors import CallbackSensor
@@ -18,10 +13,9 @@ class CarlaVisionSensor(CallbackSensor):
         attributes=None,
     ):
         super().__init__()
-        self.transform = carla.Transform(
-            carla.Location(x=offset[0], y=offset[1], z=offset[2]),
-            carla.Rotation(pitch=rotation[0], yaw=rotation[1], roll=rotation[2]),
-        )
+        self.offset = offset
+        self.rotation = rotation
+
         if isinstance(attributes, str):
             raise NotImplementedError(
                 "String parsing for attributes is not yet implemented. Feel free to do so."
@@ -38,13 +32,11 @@ class CarlaVisionSensor(CallbackSensor):
 
         self.convert = None
         convert = self.attributes.get("convert")
-        if convert is not None:
-            if isinstance(convert, int):
-                self.convert = convert
-            elif isinstance(convert, str):
-                self.convert = carla.ColorConverter.names[convert]
-            else:
-                raise TypeError("'convert' has to be int or string.")
+        if convert is not None and not (
+            isinstance(convert, str) or isinstance(convert, int)
+        ):
+            raise TypeError("'convert' has to be int or string.")
+        self.convert = convert
 
         self.frame = 0
 

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -258,8 +258,27 @@ class CarlaSimulation(DrivingSimulation):
                     if sensor_bp.has_attribute(key):
                         sensor_bp.set_attribute(key, str(val))
 
+                if isinstance(sensor.convert, str):
+                    try:
+                        sensor.convert = carla.ColorConverter.names[sensor.convert]
+                    except KeyError:
+                        raise ValueError(
+                            f"Unknown CARLA ColorConverter '{sensor.convert}'"
+                        )
+
+                transform = carla.Transform(
+                    carla.Location(
+                        x=sensor.offset[0], y=sensor.offset[1], z=sensor.offset[2]
+                    ),
+                    carla.Rotation(
+                        pitch=sensor.rotation[0],
+                        yaw=sensor.rotation[1],
+                        roll=sensor.rotation[2],
+                    ),
+                )
+
                 carla_sensor = self.world.spawn_actor(
-                    sensor_bp, sensor.transform, attach_to=obj.carlaActor
+                    sensor_bp, transform, attach_to=obj.carlaActor
                 )
                 carla_sensor.listen(sensor.onData)
                 sensor.carla_sensor = carla_sensor

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -268,11 +268,13 @@ class CarlaSimulation(DrivingSimulation):
 
                 transform = carla.Transform(
                     carla.Location(
-                        x=sensor.offset[0], y=sensor.offset[1], z=sensor.offset[2]
+                        x=sensor.offset[1],  # forward (Scenic +Y) -> CARLA +X
+                        y=sensor.offset[0],  # right   (Scenic +X) -> CARLA +Y
+                        z=sensor.offset[2],  # up      (same)
                     ),
                     carla.Rotation(
-                        pitch=sensor.rotation[0],
-                        yaw=sensor.rotation[1],
+                        pitch=sensor.rotation[1],
+                        yaw=-sensor.rotation[0],  # CARLA yaw is clockwise
                         roll=sensor.rotation[2],
                     ),
                 )


### PR DESCRIPTION
### Description
Move the` carla` import and Transform/ColorConverter handling from `sensors.py` into the simulator so CARLA-specific setup lives there and lets docs build without CARLA installed.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A