### PR TITLE
Stabilize CARLA blueprint tests by using a fixed spawn point

### DIFF
--- a/tests/simulators/carla/test_blueprints.py
+++ b/tests/simulators/carla/test_blueprints.py
@@ -47,7 +47,9 @@ def model_blueprint(simulator, mapPath, town, modelType, modelName):
             param time_step = 1.0/10
 
             model scenic.simulators.carla.model
-            ego = new {modelType} with blueprint '{modelName}'
+            ego = new {modelType} with blueprint '{modelName}',
+                at (-3.3, -68),
+                with regionContainedIn None
             terminate after 1 steps
         """
     scenario = compileScenic(code, mode2D=True)


### PR DESCRIPTION
### Description
Stabilize CARLA blueprint tests by using a fixed spawn point

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->