### PR TITLE
CI: switch Intel runner from macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
         include:
           # Only run slow tests on the latest version of Python
           - python-version: "3.13"


### PR DESCRIPTION
### Description
Replace `macos-13` (scheduled for retirement on Dec 4, 2025; Nov brownouts) with `macos-15-intel` to keep x86_64 coverage.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A