### PR TITLE
Update CARLA docs to include 0.9.16

### DIFF
--- a/docs/simulators.rst
+++ b/docs/simulators.rst
@@ -53,7 +53,7 @@ Our interface to the `CARLA <https://carla.org/>`_ simulator enables using Sceni
 The interface supports dynamic scenarios written using the CARLA world model (:obj:`scenic.simulators.carla.model`) as well as scenarios using the cross-platform :ref:`driving_domain`.
 To use the interface, please follow these instructions:
 
-1. Install the latest version of CARLA (we've tested versions 0.9.9 through 0.9.14) from the `CARLA Release Page <https://github.com/carla-simulator/carla/releases>`_.
+1. Install the latest version of CARLA (we've tested versions 0.9.9 through 0.9.16) from the `CARLA Release Page <https://github.com/carla-simulator/carla/releases>`_.
    Note that CARLA currently only supports Linux and Windows.
 2. Install Scenic in your Python virtual environment as instructed in :ref:`quickstart`.
 3. Within the same virtual environment, install CARLA's Python API.


### PR DESCRIPTION
### Description
Updates the install note to say “0.9.9 through 0.9.16”.
Tested Scenic with CARLA 0.9.15 and 0.9.16: `pytest tests/simulators/carla` → all tests passed.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A