### PR TITLE
Add tests for filter(lambda) error cases

### DIFF
--- a/tests/syntax/test_distributions.py
+++ b/tests/syntax/test_distributions.py
@@ -510,6 +510,31 @@ def test_list_filtered_empty_2():
     assert sum(v == 2 for v in vs) >= 85
 
 
+def test_filter_lambda_random_global():
+    scenario = compileScenic(
+        """
+        thresh = Range(0, 1)
+        mylist = [Range(-1, 1), Range(2, 3)]
+        filtered = filter(lambda v: v > thresh, mylist)
+        ego = new Object with foo Uniform(*filtered)
+        """
+    )
+    with pytest.raises(RandomControlFlowError):
+        sampleEgo(scenario)
+
+
+def test_filter_lambda_random_threshold():
+    scenario = compileScenic(
+        """
+        mylist = [Range(-1, 1), Range(3, 4)]
+        filtered = filter(lambda v: v > Range(0, 1), mylist)
+        ego = new Object with foo Uniform(*filtered)
+        """
+    )
+    with pytest.raises(RandomControlFlowError):
+        sampleEgo(scenario)
+
+
 def test_tuple():
     scenario = compileScenic("ego = new Object with foo tuple([3, Uniform(1, 2)])")
     ts = [sampleEgo(scenario).foo for i in range(60)]


### PR DESCRIPTION
### Description
Add tests for using random globals in `filter(lambda)` and creating distributions inside `filter(lambda)` .

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A