### PR TITLE
Improved error on object creation in compose blocks; related tweaks

### DIFF
--- a/docs/reference/statements.rst
+++ b/docs/reference/statements.rst
@@ -41,7 +41,12 @@ Behavior Definition
 Defines a :term:`dynamic behavior`, which can be assigned to a Scenic object by setting its :prop:`behavior` property using the :scenic:`with behavior {behavior}` specifier; this makes the object an :term:`agent`.
 See our tutorial on :ref:`dynamics` for examples of how to write behaviors.
 
-Behavior definitions have the same form as function definitions, with an argument list and a body consisting of one or more statements; the body may additionally begin with definitions of preconditions and invariants.
+Behavior definitions have a similar form to function definitions, with an argument list and a body consisting of one or more statements.
+A behavior may not use top-level definitional statements such as :keyword:`param`, :keyword:`mutate`, and :keyword:`terminate when`, and it cannot create Objects with :keyword:`new`.
+However, the :keyword:`require` statement *is* allowed, as are ordinary control-flow constructs and function definitions.
+In addition, there are many special statements allowed in behaviors to take actions, invoke sub-behaviors, etc.: see :ref:`dynamic_statements`.
+
+The body of a behavior may optionally begin with definitions of preconditions and invariants.
 Preconditions are checked when a behavior is started, and invariants are checked at every time step of the simulation while the behavior is executing (including time step zero, like preconditions, but *not* including time spent inside sub-behaviors: this allows sub-behaviors to break and restore invariants before they return).
 
 The body of a behavior executes in parallel with the simulation: in each time step, it must either :keyword:`take` specified action(s) or :keyword:`wait` and perform no actions.
@@ -102,7 +107,9 @@ Defines a Scenic :term:`modular scenario`.
 Scenario definitions, like :ref:`behavior definitions <behaviorDef>`, may include preconditions and invariants.
 The body of a scenario consists of two optional parts: a ``setup`` block and a ``compose`` block.
 The ``setup`` block contains code that runs once when the scenario begins to execute, and is a list of statements like a top-level Scenic program (so it may create objects, define requirements, etc.).
-The ``compose`` block orchestrates the execution of sub-scenarios during a dynamic scenario, and may use :keyword:`do` and any of the other statements allowed inside behaviors (except :keyword:`take`, which only makes sense for an individual :term:`agent`).
+The ``compose`` block orchestrates the execution of sub-scenarios during a dynamic scenario, and may use :keyword:`do` and any of the other statements allowed inside a :ref:`behavior <behaviorDef>` (except :keyword:`take`, which only makes sense for an individual :term:`agent`).
+The constructs illegal in behaviors, such as defining global parameters and creating Objects with :keyword:`new`, are also illegal in ``compose`` blocks: they can be placed in the ``setup`` block of a sub-scenario instead.
+
 If a modular scenario does not use preconditions, invariants, or sub-scenarios (i.e., it only needs a ``setup`` block) it may be written in the second form above, where the entire body of the ``scenario`` comprises the ``setup`` block.
 
 .. seealso:: Our tutorial on :ref:`composition` gives many examples of how to use modular scenarios.
@@ -308,6 +315,8 @@ For a complete example, see :ref:`sensors`.
 
 If you need to customize the way files are saved (e.g. to specify a specific video codec), you may pass a `Recorder` object to the ``to`` clause instead of a string.
 
+
+.. _dynamic_statements:
 
 Dynamic Statements
 ==================

--- a/src/scenic/syntax/compiler.py
+++ b/src/scenic/syntax/compiler.py
@@ -1297,9 +1297,11 @@ class ScenicToPythonTransformer(Transformer):
             ),
         )
 
+    @context(Context.DYNAMIC)
     def visit_DoChoose(self, node: s.DoChoose):
         return self.makeDoLike(node, node.elts, schedule="choose")
 
+    @context(Context.DYNAMIC)
     def visit_DoShuffle(self, node: s.DoChoose):
         return self.makeDoLike(node, node.elts, schedule="shuffle")
 
