### PR TITLE
Derive default velocity from speed and orientation

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1081,7 +1081,11 @@ class Object(OrientedPoint):
         "showVisibleRegion": False,
         "color": None,
         "render": True,
-        "velocity": PropertyDefault((), {"dynamic"}, lambda self: Vector(0, 0, 0)),
+        "velocity": PropertyDefault(
+            ("speed", "orientation"),
+            {"dynamic"},
+            lambda self: Vector(0, self.speed, 0).rotatedBy(self.orientation),
+        ),
         "speed": PropertyDefault((), {"dynamic"}, lambda self: 0),
         "angularVelocity": PropertyDefault((), {"dynamic"}, lambda self: Vector(0, 0, 0)),
         "angularSpeed": PropertyDefault((), {"dynamic"}, lambda self: 0),

--- a/tests/syntax/test_specifiers.py
+++ b/tests/syntax/test_specifiers.py
@@ -87,6 +87,21 @@ def test_lazy_value_in_requirement_2():
         sampleScene(scenario, maxIterations=1)
 
 
+def test_default_velocity_depends_on_speed_and_orientation():
+    # Heading convention in Scenic: 0 deg = +Y, 90 deg = -X
+    ego = sampleEgoFrom("ego = new Object with speed 10, facing 90 deg")
+    assert tuple(ego.velocity) == pytest.approx((-10, 0, 0))
+
+    # Order independence (dependency graph should resolve the same way)
+    ego = sampleEgoFrom("ego = new Object facing 90 deg, with speed 10")
+    assert tuple(ego.velocity) == pytest.approx((-10, 0, 0))
+
+    # Orientation derived from another specifier (not a literal heading)
+    ego = sampleEgoFrom("ego = new Object with speed 10, facing toward -1 @ 1")
+    s = 10 * math.sqrt(0.5)
+    assert tuple(ego.velocity) == pytest.approx((-s, s, 0))
+
+
 ## Value normalization
 
 


### PR DESCRIPTION
### Description
Previously, the default/initial velocity was always (0, 0, 0). Now velocity is derived from speed and orientation so it matches the documented behavior.

### Issue Link
[#339 ](https://github.com/BerkeleyLearnVerify/Scenic/issues/339)

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->