### PR TITLE
Fix requirements using locals of a top-level modular scenario

### DIFF
--- a/src/scenic/core/dynamics/scenarios.py
+++ b/src/scenic/core/dynamics/scenarios.py
@@ -13,6 +13,7 @@ import weakref
 import rv_ltl
 
 import scenic
+from scenic.core.distributions import Samplable
 import scenic.core.dynamics as dynamics
 from scenic.core.errors import InvalidScenarioError, ScenicSyntaxError
 from scenic.core.lazy_eval import DelayedArgument, needsLazyEvaluation
@@ -434,7 +435,7 @@ class DynamicScenario(Invocable):
 
     def _addRequirement(self, ty, reqID, req, line, name, prob, recConfig=None):
         """Save a requirement defined at compile-time for later processing."""
-        preq = PendingRequirement(ty, req, line, prob, name, self._ego, recConfig)
+        preq = PendingRequirement(ty, req, line, prob, name, self._ego, recConfig, self)
         self._pendingRequirements.append((reqID, preq))
 
     def _addDynamicRequirement(self, ty, req, line, name):
@@ -534,6 +535,13 @@ class DynamicScenario(Invocable):
         )  # TODO unify these!
         return scenario
 
+    def _makeLocalsSnapshot(self):
+        locs = {}
+        for local in self._locals:
+            if local in self.__dict__:
+                locs[local] = self.__dict__[local]
+        return LocalsSnapshot(locs)
+
     def __getattr__(self, name):
         if name in self._locals:
             return DelayedArgument(
@@ -547,3 +555,13 @@ class DynamicScenario(Invocable):
         else:
             args = argsToString(self._args, self._kwargs)
             return f"{self.__class__.__name__}({args})"
+
+
+class LocalsSnapshot(Samplable):
+    def __init__(self, locs):
+        self._locs = locs
+        self.__dict__.update(locs)
+        super().__init__(locs.values())
+
+    def sampleGiven(self, value):
+        return LocalsSnapshot({name: value[val] for name, val in self._locs.items()})

--- a/src/scenic/core/requirements.py
+++ b/src/scenic/core/requirements.py
@@ -39,7 +39,7 @@ class RequirementType(enum.Enum):
 
 
 class PendingRequirement:
-    def __init__(self, ty, condition, line, prob, name, ego, recConfig):
+    def __init__(self, ty, condition, line, prob, name, ego, recConfig, scenario):
         self.ty = ty
         self.condition = condition
         self.line = line
@@ -68,6 +68,10 @@ class PendingRequirement:
                 assert globs is atomGlobals
             else:
                 atomGlobals = globs
+        for cell in self.cells:
+            # save current values of scenario locals (only needed for top-level scenario)
+            if cell.cell_contents is scenario:
+                cell.cell_contents = scenario._makeLocalsSnapshot()
         self.egoObject = ego
 
     def compile(self, namespace, scenario, syntax=None):

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -75,6 +75,38 @@ def test_requirement():
     assert all(2 < w <= 3 for w in ws)
 
 
+def test_requirement_local_main():
+    scenario = compileScenic(
+        """
+        scenario Main():
+            ego = new Object
+            other = new Object at (10, Range(1, 2))
+            require other.position.y > 1.5
+            other = 42  # should not affect requirement above
+        """
+    )
+    ys = [sampleScene(scenario, maxIterations=60).objects[1].y for i in range(60)]
+    assert all(1.5 < y <= 2 for y in ys)
+
+
+def test_requirement_local_sub():
+    scenario = compileScenic(
+        """
+        scenario Main():
+            compose:
+                do Sub()
+
+        scenario Sub():
+            ego = new Object
+            other = new Object at (10, Range(1, 2))
+            require other.position.y > 1.5
+            other = 42  # should not affect requirement above
+        """
+    )
+    ys = [sampleTrajectory(scenario, maxIterations=60)[0][1][1] for i in range(60)]
+    assert all(1.5 < y <= 2 for y in ys)
+
+
 def test_soft_requirement():
     scenario = compileScenic(
         """


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

Fixes #392, wherein an internal error resulted when a `require` statement in a modular scenario referred to one of the scenario's local variables. The bug actually only happened when the modular scenario was at the top level, not invoked in the `compose` block of another scenario, but I've added tests for both cases.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

Fixes #392.

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)

### Additional Notes

This PR only fixes the specific issue in #392, but I think same kind of issue will happen when other kinds of mutable objects are used inside requirements, e.g. dicts. I'm not sure how to fix the problem in all cases, so I will leave it for a future PR.