@@ -1464,6 +1466,9 @@ class ScenicToPythonTransformer(Transformer):
 
     # Instance & Specifier
 
+    # N.B. We can't use @context(Context.TOP_LEVEL) here because we actually
+    # allow `new Point` anywhere; we'll catch `new Object` inside behaviors in
+    # the veneer object registration code.
     def visit_New(self, node: s.New):
         return ast.Call(
             func=ast.Name(id="new", ctx=loadCtx),

--- a/src/scenic/syntax/veneer.py
+++ b/src/scenic/syntax/veneer.py
@@ -426,6 +426,8 @@ def registerObject(obj):
     elif activity > 0 or currentScenario:
         assert not evaluatingRequirement
         assert isinstance(obj, Object)
+        if currentScenario and currentScenario._isRunning:
+            raise InvalidScenarioError("tried to create an object inside a compose block")
         currentScenario._registerObject(obj)
         if currentSimulation:
             currentSimulation._createObject(obj)

--- a/tests/syntax/test_compiler.py
+++ b/tests/syntax/test_compiler.py
@@ -1441,7 +1441,9 @@ class TestCompiler:
                 assert False
 
     def test_do_choose(self):
-        node, _ = compileScenicAST(DoChoose([Constant("foo"), Constant("bar")]))
+        node, _ = compileScenicAST(
+            DoChoose([Constant("foo"), Constant("bar")]), inBehavior=True
+        )
         match node:
             case [
                 Expr(
@@ -1469,8 +1471,10 @@ class TestCompiler:
             case _:
                 assert False
 
-    def test_do_choose(self):
-        node, _ = compileScenicAST(DoShuffle([Constant("foo"), Constant("bar")]))
+    def test_do_shuffle(self):
+        node, _ = compileScenicAST(
+            DoShuffle([Constant("foo"), Constant("bar")]), inBehavior=True
+        )
         match node:
             case [
                 Expr(

--- a/tests/syntax/test_dynamics.py
+++ b/tests/syntax/test_dynamics.py
@@ -247,7 +247,7 @@ def test_behavior_create_object():
 
 def test_behavior_define_param():
     with pytest.raises(ScenicSyntaxError):
-        scenario = compileScenic(
+        compileScenic(
             """
             behavior Bar():
                 param foo = 3
@@ -255,7 +255,6 @@ def test_behavior_define_param():
             ego = new Object with behavior Bar
             """
         )
-        sampleResultOnce(scenario)
 
 
 def test_behavior_illegal_yield():

--- a/tests/syntax/test_modular.py
+++ b/tests/syntax/test_modular.py
@@ -188,6 +188,38 @@ def test_workspace_top_level():
     sampleResult(scenario, maxSteps=1)
 
 
+def test_dynamic_object_creation():
+    scenario = compileScenic(
+        """
+        scenario Main():
+            compose:
+                wait
+                do Sub()
+
+        scenario Sub():
+            new Object with behavior Foo()
+
+        behavior Foo():
+            take 42
+        """
+    )
+    actions = sampleEgoActions(scenario, maxSteps=2)
+    assert tuple(actions) == (None, 42)
+
+
+def test_object_creation_in_compose():
+    with pytest.raises(InvalidScenarioError):
+        scenario = compileScenic(
+            """
+            scenario Main():
+                compose:
+                    wait
+                    new Object
+            """
+        )
+        sampleResultOnce(scenario)
+
+
 @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="need SIGALRM")
 @pytest.mark.slow
 def test_scenario_stuck(monkeypatch):


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes introduced by this pull request -->

Creating objects inside `compose` blocks is not allowed, but triggers an assertion failure (see #469) rather than a proper error message. This PR adds an error message, documents the restrictions on behaviors and similar contexts, and makes some related minor improvements.

### Issue Link
<!-- Provide a link to the related issue on GitHub or another issue tracking system -->

Fixes #469.

### Checklist
- [x] I have tested the changes locally via `pytest` and/or other means
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code with black and isort
- [x] I have added test cases (if applicable)