### PR TITLE
Prepare version 3.1.1

### DIFF
--- a/docs/new.rst
+++ b/docs/new.rst
@@ -15,6 +15,14 @@ It also features a new parser enabling clearer error messages, greater language 
 
 See :ref:`porting to Scenic 3` for tools to help migrate existing 2D scenarios.
 
+Scenic 3.1.1
+------------
+
+Minor new features:
+
+	* Added support for Python 3.14.
+
+
 Scenic 3.1.0
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scenic"
-version = "3.1.0"
+version = "3.1.1"
 description = "The Scenic scenario description language."
 authors = [
 	{ name = "Daniel Fremont" },


### PR DESCRIPTION
The CI is currently failing because it's pulling in `pygame` from VerifAI, but I need to make a new release of Scenic before I can make a new release of VerifAI with the switch to `pygame-ce`. I've tested with `tox` locally so everything should be OK; if the CI problem doesn't resolve after making both releases, we can yank as needed.