### PR TITLE
Add Fix for the Size-based `containsRegion` Heuristic

### DIFF
--- a/src/scenic/core/regions.py
+++ b/src/scenic/core/regions.py
@@ -216,10 +216,15 @@ class Region(Samplable, ABC):
             if self.dimensionality < reg.dimensionality:
                 return False
 
-            if self.size is not None and reg.size is not None:
+            if tolerance == 0 and self.size is not None and reg.size is not None:
                 # A smaller region cannot contain a larger region of the
-                # same dimensionality.
-                if self.dimensionality == reg.dimensionality and self.size < reg.size:
+                # same dimensionality. We add a small factor to account for numerical error.
+                # NOTE: This path is ignored when tolerance is non-zero as evaluating it correctly
+                # in that case is non-trivial.
+                if (
+                    self.dimensionality == reg.dimensionality
+                    and self.size * 1.01 < reg.size
+                ):
                     return False
 
         return self.containsRegionInner(reg, tolerance)


### PR DESCRIPTION
### Description
This fixes the size-based fast path used in `containsRegion`. It previously triggered when tolerance is non-zero (but ignored tolerance) and was susceptible to small numerical errors. This fix disables it for cases with non-zero tolerance and adds a small fudge-factor to ensure the heuristic is robust to small numerical errors.

### Issue Link
N/A

### Checklist
- [X] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes
N/A