### PR TITLE
Add test for invariant checks after actions in try-interrupt blocks

### DIFF
--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -1777,6 +1777,27 @@ def test_interrupt_except_else():
     assert tuple(actions) == (1, 2, 3, 1, 1, 5, None)
 
 
+def test_interrupt_invariant_after_actions():
+    scenario = compileScenic(
+        """
+        behavior Foo():
+            invariant: ego.bar == 0
+            try:
+                for i in range(3):
+                    take 1
+            interrupt when simulation().currentTime == 1:
+                take 2
+                ego.bar = 1
+            except InvariantViolation:
+                ego.bar = 0
+                take 4
+        ego = new Object with bar 0, with behavior Foo
+        """
+    )
+    actions = sampleEgoActions(scenario, maxSteps=4)
+    assert tuple(actions) == (1, 2, 4, None)
+
+
 # Nesting
 
 


### PR DESCRIPTION
### Description
Adds test for invariant checks after actions in try-interrupt blocks

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->