### PR TITLE
Pin MetaDrive extra to stable commit

### DIFF
--- a/docs/simulators.rst
+++ b/docs/simulators.rst
@@ -21,17 +21,13 @@ MetaDrive
 
 Scenic supports integration with the `MetaDrive <https://metadriverse.github.io/metadrive/>`_ simulator as an optional dependency,
 enabling users to describe dynamic simulations of vehicles, pedestrians, and traffic scenarios.
-If your system supports it, you can install it with:
+You can install it with:
 
 .. code-block:: console
 
     python -m pip install scenic[metadrive]
 
 Scenic supports both 2D and 3D rendering modes for MetaDrive simulations.
-2D rendering is available on all systems, providing a top-down view.
-However, 3D rendering may not work properly on macOS devices with M-series chips.
-Additionally, there is an issue where cars do not fully brake in certain scenarios.
-These issues are expected to be addressed in the next version of MetaDrive.
 
 Scenic uses OpenDRIVE maps, while MetaDrive relies on SUMO maps. Scenic provides corresponding SUMO maps for OpenDRIVE maps under the :file:`assets/maps/CARLA` directory.
 Additionally, you can convert your own OpenDRIVE maps to SUMO maps using the `netconvert <https://sumo.dlr.de/docs/Networks/Import/OpenDRIVE.html>`_ tool.
@@ -40,15 +36,6 @@ Otherwise, you can specify it explicitly using the ``sumo_map`` global parameter
 
 The simulator is compatible with scenarios written using Scenic's :ref:`driving_domain`.
 For more information, refer to the documentation of the `scenic.simulators.metadrive` module.
-
-.. note::
-
-	The current version of MetaDrive on PyPI may not support the latest versions of Python or Apple Silicon hardware.
-	If the above command gives an error or you get a "could not open window" error when running MetaDrive, you can try installing a newer version from the MetaDrive repo as follows:
-
-	.. code-block:: console
-
-		python -m pip install "metadrive-simulator @ git+https://github.com/metadriverse/metadrive.git@main"
 
 
 Built-in Newtonian Simulator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ guideways = [
 	'pyproj ~= 3.3; python_version >= "3.10"',
 ]
 metadrive = [
-	"metadrive-simulator >= 0.4.3",
+	"metadrive-simulator@git+https://github.com/metadriverse/metadrive.git@85e5dadc6c7436d324348f6e3d8f8e680c06b4db",
 	"sumolib >= 1.21.0",
 ]
 test = [	# minimum dependencies for running tests (used for tox virtualenvs)
@@ -67,7 +67,7 @@ test = [	# minimum dependencies for running tests (used for tox virtualenvs)
 test-full = [  # like 'test' but adds dependencies for optional features
 	"scenic[test]",       # all dependencies from 'test' extra above
 	"scenic[guideways]",  # for running guideways modules
-	'scenic[metadrive]; python_version <= "3.11"',  # MetaDrive only supports Python ≤ 3.11; excluded for newer versions
+	"scenic[metadrive]",
 	"astor >= 0.8.1",
 	'carla >= 0.9.12; python_version <= "3.10" and (platform_system == "Linux" or platform_system == "Windows")',
 	"dill",

--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -63,9 +63,6 @@ def test_throttle(getMetadriveSimulator):
     assert speeds[len(speeds) // 2][1] < speeds[-1][1]
 
 
-@pytest.mark.xfail(
-    reason="Expected failure until MetaDrive uploads the next version on PyPI to fix the issue where cars aren't fully stopping."
-)
 def test_brake(getMetadriveSimulator):
     simulator, openDrivePath, sumoPath = getMetadriveSimulator("Town01")
     code = f"""


### PR DESCRIPTION
### Description
Until MetaDrive publishes a new release on PyPI, this PR updates our `metadrive` **extra** to install MetaDrive from a stable commit on their main branch instead of the old PyPI release. This fixes several issues: 3D rendering now works on Apple Silicon, the Python version restriction is no longer needed (tested successfully on Python 3.9-3.13), and cars now fully stop in breaking scenarios. 

### Issue Link
N/A
### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A