### PR TITLE
Fix `occupiedSpace` heuristic to account for mutations

### DIFF
--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1398,8 +1398,9 @@ class Object(OrientedPoint):
             self.width,
             self.length,
             self.height,
+            self.mutationScale,
         )
-        return not any(needsSampling(v) for v in deps) and not self.mutator
+        return not any(needsSampling(v) for v in deps) and self.mutationScale == 0
 
     @cached_property
     def boundingBox(self):

--- a/src/scenic/core/object_types.py
+++ b/src/scenic/core/object_types.py
@@ -1399,7 +1399,7 @@ class Object(OrientedPoint):
             self.length,
             self.height,
         )
-        return not any(needsSampling(v) for v in deps)
+        return not any(needsSampling(v) for v in deps) and not self.mutator
 
     @cached_property
     def boundingBox(self):

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -172,6 +172,17 @@ def test_mutate_nonobject():
         )
 
 
+def test_mutate_occupiedSpace():
+    scenario = compileScenic(
+        """
+        ego = new Object at (0, 0, 0)
+        mutate ego
+        """
+    )
+    ego = sampleEgo(scenario)
+    assert tuple(ego.position) == tuple(ego.occupiedSpace.mesh.center_mass)
+
+
 def test_verbose():
     for verb in range(4):
         setDebuggingOptions(verbosity=verb)

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -180,7 +180,7 @@ def test_mutate_occupiedSpace():
         """
     )
     ego = sampleEgo(scenario)
-    assert tuple(ego.position) == tuple(ego.occupiedSpace.mesh.center_mass)
+    assert tuple(ego.position) == pytest.approx(tuple(ego.occupiedSpace.mesh.center_mass))
 
 
 def test_verbose():

--- a/tests/syntax/test_basic.py
+++ b/tests/syntax/test_basic.py
@@ -175,7 +175,7 @@ def test_mutate_nonobject():
 def test_mutate_occupiedSpace():
     scenario = compileScenic(
         """
-        ego = new Object at (0, 0, 0)
+        ego = new Object at (1,2,3), with foo Range(1,2)
         mutate ego
         """
     )


### PR DESCRIPTION
### Description
Adds a fix to ensure that mutations are taken into account when computing the `occupiedSpace` property.

### Issue Link
https://github.com/BerkeleyLearnVerify/Scenic/issues/348

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [X] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [X] I have added test cases (if applicable)

### Additional Notes
N/A