### PR TITLE
Prepare version 3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scenic"
-version = "3.1.1"
+version = "3.2.0b1"
 description = "The Scenic scenario description language."
 authors = [
 	{ name = "Daniel Fremont" },

--- a/src/scenic/simulators/carla/blueprints.py
+++ b/src/scenic/simulators/carla/blueprints.py
@@ -115,18 +115,18 @@ def _get_dim(bp_id, key, default):
 
 
 @distributionFunction
-def width(bp_id, default):
+def width(bp_id, default) -> float:
     """Get width for ``bp_id``; return ``default`` if unknown."""
     return _get_dim(bp_id, "width", default)
 
 
 @distributionFunction
-def length(bp_id, default):
+def length(bp_id, default) -> float:
     """Get length for ``bp_id``; return ``default`` if unknown."""
     return _get_dim(bp_id, "length", default)
 
 
 @distributionFunction
-def height(bp_id, default):
+def height(bp_id, default) -> float:
     """Get height for ``bp_id``; return ``default`` if unknown."""
     return _get_dim(bp_id, "height", default)


### PR DESCRIPTION
Preparation for a 3.2.0b1 release to support VerifAI 3. This PR just bumps the version number and adds a few type annotations to fix a warning from VerifAI (which was no longer able to infer the type of `Car.height` because of the improved system for CARLA object dimensions).