### PR TITLE
Skip MetaDrive tests when assets cannot be downloaded

### DIFF
--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -1,10 +1,22 @@
 import os
+from urllib.error import URLError
 
 import numpy as np
 import pytest
 
 try:
     import metadrive
+    from metadrive.pull_asset import pull_asset
+
+    # Make sure MetaDrive assets are available.
+    # On CI, if the asset server is down or unreachable, skip this whole file.
+    try:
+        pull_asset(update=False)
+    except URLError as e:
+        pytest.skip(
+            f"MetaDrive assets could not be pulled ({e}); skipping MetaDrive tests",
+            allow_module_level=True,
+        )
 
     from scenic.simulators.metadrive import MetaDriveSimulator
 except ModuleNotFoundError:


### PR DESCRIPTION
### Description
MetaDrive needs to download an `assets` folder from a remote URL the first time it runs. On a local machine this usually happens once per virtual environment and is then cached. In CI, each run starts from a clean environment, so MetaDrive has to download the assets every time, and if that download fails, all of our MetaDrive tests fail.

This PR updates `test_metadrive.py` so that we explicitly call `metadrive.pull_asset(update=False)` before running any tests. If the asset download fails, we skip the entire MetaDrive test file instead of failing CI.

This keeps the MetaDrive tests from failing due to temporary download issues while still running them whenever the assets can be fetched successfully.

### Issue Link


### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->