### PR TITLE
Use commit SHAs instead of refs in benchmark workflow

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -62,26 +62,26 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.issue.number
               });
-              core.exportVariable('BASE_BRANCH', pr.data.base.ref);
-              core.exportVariable('COMPARE_BRANCH', pr.data.mergeable ?
-                `refs/pull/${context.issue.number}/merge` : pr.data.head.ref )
+              core.exportVariable('BASE_SHA', pr.data.base.sha);
+              core.exportVariable('COMPARE_SHA', pr.data.mergeable ?
+                pr.data.merge_commit_sha : pr.data.head.sha )
 
       - name: Print PR Details
         run: |
-          echo "COMPARE_BRANCH: $COMPARE_BRANCH"
-          echo "BASE_BRANCH: $BASE_BRANCH"
+          echo "COMPARE_SHA: $COMPARE_SHA"
+          echo "BASE_SHA: $BASE_SHA"
 
       - name: Checkout base branch
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
-          ref: ${{ env.BASE_BRANCH }}
+          ref: ${{ env.BASE_SHA }}
           path: base
           persist-credentials: false
 
       - name: Checkout compare branch
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
-          ref: ${{ env.COMPARE_BRANCH }}
+          ref: ${{ env.COMPARE_SHA }}
           path: compare
           persist-credentials: false
 


### PR DESCRIPTION
### Description
Updated the benchmark workflow to use commit SHAs instead of refs when checking out the base and compare versions. This makes the benchmark run against specific commits rather than moving branch refs.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->