### PR TITLE
Include XODR <header><offset> in Scenic <-> MetaDrive coordinate alignment

### DIFF
--- a/src/scenic/simulators/metadrive/model.scenic
+++ b/src/scenic/simulators/metadrive/model.scenic
@@ -94,6 +94,7 @@ if bool(globalParameters.screen_record) and not bool(globalParameters.render):
 
 simulator MetaDriveSimulator(
     sumo_map=globalParameters.sumo_map,
+    xodr_map=globalParameters.map,
     timestep=float(globalParameters.timestep),
     render=bool(globalParameters.render),
     render3D=bool(globalParameters.render3D),

--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -35,6 +35,7 @@ class MetaDriveSimulator(DrivingSimulator):
     def __init__(
         self,
         sumo_map,
+        xodr_map,
         timestep=0.1,
         render=True,
         render3D=False,
@@ -49,11 +50,14 @@ class MetaDriveSimulator(DrivingSimulator):
         self.scenario_number = 0
         self.timestep = timestep
         self.sumo_map = sumo_map
+        self.xodr_map = xodr_map
         self.real_time = real_time
         self.screen_record = screen_record
         self.screen_record_filename = screen_record_filename
         self.screen_record_path = screen_record_path
-        self.scenic_offset, self.sumo_map_boundary = utils.getMapParameters(self.sumo_map)
+        self.scenic_offset, self.sumo_map_boundary = utils.getMapParameters(
+            self.sumo_map, self.xodr_map
+        )
 
         if self.screen_record and self.render3D:
             raise SimulationCreationError(

--- a/src/scenic/simulators/metadrive/utils.py
+++ b/src/scenic/simulators/metadrive/utils.py
@@ -1,7 +1,10 @@
-# NOTE: MetaDrive uses a coordinate system where (0,0) is centered
-# around the middle of the SUMO map. To ensure alignment, we shift
-# positions using both the computed SUMO map center (center_x, center_y)
-# and adjust for SUMO’s netOffset (offset_x, offset_y).
+# NOTE: MetaDrive uses a coordinate system where (0, 0) is centered near the
+# middle of the SUMO map.
+# Some OpenDRIVE maps include a dataset-level <header><offset ...>, and
+# SUMO/netconvert may apply an additional translation recorded as
+# <location netOffset="..."> in the .net.xml.
+# To align Scenic with MetaDrive, we account for both translations (when
+# present) and then recenter using the convBoundary midpoint.
 
 import math
 import xml.etree.ElementTree as ET
@@ -51,13 +54,34 @@ def extractNetOffsetAndBoundary(sumo_map_path):
     return net_offset, sumo_map_boundary
 
 
-def getMapParameters(sumo_map_path):
+def extractXODROffset(xodr_map_path):
+    """Return the (x, y) translation from the OpenDRIVE <header><offset> element.
+
+    If the file has no <header> or no <offset>, returns (0.0, 0.0).
+    """
+    tree = ET.parse(xodr_map_path)
+    root = tree.getroot()
+    header = root.find("header")
+    if header is None:
+        return 0.0, 0.0
+    offset = header.find("offset")
+    if offset is None:
+        return 0.0, 0.0
+    return float(offset.get("x", "0")), float(offset.get("y", "0"))
+
+
+def getMapParameters(sumo_map_path, xodr_map_path):
     """Retrieve the map parameters."""
     net_offset, sumo_map_boundary = extractNetOffsetAndBoundary(sumo_map_path)
     xmin, ymin, xmax, ymax = sumo_map_boundary
     center_x = (xmin + xmax) / 2
     center_y = (ymin + ymax) / 2
-    scenic_offset = (center_x - net_offset[0], center_y - net_offset[1])
+
+    xodr_offset = extractXODROffset(xodr_map_path)
+    combined_offset_x = net_offset[0] + xodr_offset[0]
+    combined_offset_y = net_offset[1] + xodr_offset[1]
+
+    scenic_offset = (center_x - combined_offset_x, center_y - combined_offset_y)
     return scenic_offset, sumo_map_boundary
 
 

--- a/tests/simulators/metadrive/test_metadrive.py
+++ b/tests/simulators/metadrive/test_metadrive.py
@@ -89,6 +89,7 @@ def getMetadriveSimulator(getAssetPath):
         sumoPath = os.path.join(base, f"{town}.net.xml")
         simulator = MetaDriveSimulator(
             sumo_map=sumoPath,
+            xodr_map=openDrivePath,
             render=render,
             render3D=render3D,
             **kwargs,


### PR DESCRIPTION
### Description
Include OpenDRIVE `<header><offset>`(if present) when computing the Scenic offset (in addition to SUMO `netOffset`) used to convert between OpenDRIVE coordinates and MetaDrive’s SUMO-centered coordinates, restoring correct alignment for georeferenced maps.

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A