### PR TITLE
Add benchmarks and runner script for CI

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -142,7 +142,8 @@ The :file:`tools/benchmarking` folder contains tools to help measure Scenic's pe
 and resource usage. In particular, the :file:`tools/benchmarking/ci` folder contains a set
 of benchmarks available to run as a CI workflow to assess the performance impact of a PR.
 Those with write or triage permissions in the Scenic repository can trigger benchmarking
-by leaving a comment on the PR starting with ``!benchmark``. You can also run benchmarks
+of a commit by leaving a comment on the PR of the form ``!benchmark HASH``, specifying the
+hash of the desired commit. You can also run benchmarks
 locally using the :file:`run_benchmarking.py` script: use its ``-h`` option for
 instructions. The script uses `pyperf <https://pyperf.readthedocs.io/>`_, which runs the
 benchmarks many times to improve the stability of the results, so benchmarking is slow.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -135,6 +135,38 @@ commonly-used features are:
 	* the :rst:role:`term` role for glossary terms is extended so that the cross-reference will
 	  work even if the link is plural but the glossary entry is singular or vice versa.
 
+Benchmarking and Profiling
+--------------------------
+
+The :file:`tools/benchmarking` folder contains tools to help measure Scenic's performance
+and resource usage. In particular, the :file:`tools/benchmarking/ci` folder contains a set
+of benchmarks available to run as a CI workflow to assess the performance impact of a PR.
+Those with write or triage permissions in the Scenic repository can trigger benchmarking
+by leaving a comment on the PR starting with ``!benchmark``. You can also run benchmarks
+locally using the :file:`run_benchmarking.py` script: use its ``-h`` option for
+instructions. The script uses `pyperf <https://pyperf.readthedocs.io/>`_, which runs the
+benchmarks many times to improve the stability of the results, so benchmarking is slow.
+You may want to use the ``--fast`` option for quick-and-dirty results. Note that
+even with the slow default options, many of the Scenic benchmarks have substantial
+variability, so speed differences on the order of 10% or less are probably not
+significant.
+
+When working on optimizing a particular part of Scenic, it is much faster to focus on one
+or a few suitable Scenic programs rather than constantly re-running the whole benchmark
+suite. Scenic's :option:`--gather-stats` option is convenient for measuring the time and
+sampling iterations required for a single Scenic program. For example:
+
+.. code:: console
+
+	scenic examples/webots/vacuum/vacuum_simple.scenic -v 0 --gather-stats 100
+
+This option is also ideal for running Scenic in a profiler to investigate where time is
+being spent. Using `Pyinstrument <https://github.com/joerick/pyinstrument>`_, for example:
+
+.. code:: console
+
+	pyinstrument -r html -m scenic examples/webots/vacuum/vacuum_simple.scenic -v 0 --gather-stats 100
+
 .. rubric:: Footnotes
 
 .. [#f1] To run the formatters on *all* files, changed or otherwise, use :command:`make format` in the root directory of the repository. But this should not be necessary if you installed the pre-commit hooks and so all files already committed are clean.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -144,7 +144,7 @@ of benchmarks available to run as a CI workflow to assess the performance impact
 Those with write or triage permissions in the Scenic repository can trigger benchmarking
 of a commit by leaving a comment on the PR of the form ``!benchmark HASH``, specifying the
 hash of the desired commit. You can also run benchmarks
-locally using the :file:`run_benchmarking.py` script: use its ``-h`` option for
+locally using the :file:`run_benchmarks.py` script: use its ``-h`` option for
 instructions. The script uses `pyperf <https://pyperf.readthedocs.io/>`_, which runs the
 benchmarks many times to improve the stability of the results, so benchmarking is slow.
 You may want to use the ``--fast`` option for quick-and-dirty results. Note that

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -134,3 +134,10 @@ Debugging
 	Implies the :option:`-b` option.
 
 	This option can be enabled from the Python API using `scenic.setDebuggingOptions`.
+
+.. option:: --gather-stats
+
+	Collect timing statistics over a specified number of scenes, rather than rendering
+	diagrams. If the number is negative, it is considered a number of rejection sampling
+	iterations rather than scenes (useful to reduce variability, and if the number of
+	iterations required to generate a scene is very large).

--- a/tools/benchmarking/ci/distributions.scenic
+++ b/tools/benchmarking/ci/distributions.scenic
@@ -1,0 +1,20 @@
+a = Range(0, 1)
+b = Uniform(-a, a)
+c = Normal(b, 1)
+d = TruncatedNormal(min(max(c, -5), 5), a+1, -10, 10)
+e = (Orientation.fromEuler(1, 2, 3) + a).yaw
+
+x = DiscreteRange(0, 2)
+y = Discrete({x: 3, x*x: 5})
+
+l = Uniform([a, b, c], [a, b, c, d], [a, b, c, d, e])
+elem = Uniform(*l[x:])
+
+vf = VectorField("foo", lambda pos: pos.x)
+
+ego = new Object in RectangularRegion((d, y), elem, 10, 10),
+    facing a + (e relative to vf)
+
+vecs = [ego.position, ego.position.rotatedBy(a)]
+shuf = Uniform(vecs, vecs[::-1])
+param p = Uniform(*shuf).x + shuf[0].distanceTo(shuf[1])

--- a/tools/benchmarking/ci/driving.scenic
+++ b/tools/benchmarking/ci/driving.scenic
@@ -1,0 +1,19 @@
+
+from utils import getAssetPath
+
+param map = getAssetPath("maps/CARLA/Town01.xodr")
+param use2DMap = True
+param map_options = dict(useCache=False, writeCache=False)
+model scenic.domains.driving.model
+
+selected_road = Uniform(*network.roads)
+selected_lane = Uniform(*selected_road.lanes)
+ego = new Car on selected_lane.centerline
+
+new Pedestrian on visible sidewalk
+
+rightCurb = ego.laneGroup.curb
+spot = new OrientedPoint on visible rightCurb
+badAngle = Uniform(1.0, -1.0) * Range(10, 20) deg
+parkedCar = new Car left of spot by 0.5,
+                facing badAngle relative to roadDirection

--- a/tools/benchmarking/ci/driving_2d.scenic
+++ b/tools/benchmarking/ci/driving_2d.scenic
@@ -1,0 +1,20 @@
+# option: mode2D=True
+
+from utils import getAssetPath
+
+param map = getAssetPath("maps/CARLA/Town01.xodr")
+param use2DMap = True
+param map_options = dict(useCache=False, writeCache=False)
+model scenic.domains.driving.model
+
+selected_road = Uniform(*network.roads)
+selected_lane = Uniform(*selected_road.lanes)
+ego = new Car on selected_lane.centerline
+
+new Pedestrian on visible sidewalk
+
+rightCurb = ego.laneGroup.curb
+spot = new OrientedPoint on visible rightCurb
+badAngle = Uniform(1.0, -1.0) * Range(10, 20) deg
+parkedCar = new Car left of spot by 0.5,
+                facing badAngle relative to roadDirection

--- a/tools/benchmarking/ci/many_boxes_2d.scenic
+++ b/tools/benchmarking/ci/many_boxes_2d.scenic
@@ -1,0 +1,5 @@
+
+workspace = Workspace(RectangularRegion((0, 0), 0, 100, 100))
+
+for _ in range(10):
+    new Object in workspace, facing toward (0, 0, 0)

--- a/tools/benchmarking/ci/many_boxes_3d.scenic
+++ b/tools/benchmarking/ci/many_boxes_3d.scenic
@@ -1,0 +1,5 @@
+
+workspace = Workspace(BoxRegion(dimensions=(100, 100, 100)))
+
+for _ in range(10):
+    new Object in workspace, facing toward (0, 0, 0)

--- a/tools/benchmarking/ci/many_planes.scenic
+++ b/tools/benchmarking/ci/many_planes.scenic
@@ -1,0 +1,11 @@
+from utils import getAssetPath
+
+workspace = Workspace(RectangularRegion(0@0, 0, 100, 100))
+
+plane_shape = MeshShape.fromFile(
+    getAssetPath("meshes/classic_plane.obj.bz2"),
+    initial_rotation=(-90 deg, 0, -10 deg)
+)
+
+for i in range(4):
+    new Object at Range(-40, 40) @ Range(-40, 40), with shape plane_shape

--- a/tools/benchmarking/ci/mars.scenic
+++ b/tools/benchmarking/ci/mars.scenic
@@ -1,0 +1,98 @@
+"""Reduced version of the Webots Mars rover example."""
+
+model scenic.simulators.webots.model
+
+from utils import getAssetPath
+
+# Set up workspace
+width = 10
+length = 10
+workspace = Workspace(RectangularRegion(0 @ 0, 0, width, length))
+
+# types of objects
+
+class MarsGround(Ground):
+    width: width
+    length: length
+    color: (0.863 , 0.447, 0.0353)
+    gridSize: 20
+
+class MarsHill(Hill):
+    position: new Point in workspace
+    width: Range(1,2)
+    length: Range(1,2)
+    height: Range(0.1, 0.3)
+    spread: Range(0.2, 0.3)
+    regionContainedIn: everywhere
+
+class Goal(WebotsObject):
+    """Flag indicating the goal location."""
+    width: 0.1
+    length: 0.1
+    webotsType: 'GOAL'
+    color: (0.035 , 0.639, 0.784)
+
+class Rover(WebotsObject):
+    """Mars rover."""
+    width: 0.5
+    length: 0.7
+    height: 0.4
+    webotsType: 'ROVER'
+    rotationOffset: (90 deg, 0, 0)
+
+class Debris(WebotsObject):
+    """Abstract class for debris scattered randomly in the workspace."""
+    # Recess things into the ground slightly by default
+    baseOffset: (0, 0, -self.height/3)
+
+class BigRock(Debris):
+    """Large rock."""
+    shape: MeshShape.fromFile(getAssetPath("meshes/webots_rock_large.obj.bz2"))
+    yaw: Range(0, 360 deg)
+    webotsType: 'ROCK_BIG'
+    positionOffset: Vector(0,0, -self.height/2)
+
+class Rock(Debris):
+    """Small rock."""
+    shape: MeshShape.fromFile(getAssetPath("meshes/webots_rock_small.obj.bz2"))
+    yaw: Range(0, 360 deg)
+    webotsType: 'ROCK_SMALL'
+    positionOffset: Vector(0,0, -self.height/2)
+
+class Pipe(Debris):
+    """Pipe with variable length."""
+    width: 0.2
+    length: Range(0.5, 1.5)
+    height: self.width
+    shape: CylinderShape(initial_rotation=(90 deg, 0, 90 deg))
+    yaw: Range(0, 360 deg)
+    webotsType: 'PIPE'
+    rotationOffset: (90 deg, 0, 90 deg)
+
+    def startDynamicSimulation(self):
+        # Apply variable length
+        self.webotsObject.getField('height').setSFFloat(self.length)
+
+
+# Ground with random gaussian hills
+ground = new MarsGround on (0,0,0), with terrain [new MarsHill for _ in range(15)]
+
+# Ego and goal on ground
+ego = new Rover at (0, -3), on ground, with controller 'sojourner'
+goal = new Goal at (Range(-1, 1), Range(2, 3)), on ground, facing (0,0,0)
+
+# Bottleneck made of two pipes with a rock in between
+bottleneck = new OrientedPoint at ego offset by Range(-0.5, 0.5) @ Range(0.5, 1.5), facing Range(-30, 30) deg
+require abs((angle to goal) - (angle to bottleneck)) <= 10 deg
+new BigRock at bottleneck, on ground
+
+gap = 1.2 * ego.width
+halfGap = gap / 2
+
+leftEdge = new OrientedPoint left of bottleneck by halfGap,
+    facing Range(60, 120) deg relative to bottleneck.heading
+rightEdge = new OrientedPoint right of bottleneck by halfGap,
+    facing Range(-120, -60) deg relative to bottleneck.heading
+
+new Pipe ahead of leftEdge, with length Range(1, 2), on ground, facing leftEdge, with parentOrientation 0
+new Pipe ahead of rightEdge, with length Range(1, 2), on ground, facing rightEdge, with parentOrientation 0

--- a/tools/benchmarking/ci/nearby_nonconvex.scenic
+++ b/tools/benchmarking/ci/nearby_nonconvex.scenic
@@ -1,0 +1,4 @@
+region = BoxRegion().difference(BoxRegion(dimensions=(0.1, 0.1, 0.1)))
+shape = MeshShape(region.mesh)
+ego = new Object with shape shape
+other = new Object at (Range(0.9, 1.1), 0), with shape shape

--- a/tools/benchmarking/ci/run_benchmarks.py
+++ b/tools/benchmarking/ci/run_benchmarks.py
@@ -1,3 +1,4 @@
+import argparse
 import math
 from pathlib import Path
 import sys
@@ -100,6 +101,19 @@ defaultTypes = ("compile", "scene10")
 for ty in defaultTypes:
     assert ty in benchmarkTypes
 
+description = """\
+Run benchmarks. By default, runs all .scenic files in this directory, but
+particular benchmark files can be specified instead. For each file, several
+types of benchmarks are available, e.g. compilation or scene generation time.
+The default choice of types can be overridden using the --types option. For
+example, to measure compile time and the time to sample 100 scenes from the
+`tight_fit_2d.scenic` scenario, you can run:
+
+python run_benchmarks.py tight_fit_2d.scenic --types compile scene100
+
+Many additional options are inherited from `pyperf`: see its documentation
+for details.
+"""
 
 if __name__ == "__main__":
 
@@ -110,10 +124,17 @@ if __name__ == "__main__":
             cmd.extend(args.types)
 
     runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    runner.argparser.description = description
+    runner.argparser.formatter_class = argparse.RawDescriptionHelpFormatter
     types = ["all"]
-    types.extend(benchmarkTypes)
+    types.extend(sorted(benchmarkTypes))
     runner.argparser.add_argument(
-        "--types", nargs="+", action="extend", metavar="TYPE", choices=types
+        "--types",
+        nargs="+",
+        action="extend",
+        metavar="TYPE",
+        choices=types,
+        help=f"types of benchmark to run (options: {types}; default: {defaultTypes})",
     )
     runner.argparser.add_argument(
         "benchmarks", nargs="*", type=Path, help="benchmarks to run (default all)"

--- a/tools/benchmarking/ci/run_benchmarks.py
+++ b/tools/benchmarking/ci/run_benchmarks.py
@@ -1,0 +1,139 @@
+import math
+from pathlib import Path
+import sys
+import time
+import warnings
+
+import pyperf
+
+import scenic
+from scenic.core.distributions import RejectionException
+
+scenic.setDebuggingOptions(fullBacktrace=True, debugExceptions=False)
+
+
+def normalizeOptionValue(value):
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    if value == "True":
+        return True
+    if value == "False":
+        return False
+    return value
+
+
+def parseOptions(path):
+    prefix = "# option: "
+    prefixLen = len(prefix)
+    options = {}
+    with path.open() as f:
+        for i, line in enumerate(f):
+            if not line.startswith(prefix):
+                break
+            rest = line[prefixLen:]
+            name, sep, value = rest.rpartition("=")
+            if sep != "=":
+                raise RuntimeError(f"benchmark option line {i} is malformed")
+            if name in options:
+                raise RuntimeError(
+                    f"benchmark option '{name}' is specified multiple times"
+                )
+            options[name] = normalizeOptionValue(value)
+    return options
+
+
+def sampleForIterations(loops, path, iterations):
+    options = parseOptions(path)
+    times = []
+
+    for _ in range(loops):
+        # Recompile each time to reset caches, checker state, etc.
+        scenario = scenic.scenarioFromFile(path, **options)
+
+        n = iterations
+        t0 = time.perf_counter()
+
+        try:
+            while n > 0:
+                scene, its = scenario.generate(maxIterations=n)
+                n -= its
+        except RejectionException:
+            pass
+
+        times.append(time.perf_counter() - t0)
+
+    return math.fsum(times)
+
+
+def generateScenes(loops, path, count):
+    options = parseOptions(path)
+    times = []
+
+    for _ in range(loops):
+        # Recompile each time to reset caches, checker state, etc.
+        scenario = scenic.scenarioFromFile(path, **options)
+
+        t0 = time.perf_counter()
+
+        for _ in range(count):
+            scenario.generate()
+
+        times.append(time.perf_counter() - t0)
+
+    return math.fsum(times)
+
+
+benchmarkTypes = {
+    "compile": ("bench_func", scenic.scenarioFromFile),
+    "sample10": ("bench_time_func", sampleForIterations, 10),
+    "sample100": ("bench_time_func", sampleForIterations, 100),
+    "scene10": ("bench_time_func", generateScenes, 10),
+    "scene100": ("bench_time_func", generateScenes, 100),
+}
+defaultTypes = ("compile", "scene10")
+for ty in defaultTypes:
+    assert ty in benchmarkTypes
+
+
+if __name__ == "__main__":
+
+    def add_cmdline_args(cmd, args):
+        cmd.extend(args.benchmarks)
+        if args.types:
+            cmd.append("--types")
+            cmd.extend(args.types)
+
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    types = ["all"]
+    types.extend(benchmarkTypes)
+    runner.argparser.add_argument(
+        "--types", nargs="+", action="extend", metavar="TYPE", choices=types
+    )
+    runner.argparser.add_argument(
+        "benchmarks", nargs="*", type=Path, help="benchmarks to run (default all)"
+    )
+    runner.parse_args()
+    benchmarks = runner.args.benchmarks
+    if not benchmarks:
+        benchmarks = sorted(Path(__file__).parent.glob("*.scenic"))
+    types = runner.args.types
+    if not types:
+        types = defaultTypes
+    elif "all" in types:
+        types = tuple(benchmarkTypes)
+
+    if not sys.warnoptions:
+        warnings.simplefilter("ignore")
+
+    for path in benchmarks:
+        name = path.stem
+        for ty in types:
+            benchTy, func, *args = benchmarkTypes[ty]
+            method = getattr(runner, benchTy)
+            method(f"{name}_{ty}", func, path, *args)

--- a/tools/benchmarking/ci/tight_fit_2d.scenic
+++ b/tools/benchmarking/ci/tight_fit_2d.scenic
@@ -1,0 +1,3 @@
+workspace = Workspace(RectangularRegion(0@0, 0, 1.1, 1.1))
+
+new Object in workspace

--- a/tools/benchmarking/ci/tight_fit_3d.scenic
+++ b/tools/benchmarking/ci/tight_fit_3d.scenic
@@ -1,0 +1,3 @@
+workspace = Workspace(BoxRegion(dimensions=(1.2, 1.2, 1.2)))
+
+new Object in workspace

--- a/tools/benchmarking/ci/utils.py
+++ b/tools/benchmarking/ci/utils.py
@@ -1,0 +1,7 @@
+import os.path
+from pathlib import Path
+
+
+def getAssetPath(relpath):
+    base = Path(__file__).parent.parent.parent.parent / "assets"
+    return os.path.join(base, relpath)

--- a/tools/benchmarking/ci/vacuum.scenic
+++ b/tools/benchmarking/ci/vacuum.scenic
@@ -1,0 +1,157 @@
+"""Reduced version of the Webots vacuum example."""
+
+model scenic.simulators.webots.model
+
+import numpy as np
+import trimesh
+import random
+from pathlib import Path
+
+from utils import getAssetPath
+
+param numToys = 1
+param duration = 10
+
+## Class Definitions ##
+
+class Vacuum(WebotsObject):
+    webotsName: "IROBOT_CREATE"
+    shape: CylinderShape()
+    width: 0.335
+    length: 0.335
+    height: 0.07
+    customData: str(random.getrandbits(32)) # Random seed for robot controller
+
+# Floor uses builtin Webots floor to keep Vacuum Sensors from breaking
+# Not actually linked to WebotsObject because Webots floor is 2D
+class Floor(Object):
+    width: 5
+    length: 5
+    height: 0.01
+    position: (0,0,-0.005)
+    #color: [200, 200, 200]
+
+class Wall(WebotsObject):
+    webotsAdhoc: {'physics': False}
+    width: 5
+    length: 0.04
+    height: 0.5
+    #color: [160, 160, 160]
+
+class DiningTable(WebotsObject):
+    webotsAdhoc: {'physics': True}
+    shape: MeshShape.fromFile(getAssetPath("meshes/dining_table.obj.bz2"))
+    width: Range(0.7, 1.5)
+    length: Range(0.7, 1.5)
+    height: 0.75
+    density: 670 # Density of solid birch
+    #color: [103, 71, 54]
+
+class DiningChair(WebotsObject):
+    webotsAdhoc: {'physics': True}
+    shape: MeshShape.fromFile(getAssetPath("meshes/dining_chair.obj.bz2"), initial_rotation=(180 deg, 0, 0))
+    width: 0.4
+    length: 0.4
+    height: 1
+    density: 670 # Density of solid birch
+    positionStdDev: (0.05, 0.05 ,0)
+    orientationStdDev: (10 deg, 0, 0)
+    #color: [103, 71, 54]
+
+class Couch(WebotsObject):
+    webotsAdhoc: {'physics': False}
+    shape: MeshShape.fromFile(getAssetPath("meshes/couch.obj.bz2"), initial_rotation=(-90 deg, 0, 0))
+    width: 2
+    length: 0.75
+    height: 0.75
+    positionStdDev: (0.05, 0.5 ,0)
+    orientationStdDev: (5 deg, 0, 0)
+    #color: [51, 51, 255]
+
+# class CoffeeTable(WebotsObject):
+#     webotsAdhoc: {'physics': False}
+#     shape: MeshShape.fromFile(getAssetPath("meshes/coffee_table.obj.bz2"))
+#     width: 1.5
+#     length: 0.5
+#     height: 0.4
+#     positionStdDev: (0.05, 0.05 ,0)
+#     orientationStdDev: (5 deg, 0, 0)
+#     #color: [103, 71, 54]
+
+class Toy(WebotsObject):
+    webotsAdhoc: {'physics': True}
+    shape: Uniform(BoxShape(), CylinderShape(), ConeShape(), SpheroidShape())
+    width: 0.1
+    length: 0.1
+    height: 0.1
+    density: 100
+    #color: [255, 128, 0]
+
+class BlockToy(Toy):
+    shape: BoxShape()
+
+## Scene Layout ##
+
+# Create room region and set it as the workspace
+room_region = RectangularRegion(0 @ 0, 0, 5.09, 5.09)
+workspace = Workspace(room_region)
+
+# Create floor and walls
+floor = new Floor
+wall_offset = floor.width/2 + 0.04/2 + 1e-4
+right_wall = new Wall at (wall_offset, 0, 0.25), facing toward floor
+left_wall = new Wall at (-wall_offset, 0, 0.25), facing toward floor
+front_wall = new Wall at (0, wall_offset, 0.25), facing toward floor
+back_wall = new Wall at (0, -wall_offset, 0.25), facing toward floor
+
+# Place vacuum on floor
+ego = new Vacuum on floor
+
+# Create a "safe zone" around the vacuum so that it does not start stuck
+safe_zone = CircularRegion(ego.position, radius=1)
+
+# Create a dining room region where we will place dining room furniture
+dining_room_region = RectangularRegion(1.25 @ 0, 0, 2.5, 5).difference(safe_zone)
+
+# Place a table with 3 chairs around it, and one knocked over on the floor
+dining_table = new DiningTable contained in dining_room_region, on floor,
+    facing Range(0, 360 deg)
+
+chair_1 = new DiningChair behind dining_table by -0.1, on floor,
+                facing toward dining_table, with regionContainedIn dining_room_region
+# chair_2 = new DiningChair ahead of dining_table by -0.1, on floor,
+#                 facing toward dining_table, with regionContainedIn dining_room_region
+# chair_3 = new DiningChair left of dining_table by -0.1, on floor,
+#                 facing toward dining_table, with regionContainedIn dining_room_region
+
+fallen_orientation = Uniform((0, -90 deg, 0), (0, 90 deg, 0), (0, 0, -90 deg), (0, 0, 90 deg))
+
+chair_4 = new DiningChair contained in dining_room_region, facing fallen_orientation,
+                on floor, with baseOffset(0,0,-0.2)
+
+# Add some noise to the positions and yaw of the chairs around the table
+mutate chair_1#, chair_2, chair_3
+
+# Create a living room region where we will place living room furniture
+living_room_region = RectangularRegion(-1.25 @ 0, 0, 2.5, 5).difference(safe_zone)
+
+couch = new Couch ahead of left_wall by 0.335,
+            on floor, facing away from left_wall
+
+# coffee_table = new CoffeeTable ahead of couch by 0.336,
+#             on floor, facing away from couch
+
+# Add some noise to the positions of the couch and coffee table
+mutate couch#, coffee_table
+
+toy_stack = new BlockToy on floor
+toy_stack = new BlockToy on toy_stack
+#toy_stack = new BlockToy on toy_stack
+
+# Spawn some toys
+for _ in range(globalParameters.numToys):
+    new Toy on floor
+
+## Simulation Setup ##
+terminate after globalParameters.duration * 60 seconds
+record (ego.x, ego.y) as VacuumPosition

--- a/tools/benchmarking/ci/visibility_2d.scenic
+++ b/tools/benchmarking/ci/visibility_2d.scenic
@@ -1,0 +1,14 @@
+workspace = Workspace(RectangularRegion((0, 0), 0, 10, 10))
+
+ego = new Object in workspace,
+    facing Range(0, 360) deg,
+    with visibleDistance 4,
+    with viewAngles (90 deg, 90 deg),
+    with showVisibleRegion True
+
+target = new Object ahead of ego by (0, Range(2, 8)),
+    with positionStdDev (0.2, 0.2, 0.2),
+    with color (0, 0, 1),
+    with requireVisible True
+
+mutate target

--- a/tools/benchmarking/ci/visibility_occlusion.scenic
+++ b/tools/benchmarking/ci/visibility_occlusion.scenic
@@ -1,0 +1,26 @@
+workspace = Workspace(BoxRegion(dimensions=(10, 10, 10)))
+innerRegion = BoxRegion(dimensions=(7, 7, 7))
+
+region = BoxRegion().difference(BoxRegion(dimensions=(0.5, 0.5, 0.5)))
+shape = MeshShape(region.mesh)
+
+obstacle = new Object contained in innerRegion,
+    with shape shape,
+    with width 2, with height 2, with length 2,
+    with positionStdDev (1, 1, 1),
+    with name "obstacle"
+
+ego = new Object contained in workspace,
+    facing directly toward obstacle,
+    with visibleDistance 20,
+    with viewAngles (90 deg, 90 deg),
+    with showVisibleRegion True,
+    with name "ego"
+
+target = new Object beyond obstacle by 2,
+    with positionStdDev (0.2, 0.2, 0.2),
+    with color (0, 0, 1),
+    with requireVisible True,
+    with name "target"
+
+mutate obstacle, target


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

Adds an initial set of benchmarks to run in CI, and a script to run them (using [pyperf](https://pyperf.readthedocs.io/)). Also adds a section to the documentation on benchmarking and profiling Scenic.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

n/a

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)