### PR TITLE
Bump verifai dependency; drop pytest upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ metadrive = [
 	"sumolib >= 1.21.0",
 ]
 test = [	# minimum dependencies for running tests (used for tox virtualenvs)
-	"pytest >= 7.0.0, <9",
+	"pytest >= 7.0.0",
 	"pytest-cov >= 3.0.0",
 	"pytest-randomly ~= 3.2",
 ]
@@ -79,7 +79,7 @@ test-full = [  # like 'test' but adds dependencies for optional features
 	"sphinx_rtd_theme >= 0.5.2",
 	"sphinx-tabs ~= 3.4.1",
 	'sumolib >= 1.21.0; python_version <= "3.11"',  # required for MetaDrive
-	"verifai >= 2.1.0b1",
+	"verifai >= 2.2.0",
 ]
 dev = [
 	"scenic[test-full]",


### PR DESCRIPTION
I [ran](https://github.com/BerkeleyLearnVerify/Scenic/actions/runs/25528966370) CI manually now that the new VerifAI release is out, and everything passed. So this PR bumps the requirement so that we disallow old versions of VerifAI which would cause both `pygame` and `pygame-ce` to get installed.

Also, in my own testing I noticed that pytest 9 works fine with our hooks, so I've removed the pytest upper bound: if a new version breaks something we should notice in CI and can then fix it (it's only a dev dependency anyway).