### PR TITLE
add test to ensure obj == self inside behavior over simulation().objects (dynamic object proxy)

### DIFF
--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -471,6 +471,21 @@ def test_behavior_lazy_nested():
     assert tuple(actions) == (pytest.approx((1.5, -0.25)), pytest.approx((-0.5, -0.25)))
 
 
+def test_obj_equals_self_inside_behavior():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            for obj in simulation().objects:
+                take (obj == self)
+
+        ego = new Object with behavior Foo
+        other = new Object at 10@10
+        """
+    )
+    actions = sampleEgoActions(scenario, maxSteps=2)
+    assert actions == [True, False]
+
+
 # Termination
 
 


### PR DESCRIPTION
### Description
Adds `test_obj_equals_self_inside_behavior` to verify `obj == self` for the object with the behavior when iterating `simulation().objects`. Covers prior cases where dynamic object proxies caused `self` misidentification.


### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A