### PR TITLE
Make MetaDrive composed scenario test deterministic

### DIFF
--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -276,12 +276,12 @@ def test_composed_scenario(getMetadriveSimulator):
 
         scenario Sub():
             setup:
-                follower = new Car with behavior FollowLaneBehavior()
+                other = new Car at (190, -196), with behavior FollowLaneBehavior()
                 terminate after 3 steps
 
         scenario Main():
             setup:
-                ego = new Car with behavior FollowLaneBehavior()
+                ego = new Car at (129, -196), with behavior FollowLaneBehavior()
             compose:
                 do Sub()
     """


### PR DESCRIPTION
### Description
This PR updates `test_composed_scenario` in `tests/simulators/metadrive/test_metadrive.py` so that the vehicles are spawned at known valid spawniing points on the map, avoiding flaky failures from random invalid placements.

This test was originally added as a follow-up to [issue #397 ](https://github.com/BerkeleyLearnVerify/Scenic/issues/397) and [PR #398](https://github.com/BerkeleyLearnVerify/Scenic/pull/398), which fixed a bug in how MetaDrive applied actions to agents in composed scenarios. The goal of the test is to verify that both the ego car and the additional car created in a sub-scenario actually execute their behaviors and move. 


### Issue Link
[issue #397 ](https://github.com/BerkeleyLearnVerify/Scenic/issues/397)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A