### PR TITLE
Use SHA from benchmark comment

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -62,9 +62,12 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.issue.number
               });
+
+              const body = context.payload.comment.body.trim();
+              const requestedSha = body.split(/\s+/)[1];
+
               core.exportVariable('BASE_SHA', pr.data.base.sha);
-              core.exportVariable('COMPARE_SHA', pr.data.mergeable ?
-                pr.data.merge_commit_sha : pr.data.head.sha )
+              core.exportVariable('COMPARE_SHA', requestedSha);
 
       - name: Print PR Details
         run: |
@@ -117,7 +120,8 @@ jobs:
             const fs = require('fs');
             const result = fs.readFileSync('comparison.txt', 'utf8');
             const commentId = context.payload.comment.id;
-            const newBody = `🚀 Benchmarks completed.\n\n${result}`;
+            const originalBody = context.payload.comment.body;
+            const newBody = `${originalBody}\n\n🚀 Benchmarks completed.\n\n${result}`;
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
### Description
Uses the SHA provided in the !benchmark comment for the compare checkout

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

### Checklist
- [ ] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
<!-- Add any additional information or context about the pull request -->
<!-- Optionally reference a Jira ticket using the following format: [SCENIC-123] -->