### PR TITLE
CARLA usability fixes (HUD, cleanup, substepping) + Ubuntu/2D defaults

### DIFF
--- a/src/scenic/__main__.py
+++ b/src/scenic/__main__.py
@@ -63,7 +63,7 @@ mainOptions.add_argument(
     "--scenario", default=None, help="name of scenario to run (if file contains multiple)"
 )
 mainOptions.add_argument(
-    "--2d", action="store_true", help="run Scenic in 2D compatibility mode"
+    "--2d", default=True, action="store_true", help="run Scenic in 2D compatibility mode"
 )
 
 # Simulation options

--- a/src/scenic/core/errors.py
+++ b/src/scenic/core/errors.py
@@ -265,8 +265,9 @@ def includeFrame(frame):
 # we specially allow overwriting excepthooks from the following modules,
 # which are known to not cause problems:
 #   - exceptiongroup (PEP 654 backport for pre-3.11)
+#   - apport_python_hook (Ubuntu crash reporting system)
 if sys.excepthook is not sys.__excepthook__ and not sys.excepthook.__module__.startswith(
-    "exceptiongroup"
+    ("exceptiongroup", "apport_python_hook")
 ):
     warnings.warn("unable to install sys.excepthook to format Scenic backtraces")
 else:

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -63,6 +63,9 @@ class CarlaSimulator(DrivingSimulator):
 
         # Set to synchronous with fixed timestep
         settings = self.world.get_settings()
+        settings.substepping = True
+        settings.max_substep_delta_time = 0.01
+        settings.max_substeps = 10
         settings.synchronous_mode = True
         settings.fixed_delta_seconds = timestep  # NOTE: Should not exceed 0.1
         self.world.apply_settings(settings)

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -135,6 +135,7 @@ class CarlaSimulation(DrivingSimulation):
                 self.displayDim, pygame.HWSURFACE | pygame.DOUBLEBUF
             )
             self.cameraManager = None
+            self.world.on_tick(self.hud.on_world_tick)
 
         if self.record:
             if not os.path.exists(self.record):
@@ -301,6 +302,9 @@ class CarlaSimulation(DrivingSimulation):
         # Run simulation for one timestep
         self.current_frame = self.world.tick()
 
+        if self.render:
+            self.displayClock.tick()
+
         # Wait for sensors to get updates
         for obj in self.objects:
             if obj.sensors:
@@ -310,7 +314,9 @@ class CarlaSimulation(DrivingSimulation):
 
         # Render simulation
         if self.render:
+            self.hud.tick(self.world, self.objects[0], self.displayClock)
             self.cameraManager.render(self.display)
+            self.hud.render(self.display)
             pygame.display.flip()
 
     def getProperties(self, obj, properties):

--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -79,6 +79,8 @@ class CarlaSimulator(DrivingSimulator):
                 "set timestep when creating the CarlaSimulator instead"
             )
 
+        self._cleanupWorld()
+
         self.scenario_number += 1
         return CarlaSimulation(
             scene,
@@ -90,6 +92,31 @@ class CarlaSimulator(DrivingSimulator):
             timestep=self.timestep,
             **kwargs,
         )
+
+    def _cleanupWorld(self):
+        """Destroy any actors left over in the CARLA world from a prior run."""
+        verbosePrint("Cleaning up existing actors in CARLA world...")
+        actor_list = self.world.get_actors()
+
+        for actor in actor_list.filter("walker.*"):
+            if actor.is_alive:
+                actor.destroy()
+
+        for actor in actor_list.filter("controller.ai.walker"):
+            if actor.is_alive:
+                actor.destroy()
+
+        for actor in actor_list.filter("vehicle.*"):
+            if actor.is_alive:
+                actor.set_autopilot(False, self.tm.get_port())
+                actor.destroy()
+
+        for actor in actor_list.filter("sensor.*"):
+            if actor.is_alive:
+                actor.destroy()
+
+        self.world.tick()
+        verbosePrint("Cleanup complete.")
 
     def destroy(self):
         super().destroy()

--- a/src/scenic/syntax/translator.py
+++ b/src/scenic/syntax/translator.py
@@ -102,7 +102,7 @@ def scenarioFromString(
 
 
 def scenarioFromFile(
-    path, params={}, model=None, scenario=None, *, mode2D=False, **kwargs
+    path, params={}, model=None, scenario=None, *, mode2D=True, **kwargs
 ):
     """Compile a Scenic file into a `Scenario`.
 


### PR DESCRIPTION
### Description

A bundle of small CARLA-related fixes plus one opinionated default change. Each commit is self-contained — happy to drop or split out individual ones if preferred.

Bug fixes:
- Allow Ubuntu's `apport_python_hook` in the excepthook check — On Ubuntu's system Python, `apport_python_hook` is installed as the default excepthook, which previously caused Scenic to warn and skip installing its own backtrace formatter. Treating it the same as `exceptiongroup` lets Scenic backtraces format correctly out of the box.
- Wire up HUD `tick()` and `render()` in the CARLA simulator — `CarlaSimulation` constructed a `visuals.HUD` but never called `tick()` or `render()`, leaving the panel permanently blank. Register `on_world_tick` for FPS counting and call `hud.tick()` and `hud.render()` each step alongside the camera render.
- Clean up residual CARLA actors before each simulation — When a previous simulation crashed or was interrupted, leftover walkers / vehicles / sensors could remain in the world and affect the next run. New `_cleanupWorld()` destroys leftovers at the start of `createSimulation()`.
- Enable CARLA physics substepping — Sets `substepping = True`, `max_substep_delta_time = 0.01`, `max_substeps = 10` (the configuration recommended by CARLA's docs for synchronous mode). Reduces tunnelling and improves collision behavior at higher speeds.

Opinionated default (open to discussion):
- Default `--2d` and `mode2D` to True. In our usage, the simulator integrations we work with require 2D compatibility mode anyway, so flipping the default removes the need to specify `--2d` on every invocation. Fully open to dropping this commit if the project would rather keep the existing 3D default.

### Issue Link

N/A — issues encountered during development of CARLA-based driving scenarios.

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [ ] I have added test cases (if applicable)

### Additional Notes

The HUD wiring and the auto-cleanup of residual actors were verified end-to-end against a running CARLA server (Town01, ego rear-ended a stopped vehicle). The Ubuntu backtrace fix mirrors the existing `exceptiongroup` handling.