### PR TITLE
Add tests for subclassing Point or OrientedPoint instead of Object

### DIFF
--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -63,7 +63,7 @@ def test_ego_subclass_point():
             class Foo(Point):
                 pass
             ego = new Foo
-        """
+            """
         )
 
 
@@ -74,7 +74,7 @@ def test_ego_subclass_orientedpoint():
             class Bar(OrientedPoint):
                 pass
             ego = new Bar
-        """
+            """
         )
 
 


### PR DESCRIPTION
### Description
Adds two tests that assert TypeError when ego is a subclass of Point or OrientedPoint (must subclass Object).

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
N/A