### PR TITLE
MetaDrive Bicycle Class implementation

### DIFF
--- a/src/scenic/simulators/metadrive/model.scenic
+++ b/src/scenic/simulators/metadrive/model.scenic
@@ -1,7 +1,7 @@
 """Scenic world model for traffic scenarios in MetaDrive.
 
 The model currently supports vehicles and pedestrians. It implements the
-basic :obj:`~scenic.domains.driving.model.Car` and `Pedestrian` classes from the :obj:`scenic.domains.driving` domain.
+basic :obj:`~scenic.domains.driving.model.Car` and `Pedestrian` classes from the :obj:`scenic.domains.driving` domain. 'Bicycle' is implemented as a subclass of 'Pedestrian'.
 Vehicles and pedestrians support the basic actions and behaviors from the driving domain.
 
 The model defines several global parameters, whose default values can be overridden
@@ -182,8 +182,18 @@ class Pedestrian(Pedestrian, MetaDriveActor, Walks):
     def isPedestrian(self):
         return True
 
+    @property
+    def isBicycle(self):
+        return False
+
     def setWalkingDirection(self, heading):
         self._walking_direction = scenicToMetaDriveHeading(heading)
 
     def setWalkingSpeed(self, speed):
         self._walking_speed = speed
+
+
+class Bicycle(Pedestrian):
+    @property
+    def isBicycle(self):
+        return True

--- a/src/scenic/simulators/metadrive/simulator.py
+++ b/src/scenic/simulators/metadrive/simulator.py
@@ -15,6 +15,7 @@ import time
 
 from metadrive.component.sensors.rgb_camera import RGBCamera
 from metadrive.component.sensors.semantic_camera import SemanticCamera
+from metadrive.component.traffic_participants.cyclist import Cyclist
 from metadrive.component.traffic_participants.pedestrian import Pedestrian
 from metadrive.component.vehicle.vehicle_type import DefaultVehicle
 
@@ -243,13 +244,20 @@ class MetaDriveSimulation(DrivingSimulation):
             self._attach_sensors(obj)
             return
 
-        # For pedestrians
+        # For pedestrians and cyclists
         if obj.isPedestrian:
-            metaDriveActor = self.client.engine.agent_manager.spawn_object(
-                Pedestrian,
-                position=converted_position,
-                heading_theta=converted_heading,
-            )
+            if obj.isBicycle:
+                metaDriveActor = self.client.engine.agent_manager.spawn_object(
+                    Cyclist,
+                    position=converted_position,
+                    heading_theta=converted_heading,
+                )
+            else:
+                metaDriveActor = self.client.engine.agent_manager.spawn_object(
+                    Pedestrian,
+                    position=converted_position,
+                    heading_theta=converted_heading,
+                )
             obj.metaDriveActor = metaDriveActor
 
             # Attach sensors (if any)


### PR DESCRIPTION
### Description
Adds Scenic's Bicycle class for the MetaDrive simulator. 

### Issue Link
N/A

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
The class is implemented as a subclass of Pedestrian. It uses MetaDrive's Cyclist class to spawn objects in the simulation. 

This is the modification we did for the paper ScenicRules.